### PR TITLE
build: Fix build issue related to mobile module

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -110,7 +110,7 @@ function install_prerequisite() {
     done
 
     # Rebase gomobile [ Needed due to issues in latest gomobile ]
-    cd $GOPATH/src/golang.org/x/mobile
+    cd "$BASE_DIR/src/golang.org/x/mobile"
     git reset --hard 30c70e3810e97d051f18b66d59ae242540c0c391
     go install ./cmd/...
     cd $BASE_DIR


### PR DESCRIPTION
GOPATH is not a directory but a list of dirs
so change directory would not work.

module is relative to BASEDIR, so it is used

This build was verified using go1.13.1, docker 18.09.7

Forwarded: https://github.com/lf-edge/edge-home-orchestration-go/pulls
Change-Id: I79fbff264f75e31746095986d28cad14b1e1092a
Signed-off-by: Philippe Coval <p.coval@samsung.com>