### PR TITLE
Add alternative way to get processor frequency (/proc/cpuinfo).

### DIFF
--- a/src/common/resourceutil/cpu/cpu_test.go
+++ b/src/common/resourceutil/cpu/cpu_test.go
@@ -144,6 +144,36 @@ func removeFakeCPUMaxFreq() {
 	os.Remove("./fakecpumaxfreq")
 }
 
+func TestGetCPUFreqCpuInfo(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		originFileOpen = fileOpen
+		fileOpen = fakeFileOpenCPUInfo
+		defer func() {
+			fileOpen = originFileOpen
+			removeFakeCPUInfo()
+		}()
+
+		ret, err := getCPUFreqCpuInfo()
+		if err != nil {
+			t.Error("unexpected error")
+		} else if ret != 3300.0 {
+			t.Error("unexpected result")
+		}
+	})
+	t.Run("Error", func(t *testing.T) {
+		originFileOpen = fileOpen
+		fileOpen = fakeFileOpenError
+		defer func() {
+			fileOpen = originFileOpen
+		}()
+
+		_, err := getCPUFreqCpuInfo()
+		if err == nil {
+			t.Error("unexpected success")
+		}
+	})
+}
+
 func TestGetCPUs(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		originFileOpen = fileOpen
@@ -181,7 +211,9 @@ func fakeFileOpenError(name string) (*os.File, error) {
 func fakeFileOpenCPUInfo(name string) (*os.File, error) {
 	f, _ := os.Create("./fakecpuinfo")
 
-	fakeFile := []byte("processor	: 0\nprocessor	: 1\nprocessor	: 2\nprocessor	: 3\nprocessor\nprocessor	: asd\n")
+	fakeFile := []byte("processor	: 0\nprocessor	: 1\nprocessor	: 2\n" +
+		"processor	: 3\nprocessor\nprocessor	: asd\n" +
+		"model name : Intel(R) Core(TM) i3-2120 CPU @ 3.30GHz\n")
 	f.Write(fakeFile)
 	f.Close()
 


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

An alternative method was added to obtain the processor frequency for calculating performance score (the value is read from the  `/proc/cpuinfo` file). 

By default, the frequency value is read from `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`, but in case of a failure it reads from the `/proc/cpuinfo` file (this happens when Linux starts on a Virtual Machine), the default `/proc/cpuinfo` cannot be used, since the current frequency displayed in the `/proc/cpuinfo` may differ from the maximum (the processor may be in low power mode).

Fixes #81

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The Edge Orchestration must run successfully in a Virtual Machine and calculate own performance score.

**Test Configuration**:
* Firmware version: **Host**: Windows 10 - VirtualBox **Guest**: Ubuntu 16.04
* Hardware: x86-64
* Toolchain: recommended by default Docker and Go versions
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
