### PR TITLE
change configuremgr as native

### DIFF
--- a/src/interfaces/javaapi/javaapi.go
+++ b/src/interfaces/javaapi/javaapi.go
@@ -25,7 +25,7 @@ import (
 
 	"common/logmgr"
 
-	configuremgr "controller/configuremgr/container"
+	configuremgr "controller/configuremgr/native"
 	"controller/discoverymgr"
 	scoringmgr "controller/scoringmgr"
 	"controller/servicemgr"


### PR DESCRIPTION
Orchestration is maintaining 2 types configuremgr(native/container), and it should be imported according to each platform.
-. Java(Android), C(Native) : native configuremgr
-. Container(Docker) : container configuremgr
But, currently javaapi imports container configuremgr. It’s wrong and cause of Watcher error.
