### PR TITLE
Update tls package for tls-psk

### DIFF
--- a/src/interfaces/capi/main_secured.go
+++ b/src/interfaces/capi/main_secured.go
@@ -45,24 +45,48 @@ package main
 // * limitations under the License.
 // *
 // *******************************************************************************/
-//#define MAX_SVC_INFO_NUM 3
-//typedef struct {
-//	char* ExecutionType;
-//	char* ExeCmd;
-//} RequestServiceInfo;
-//
-//typedef struct {
-//	char* ExecutionType;
-//	char* Target;
-//} TargetInfo;
-//
-//typedef struct {
-//	char*      Message;
-//	char*      ServiceName;
-//	TargetInfo RemoteTargetInfo;
-//} ResponseService;
+/*
+#include <stdlib.h>
+
+#define MAX_SVC_INFO_NUM 3
+typedef struct {
+	char* ExecutionType;
+	char* ExeCmd;
+} RequestServiceInfo;
+
+typedef struct {
+	char* ExecutionType;
+	char* Target;
+} TargetInfo;
+
+typedef struct {
+	char*      Message;
+	char*      ServiceName;
+	TargetInfo RemoteTargetInfo;
+} ResponseService;
+
+typedef char* (*identityGetterFunc)();
+typedef char* (*keyGetterFunc)(char* id);
+
+identityGetterFunc iGetter;
+keyGetterFunc kGetter;
+
+static void setPSKHandler(identityGetterFunc ihandle, keyGetterFunc khandle){
+	iGetter = ihandle;
+	kGetter = khandle;
+}
+
+static char* bridge_iGetter(){
+	return iGetter();
+}
+
+static char* bridge_kGetter(char* id){
+	return kGetter(id);
+}
+*/
 import "C"
 import (
+	"errors"
 	"flag"
 	"log"
 	"math"
@@ -84,6 +108,7 @@ import (
 	"restinterface/client/restclient"
 	"restinterface/internalhandler"
 	"restinterface/route"
+	"restinterface/tls"
 
 	"db/bolt/wrapper"
 )
@@ -227,6 +252,34 @@ func PrintLog(cMsg *C.char) (count C.int) {
 	log.Printf(msg)
 	count++
 	return
+}
+
+type customPSKHandler struct{}
+
+func (cHandler customPSKHandler) GetIdentity() string {
+	var cIdentity *C.char
+	cIdentity = C.bridge_iGetter()
+	identity := C.GoString(cIdentity)
+	return identity
+}
+
+func (cHandler customPSKHandler) GetKey(id string) ([]byte, error) {
+	var cKey *C.char
+	cStr := C.CString(id)
+	defer C.free(unsafe.Pointer(cStr))
+
+	cKey = C.bridge_kGetter(cStr)
+	key := C.GoString(cKey)
+	if len(key) == 0 {
+		return nil, errors.New("key is empty")
+	}
+	return []byte(key), nil
+}
+
+//export SetPSKHandler
+func SetPSKHandler(iGetter C.identityGetterFunc, kGetter C.keyGetterFunc) {
+	C.setPSKHandler(iGetter, kGetter)
+	tls.SetPSKHandler(customPSKHandler{})
 }
 
 func main() {

--- a/src/interfaces/capi/main_secured.go
+++ b/src/interfaces/capi/main_secured.go
@@ -48,6 +48,14 @@ package main
 /*
 #include <stdlib.h>
 
+#ifndef __ORCHESTRATION_H__
+#define __ORCHESTRATION_H__
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #define MAX_SVC_INFO_NUM 3
 typedef struct {
 	char* ExecutionType;
@@ -83,6 +91,13 @@ static char* bridge_iGetter(){
 static char* bridge_kGetter(char* id){
 	return kGetter(id);
 }
+#ifdef __cplusplus
+}
+
+#endif
+
+#endif // __ORCHESTRATION_H__
+
 */
 import "C"
 import (

--- a/src/interfaces/javaapi/javaapi_secured.go
+++ b/src/interfaces/javaapi/javaapi_secured.go
@@ -40,6 +40,7 @@ import (
 	"restinterface/client/restclient"
 	"restinterface/internalhandler"
 	"restinterface/route"
+	"restinterface/tls"
 )
 
 type RequestServiceInfo struct {
@@ -221,6 +222,14 @@ func OrchestrationRequestService(request *ReqeustService) *ResponseService {
 		},
 	}
 	return ret
+}
+
+type PSKHandler interface {
+	tls.PSKHandler
+}
+
+func OrchestrationSetPSKHandler(pskHandler PSKHandler) {
+	tls.SetPSKHandler(pskHandler)
 }
 
 var count int


### PR DESCRIPTION
Added custom pskHandler setter for c, java API
When try to establish a tcp session, use a custom pskhandler to perform psk secure logic.

Signed-off-by: heewon Park <h_w.park@samsung.com>