### PR TITLE
Add securemgr: container verification before executing (protection ag…

### DIFF
--- a/GoMain/src/main/main.go
+++ b/GoMain/src/main/main.go
@@ -29,6 +29,7 @@ import (
 	"controller/discoverymgr"
 	"controller/scoringmgr"
 	"controller/servicemgr"
+	"controller/securemgr"
 	executor "controller/servicemgr/executor/containerexecutor"
 
 	"orchestrationapi"
@@ -56,6 +57,7 @@ const (
 	configPath          = edgeDir + "/apps"
 	dbPath              = edgeDir + "/data/db"
 	certificateFilePath = edgeDir + "/data/cert"
+	containerWhiteListPath = edgeDir + "/data/cwl"
 
 	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
 	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"
@@ -90,6 +92,10 @@ func orchestrationInit() error {
 	if buildTags == "secure" {
 		log.Println("Orchestration init with secure option")
 		isSecured = true
+	}
+
+	if isSecured {
+		securemgr.Init(containerWhiteListPath)
 	}
 
 	restIns := restclient.GetRestClient()

--- a/GoMain/src/main/main.go
+++ b/GoMain/src/main/main.go
@@ -153,6 +153,15 @@ func orchestrationInit() error {
 	}
 	ehandle := externalhandler.GetHandler()
 	ehandle.SetOrchestrationAPI(externalapi)
+	// external secure rest api
+	if isSecured {
+		securemgrexternalapi, err := securemgr.GetExternalAPI()
+		if err != nil {
+			log.Fatalf("[%s] Secure manager external api : %s", logPrefix, err.Error())
+		} else {
+			ehandle.SetSecuremgrAPI(securemgrexternalapi)
+		}
+	}
 	ehandle.SetCipher(dummy.GetCipher(cipherKeyFilePath))
 	restEdgeRouter.Add(ehandle)
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ RESTAPI
     ```
   ---
    If the `edge-orchestration` was assembled with `secure` option.
-   You need to add a digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"`
+   You need to add a digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](doc/secure_manager.md).
    ```
    $ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
    ```  

--- a/README.md
+++ b/README.md
@@ -208,8 +208,19 @@ RESTAPI
     ```
 - Curl Example:
     ```json
-  - curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+  $ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
     ```
+  ---
+   If the `edge-orchestration` was assembled with `secure` option.
+   You need to add a digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"`
+   ```
+   $ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+   ```  
+   To add your container hash to the container white list `/var/edge-erchestration/data/cwl/containerwhitelist.txt`, you need to add a hash line to the end file.  
+   ```
+   # echo "fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752" >> /var/edge-erchestration/data/cwl/containerwhitelist.txt
+   ```
+  ---
 
 - Result(Execution on itself)
   

--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,7 @@ PKG_LIST=(
         "controller/discoverymgr"
         "controller/discoverymgr/wrapper"
         "controller/scoringmgr"
+        "controller/securemgr"
         "controller/servicemgr"
         "controller/servicemgr/executor"
         "controller/servicemgr/executor/androidexecutor"

--- a/doc/secure_manager.md
+++ b/doc/secure_manager.md
@@ -1,0 +1,126 @@
+# Secure Manager
+## Contents
+1. [Introduction](#1-introduction)
+2. [Verifier](#2-verifier)  
+    2.1 [Description](#21-description)      
+    2.2 [Workflow](#22-workflow)      
+    2.3 [Verifier Management](#23-verifier-management)     
+    2.4 [Usage Edge-Orchestration with Verifier](#24-usage-edge-orchestration-with-verifier)
+
+## 1. Introduction
+The **Secure Manager** is designed to control security components. Currently it is in an initial state of development and includes the following components:
+  1. Verifier  
+  2. TBD  
+ 
+In order for the Secure Manager to be allowed, it is necessary to assemble the **Edge-Orchestration** with the `secure` option.
+
+---
+
+## 2. Verifier
+### 2.1 Description
+The verifier ensures that only allowed containers (images) are launched; a list of allowed containers (their sha256 hashes) is stored in a `/var/edge-orchestration/data/cwl/containerwhitelist.txt` file.
+
+### 2.2 Workflow
+ > TBD
+---
+ 
+### 2.3 Verifier Management
+There are two ways to change the container white list:
+1. Using REST API
+2. Editing the `containerwhitelist.txt` file (root rights required)
+
+#### 2.3.1 REST API
+ REST API supports the next functions for contaner white list management:
+ * _**addHashCWL**_ - adds container image hash to the container white list
+ * _**delHashCWL**_ - deletes container image hash from the container white list
+ * _**delAllHashCWL**_ - deletes all container image hashes from container white list
+ * _**printAllHashCWL**_ - displays all hashes (from the container white list) in the log.
+
+Examples of using these commands are given below:
+ - POST  
+ - **IP:56001/api/v1/orchestration/securemgr** 
+ - BODY (depends on the command): 
+ 
+_**addHashCWL**_  
+JSON:
+```json
+    {
+        "SecCompName": "Verifier",
+        "TypeCmd": "addHashCWL",
+        "Desc": [
+        {
+            "ContainerHash": "fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"
+        },
+        {
+            "ContainerHash": "fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b751"
+        }],
+        "StatusCallbackURI": "http://localhost:8888/api/v1/services/notification"
+    }
+```
+Curl:
+```shell
+curl -X POST "127.0.0.1:56001/api/v1/orchestration/securemgr" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"SecureMgr\": \"Verifier\", \"CmdType\": \"addHashCWL\", \"Desc\": [{ \"ContainerHash\": \"fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"}, { \"ContainerHash\": \"fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b751\"}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+```
+
+_**delHashCWL**_  
+JSON:
+```json
+    {
+        "SecCompName": "Verifier",
+        "TypeCmd": "delHashCWL",
+        "Desc": [
+        {
+            "ContainerHash": "fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"
+        }],
+        "StatusCallbackURI": "http://localhost:8888/api/v1/services/notification"
+    }
+```
+Curl:
+```shell
+curl -X POST "127.0.0.1:56001/api/v1/orchestration/securemgr" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"SecureMgr\": \"Verifier\", \"CmdType\": \"delHashCWL\", \"Desc\": [{ \"ContainerHash\": \"fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+```
+_**delAllHashCWL**_  
+JSON:
+```json
+    {
+        "SecCompName": "Verifier",
+        "TypeCmd": "delAllHashCWL",
+        "StatusCallbackURI": "http://localhost:8888/api/v1/services/notification"
+    }
+```
+Curl:
+```shell
+curl -X POST "127.0.0.1:56001/api/v1/orchestration/securemgr" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"SecureMgr\": \"Verifier\", \"CmdType\": \"delAllHashCWL\", \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+```
+_**printAllHashCWL**_  
+JSON:
+```json
+    {
+        "SecCompName": "Verifier",
+        "TypeCmd": "printAllHashCWL",
+        "StatusCallbackURI": "http://localhost:8888/api/v1/services/notification"
+    }
+```
+Curl:
+```shell
+curl -X POST "127.0.0.1:56001/api/v1/orchestration/securemgr" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"SecureMgr\": \"Verifier\", \"CmdType\": \"printAllHashCWL\", \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+```
+
+#### 2.3.2 Editing the container white list by other tools.
+  
+The `/var/edge-orchestration/data/cwl/containerwhitelist.txt` file consists of records that include: container's image sha256 hash (64-ASCII symbols) + '\n'
+Therefore, it can be edited with any editor or from the command line.
+Example: _how to add hash by command line_
+```shell
+# echo "fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752" >> /var/edge-erchestration/data/cwl/containerwhitelist.txt
+```
+---
+
+### 2.4 Usage Edge-Orchestration with Verifier
+To run **Edge Orchestration** container you need to add a digest (sha256) to the last parameter. For example:  `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`
+```
+$ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+```  
+If the `"fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"` hash is written to the `/var/edge-erchestration/data/cwl/containerwhitelist.txt` file, the container will be launched successfully.
+
+---

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,6 +25,7 @@ ignore:
   - controller/discoverymgr
   - controller/discoverymgr/wrapper
   - controller/scoringmgr
+  - controller/securemgr
   - controller/servicemgr
   - controller/servicemgr/executor
   - controller/servicemgr/executor/androidexecutor

--- a/src/controller/securemgr/verifier.go
+++ b/src/controller/securemgr/verifier.go
@@ -1,0 +1,117 @@
+/*******************************************************************************
+* Copyright 2020 Samsung Electronics All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+package securemgr
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+)
+
+// cwl - Container White List
+
+const (
+	cwlFileName 		= "containerwhitelist.txt"
+	hashHelloWorld		= "fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"
+)
+
+// VerifierImpl structure
+type VerifierImpl struct{}
+
+var (
+	containerWhiteList	[]string
+	logPrefix			= "[verifier]"
+	verifierIns 		*VerifierImpl
+	initialized		  	= false
+)
+
+func init() {
+	verifierIns = new(VerifierImpl)
+}
+
+// initContainerWhiteList fill the containerWhiteList by reading the information
+// from the file if it exists or creates it otherwise
+func initContainerWhiteList(cwlFilePath string) error {
+	fileContent, err := ioutil.ReadFile(cwlFilePath)
+	if err != nil {
+		containerWhiteList = append(containerWhiteList, hashHelloWorld) // hello-world container image
+		err = ioutil.WriteFile(cwlFilePath, []byte(hashHelloWorld + "\n"), 0666)
+		if err != nil {
+			log.Println(logPrefix, "Can't create " + cwlFileName + ": ", err)
+		}
+	} else {
+		containerWhiteList = strings.Split(string(fileContent),"\n")
+		//for _, whitelistItem := range containerWhiteList {
+		//	log.Println(logPrefix, whitelistItem)
+		//}
+	}
+	return err
+}
+
+// GetInstance gives the VerifierImpl singletone instance
+func GetInstance() *VerifierImpl {
+	return verifierIns
+}
+
+func containerHashIsInWhiteList(hash string) bool {
+	for _, whitelistItem := range containerWhiteList {
+		if (hash == whitelistItem) {
+			return true
+		}
+	}
+	return false
+}
+
+func getIndexHashInContainerName(containerName string) (int, error) {
+	digestIndex := strings.Index(containerName, "@sha256:")
+	if digestIndex == -1 {
+		return -1, errors.New("Container name doesn't contain a digest")
+	}
+	digestIndex = digestIndex + len("@sha256:")
+	return digestIndex, nil
+}
+
+// Init sets the environments for securemgr
+func Init(cwlPath string) {
+	if _, err := os.Stat(cwlPath); err != nil {
+		err := os.MkdirAll(cwlPath, os.ModePerm)
+		if err != nil {
+			log.Panicf("Failed to create cwlPath %s: %s\n", cwlPath, err)
+		}
+	}
+	initContainerWhiteList(cwlPath + "/" + cwlFileName)
+	initialized = true
+}
+// ContainerIsInWhiteList checks if the containerName is in containerWhiteList
+func (VerifierImpl) ContainerIsInWhiteList(containerName string) error {
+	if initialized == false {
+		return nil
+	}
+	index, err := getIndexHashInContainerName(containerName)
+	if err != nil {
+		return err
+	}
+	//log.Println(logPrefix, "SHA:" , containerName[index:])
+	if containerHashIsInWhiteList(containerName[index:]) {
+		log.Println(logPrefix, "Container is in whitelist")
+		return nil
+	} else {
+		return errors.New("Container is not in whitelist")
+	}
+}

--- a/src/controller/securemgr/verifier_test.go
+++ b/src/controller/securemgr/verifier_test.go
@@ -17,14 +17,17 @@
 package securemgr
 
 import (
+	"log"
 	"os"
 	"testing"
 )
 
 const (
-	fakecwlPath			= "fakecwl"
-	fakecwlFilePath		= fakecwlPath + "/" + cwlFileName
-	fakehashHelloWorld	= "1834bdb494c6150a9861cf32432df7c5d93fe2bc99e008da83a57a318dc207d7"
+	fakecwlPath				= "fakecwl"
+	fakecwlFilePath			= fakecwlPath + "/" + cwlFileName
+	hashHelloWorld			= "fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"
+	fakehashHelloWorld		= "1834bdb494c6150a9861cf32432df7c5d93fe2bc99e008da83a57a318dc207d7"
+	fakehashExtraContainer	= "99a55eca2c0afefdb019787b0e8d980e0efdf5c29db0d9004fbfe20612b73b96"
 )
 
 func TestGetIndexHashInContainerName(t *testing.T) {
@@ -44,6 +47,7 @@ func TestGetIndexHashInContainerName(t *testing.T) {
 
 func TestContainerHashIsInWhiteList(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
+
 		containerWhiteList = append(containerWhiteList, hashHelloWorld) // hello-world container image
 
 		if !containerHashIsInWhiteList(hashHelloWorld) {
@@ -53,6 +57,33 @@ func TestContainerHashIsInWhiteList(t *testing.T) {
 		if containerHashIsInWhiteList("121212") {
 			t.Error("unexpected success")
 		}
+	})
+}
+
+func TestGetExternalAPI(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		if _, err := GetExternalAPI(); err != nil {
+			t.Error("unexpected fail")
+		}
+		verifierInsOriginal := verifierIns
+		verifierIns = nil
+		if _, err := GetExternalAPI(); err == nil {
+			t.Error("unexpected success")
+		}
+		verifierIns = verifierInsOriginal
+
+	})
+}
+
+func TestPrintAllHashFromContainerWhiteList(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		printAllHashFromContainerWhiteList()
+
+		containerWhiteListOriginal := containerWhiteList
+		containerWhiteList = nil
+		printAllHashFromContainerWhiteList()
+		containerWhiteList = containerWhiteListOriginal
+
 	})
 }
 
@@ -84,23 +115,146 @@ func TestInitContainerWhiteList(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		defer os.RemoveAll(fakecwlPath)
 
+		os.RemoveAll(fakecwlPath)
 		Init(fakecwlPath)
-		if !containerHashIsInWhiteList(hashHelloWorld) {
-			t.Error("unexpected fail")
+		if containerHashIsInWhiteList(hashHelloWorld) {
+			t.Error("unexpected success")
 		}
 
-		if err := initContainerWhiteList(fakecwlFilePath); err != nil {
-			t.Error("unexpected fail")
-		}
-		if !containerHashIsInWhiteList(hashHelloWorld) {
+		if err := initContainerWhiteList(); err != nil {
 			t.Error("unexpected fail")
 		}
 	})
 	t.Run("Error", func(t *testing.T) {
-		err := initContainerWhiteList("")
+		err := initContainerWhiteList()
 		if err == nil {
 			t.Error("unexpected success")
 		}
+	})
+}
+
+func TestAddHashToContainerWhiteList(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		defer os.RemoveAll(fakecwlPath)
+
+		Init(fakecwlPath)
+		if err := addHashToContainerWhiteList(fakehashExtraContainer); err != nil {
+			t.Error("unexpected fail")
+		}
+		if !containerHashIsInWhiteList(fakehashExtraContainer) {
+			t.Error("unexpected fail")
+		}
+		os.RemoveAll(fakecwlPath + "/" + cwlFileName)
+		if err := addHashToContainerWhiteList(fakehashExtraContainer); err != nil {
+			t.Error("unexpected fail")
+		}
+		if !containerHashIsInWhiteList(fakehashExtraContainer) {
+			t.Error("unexpected fail")
+		}
+		if err := addHashToContainerWhiteList(fakehashExtraContainer); err != nil {
+			t.Error("unexpected fail")
+		}
+	})
+	t.Run("Error", func(t *testing.T) {
+		err := initContainerWhiteList()
+		if err == nil {
+			t.Error("unexpected success")
+		}
+		if err = addHashToContainerWhiteList(fakehashExtraContainer); err == nil {
+			t.Error("unexpected success")
+		}
+	})
+}
+
+func TestDelHashFromContainerWhiteList(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		defer os.RemoveAll(fakecwlPath)
+
+		Init(fakecwlPath)
+		if err := addHashToContainerWhiteList(fakehashExtraContainer); err != nil {
+			t.Error("unexpected fail")
+		}
+		if !containerHashIsInWhiteList(fakehashExtraContainer) {
+			t.Error("unexpected fail")
+		}
+
+		if err := delHashFromContainerWhiteList(fakehashExtraContainer); err != nil {
+			log.Println(logPrefix, "Can't create "+cwlFileName+": ", err)
+		}
+
+		if containerHashIsInWhiteList(fakehashExtraContainer) {
+			t.Error("unexpected success")
+		}
+
+		if err := delHashFromContainerWhiteList(fakehashExtraContainer); err != nil {
+			t.Error("unexpected fail")
+		}
+
+	})
+	t.Run("Error", func(t *testing.T) {
+		os.RemoveAll(fakecwlPath + "/" + cwlFileName)
+		if err := delHashFromContainerWhiteList(fakehashExtraContainer); err == nil {
+			t.Error("unexpected success")
+		}
+
+	})
+}
+
+func TestDelAllHashFromContainerWhiteList(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		defer os.RemoveAll(fakecwlPath)
+
+		Init(fakecwlPath)
+		if err := addHashToContainerWhiteList(fakehashExtraContainer); err != nil {
+			t.Error("unexpected fail")
+		}
+		if err := delAllHashFromContainerWhiteList(); err != nil {
+			t.Error("unexpected fail")
+		}
+
+		if containerHashIsInWhiteList(fakehashExtraContainer) {
+			t.Error("unexpected success")
+		}
+
+		if containerWhiteList != nil {
+			t.Error("unexpected success")
+		}
+	})
+	t.Run("Error", func(t *testing.T) {
+		os.RemoveAll(fakecwlPath + "/" + cwlFileName)
+		if err := delAllHashFromContainerWhiteList(); err == nil {
+			t.Error("unexpected success")
+		}
+	})
+}
+
+func RequestUpdateCWL(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		defer os.RemoveAll(fakecwlPath)
+
+		Init(fakecwlPath)
+		if err := addHashToContainerWhiteList(fakehashExtraContainer); err != nil {
+			t.Error("unexpected fail")
+		}
+		if !containerHashIsInWhiteList(fakehashExtraContainer) {
+			t.Error("unexpected fail")
+		}
+
+		if err := delHashFromContainerWhiteList(fakehashExtraContainer); err != nil {
+			t.Error("unexpected success")
+		}
+
+		if containerHashIsInWhiteList(fakehashExtraContainer) {
+			t.Error("unexpected success")
+		}
+	})
+	t.Run("Error", func(t *testing.T) {
+		os.RemoveAll(fakecwlPath + "/" + cwlFileName)
+
+		if err := delHashFromContainerWhiteList(fakehashExtraContainer); err != nil {
+			t.Error("unexpected success")
+		}
+
 	})
 }
 
@@ -125,7 +279,57 @@ func TestInit(t *testing.T) {
 			t.Error(err.Error())
 		}
 	})
-//	t.Run("Error", func(t *testing.T) {
-//	})
+}
+
+func TestRequestSecureMgr(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		defer os.RemoveAll(fakecwlPath)
+
+		Init(fakecwlPath)
+		containerInfo := RequestSecureMgr{
+			SecureInsName: "verifier",
+			CmdType: "addHashCWL",
+			Desc: []RequestDescInfo {
+				{
+					//ContainerName: "hello_world_",
+					ContainerHash: fakehashHelloWorld,
+				},
+				{
+					//ContainerName: "hello_world",
+					ContainerHash: hashHelloWorld,
+				},
+			},
+		}
+		m := GetInstance()
+
+		resp := m.RequestSecureMgr(containerInfo)
+		if resp.Message != ERROR_NONE {
+			t.Error("unexpected fail")
+		}
+
+		containerInfo.CmdType = "delHashCWL"
+		resp = m.RequestSecureMgr(containerInfo)
+		if resp.Message != ERROR_NONE {
+			t.Error("unexpected fail")
+		}
+
+		containerInfo.CmdType = "printAllHashCWL"
+		resp = m.RequestSecureMgr(containerInfo)
+		if resp.Message != ERROR_NONE {
+			t.Error("unexpected fail")
+		}
+
+		containerInfo.CmdType = "delAllHashCWL"
+		resp = m.RequestSecureMgr(containerInfo)
+		if resp.Message != ERROR_NONE {
+			t.Error("unexpected fail")
+		}
+
+		containerInfo.CmdType = "CWL"
+		resp = m.RequestSecureMgr(containerInfo)
+		if resp.Message == ERROR_NONE {
+			t.Error("unexpected success")
+		}
+	})
 }
 

--- a/src/controller/securemgr/verifier_test.go
+++ b/src/controller/securemgr/verifier_test.go
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+package securemgr
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	fakecwlPath			= "fakecwl"
+	fakecwlFilePath		= fakecwlPath + "/" + cwlFileName
+	fakehashHelloWorld	= "1834bdb494c6150a9861cf32432df7c5d93fe2bc99e008da83a57a318dc207d7"
+)
+
+func TestGetIndexHashInContainerName(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		_, err := getIndexHashInContainerName("hello-world@sha256:" + hashHelloWorld)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	})
+	t.Run("Error", func(t *testing.T) {
+		index, err := getIndexHashInContainerName("hello-world@sha56:" + hashHelloWorld)
+		if err == nil && index != -1 {
+			t.Error("unexpected success")
+		}
+	})
+}
+
+func TestContainerHashIsInWhiteList(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		containerWhiteList = append(containerWhiteList, hashHelloWorld) // hello-world container image
+
+		if !containerHashIsInWhiteList(hashHelloWorld) {
+			t.Error("unexpected fail")
+		}
+
+		if containerHashIsInWhiteList("121212") {
+			t.Error("unexpected success")
+		}
+	})
+}
+
+func TestContainerIsInWhiteList(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		containerWhiteList = append(containerWhiteList, hashHelloWorld) // hello-world container image
+
+		m := GetInstance()
+		if err := m.ContainerIsInWhiteList("hello-world@sha256:" + hashHelloWorld); err != nil {
+			t.Error("unexpected fail")
+		}
+
+		initialized = true
+		if err := m.ContainerIsInWhiteList("hello-world@sha256:" + hashHelloWorld); err != nil {
+			t.Error("unexpected fail")
+		}
+
+		if err := m.ContainerIsInWhiteList("hello-world@ha256:" + hashHelloWorld); err == nil {
+			t.Error("unexpected success")
+		}
+
+		if err := m.ContainerIsInWhiteList("hello-world@sha256:" + fakehashHelloWorld); err == nil {
+			t.Error("unexpected success")
+		}
+	})
+}
+
+func TestInitContainerWhiteList(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		defer os.RemoveAll(fakecwlPath)
+
+		Init(fakecwlPath)
+		if !containerHashIsInWhiteList(hashHelloWorld) {
+			t.Error("unexpected fail")
+		}
+
+		if err := initContainerWhiteList(fakecwlFilePath); err != nil {
+			t.Error("unexpected fail")
+		}
+		if !containerHashIsInWhiteList(hashHelloWorld) {
+			t.Error("unexpected fail")
+		}
+	})
+	t.Run("Error", func(t *testing.T) {
+		err := initContainerWhiteList("")
+		if err == nil {
+			t.Error("unexpected success")
+		}
+	})
+}
+
+func TestInit(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		defer os.RemoveAll(fakecwlPath)
+
+		Init("./")
+		if _, err := os.Stat(cwlFileName); err != nil {
+			t.Error("unexpected success")
+		}
+		if err := os.Remove(cwlFileName); err != nil {
+			t.Error(err.Error())
+		}
+
+		Init(fakecwlPath)
+		if _, err := os.Stat(fakecwlPath); err != nil {
+			t.Error(err.Error())
+		}
+
+		if _, err := os.Stat(fakecwlFilePath); os.IsNotExist(err) {
+			t.Error(err.Error())
+		}
+	})
+//	t.Run("Error", func(t *testing.T) {
+//	})
+}
+

--- a/src/controller/servicemgr/executor/containerexecutor/containerexecutor.go
+++ b/src/controller/servicemgr/executor/containerexecutor/containerexecutor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/pflag"
 
 	servicemgr "controller/servicemgr"
+	securemgr "controller/securemgr"
 	"controller/servicemgr/executor"
 	"controller/servicemgr/notification"
 )
@@ -70,8 +71,14 @@ func (c ContainerExecutor) Execute(s executor.ServiceExecutionInfo) error {
 	log.Println(logPrefix, "parameter length :", len(c.ParamStr))
 	paramLen := len(c.ParamStr)
 
+	err := securemgr.GetInstance().ContainerIsInWhiteList(s.ParamStr[paramLen-1])
+	if err != nil {
+		log.Println(logPrefix, err.Error())
+		return err
+	}
+
 	// @Note : Pull docker image
-	err := c.ceImplIns.ImagePull(s.ParamStr[paramLen-1])
+	err = c.ceImplIns.ImagePull(s.ParamStr[paramLen-1])
 	if err != nil {
 		log.Println(logPrefix, err.Error())
 	}

--- a/src/restinterface/externalhandler/externalhandler.go
+++ b/src/restinterface/externalhandler/externalhandler.go
@@ -32,6 +32,7 @@ import (
 	"restinterface/cipher"
 	"restinterface/externalhandler/senderresolver"
 	"restinterface/resthelper"
+	"controller/securemgr"
 )
 
 const logPrefix = "RestExternalInterface"
@@ -40,6 +41,9 @@ const logPrefix = "RestExternalInterface"
 type Handler struct {
 	isSetAPI bool
 	api      orchestrationapi.OrcheExternalAPI
+
+	isSetSecureAPI bool
+	sapi     securemgr.SecureMgrExternalAPI
 
 	helper resthelper.RestHelper
 
@@ -62,6 +66,13 @@ func init() {
 			Pattern:     "/api/v1/orchestration/services",
 			HandlerFunc: handler.APIV1RequestServicePost,
 		},
+		restinterface.Route{
+			Name:        "APIV1RequestSecuremgrPost",
+			Method:      strings.ToUpper("Post"),
+			Pattern:     "/api/v1/orchestration/securemgr",
+			HandlerFunc: handler.APIV1RequestSecuremgrPost,
+		},
+
 	}
 	handler.netHelper = networkhelper.GetInstance()
 }
@@ -75,6 +86,12 @@ func GetHandler() *Handler {
 func (h *Handler) SetOrchestrationAPI(o orchestrationapi.OrcheExternalAPI) {
 	h.api = o
 	h.isSetAPI = true
+}
+
+// SetSecuremgrAPI sets SecureMgrExternalAPI
+func (h *Handler) SetSecuremgrAPI(s securemgr.SecureMgrExternalAPI) {
+	h.sapi = s
+	h.isSetSecureAPI = true
 }
 
 // APIV1RequestServicePost handles service request from service application
@@ -223,6 +240,115 @@ SEND_RESP:
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
 	if err != nil {
 		log.Printf("[%s] can not encryption", logPrefix)
+		h.helper.Response(w, http.StatusServiceUnavailable)
+		return
+	}
+
+	h.helper.ResponseJSON(w, respEncryptBytes, http.StatusOK)
+}
+
+// APIV1RequestSecuremgrPost handles securemgr request from securemgr configure application
+func (h *Handler) APIV1RequestSecuremgrPost(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[%s] APIV1RequestSecuremgrPost", logPrefix)
+	if h.isSetSecureAPI == false {
+		log.Printf("[%s] does not set api", logPrefix)
+		h.helper.Response(w, http.StatusServiceUnavailable)
+		return
+	} else if h.IsSetKey == false {
+		log.Printf("[%s] does not set key", logPrefix)
+		h.helper.Response(w, http.StatusServiceUnavailable)
+		return
+	}
+
+	reqAddr := strings.Split(r.RemoteAddr, ":")
+	var addr string
+	if strings.Contains(r.RemoteAddr, "::1") {
+		addr = "localhost"
+	} else {
+		addr = reqAddr[0]
+	}
+
+	ips, err := h.netHelper.GetIPs()
+	if err != nil {
+		h.helper.Response(w, http.StatusServiceUnavailable)
+		return
+	} else if addr != "localhost" && addr != "127.0.0.1" && common.HasElem(ips, addr) == false {
+		h.helper.Response(w, http.StatusNotAcceptable)
+		return
+	}
+
+	var (
+		responseMsg  string
+		responseName string
+		resp         securemgr.ResponseSecureMgr
+		containerDescs        []interface{}
+	)
+
+	//request
+	encryptBytes, _ := ioutil.ReadAll(r.Body)
+
+	appCommand, err := h.Key.DecryptByteToJSON(encryptBytes)
+	if err != nil {
+		log.Printf("[%s] cannot decryption", logPrefix)
+		h.helper.Response(w, http.StatusServiceUnavailable)
+		return
+	}
+
+	containerInfos := securemgr.RequestSecureMgr{}
+
+	SecureInsName, ok := appCommand["SecureMgr"].(string)
+	if ok {
+		containerInfos.SecureInsName = SecureInsName
+		log.Println("SecureMgr: ", containerInfos.SecureInsName)
+	}
+
+	containerInfos.CmdType, ok = appCommand["CmdType"].(string)
+	if ok {
+		log.Println("CmdType: ", containerInfos.CmdType)
+	}
+	if containerInfos.CmdType == "addHashCWL" || containerInfos.CmdType =="delHashCWL" {
+		containerDescs, ok = appCommand["Desc"].([]interface{})
+		if !ok {
+			log.Println("Error")
+			responseMsg = securemgr.INVALID_PARAMETER
+			responseName = "verifier"
+			goto SEND_RESP
+		}
+
+		containerInfos.Desc = make([]securemgr.RequestDescInfo, len(containerDescs))
+		for idx, containerDesc := range containerDescs {
+			tmp := containerDesc.(map[string]interface{})
+			//name, ok := tmp["ContainerName"].(string)
+			//if !ok {
+			//	responseMsg = securemgr.INVALID_PARAMETER
+			//	responseName = "verifier"
+			//	goto SEND_RESP
+			//}
+			//containerInfos.Desc[idx].ContainerName = name
+
+			hash, ok := tmp["ContainerHash"].(string)
+			if !ok {
+				responseMsg = securemgr.INVALID_PARAMETER
+				responseName = "verifier"
+				goto SEND_RESP
+			}
+			containerInfos.Desc[idx].ContainerHash = hash
+		}
+	}
+
+	resp = h.sapi.RequestSecureMgr(containerInfos)
+
+	responseMsg = resp.Message
+	responseName = resp.SecureCmpName
+
+SEND_RESP:
+	respJSONMsg := make(map[string]interface{})
+	respJSONMsg["Message"] = responseMsg
+	respJSONMsg["SecureCmpName"] = responseName
+
+	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
+	if err != nil {
+		log.Printf("[%s] cannot encryption", logPrefix)
 		h.helper.Response(w, http.StatusServiceUnavailable)
 		return
 	}


### PR DESCRIPTION
…ainst malicious containers)

Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

To protect _Edge Devices_ against running malicious containers to the `secure` mode, a white list (hashes of containers) was added that can be launched on the device. The virifier is the first functionality that the security module will provide.
in the future, verification should work by default, not only in `secure` mode

Fixes #85 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (detail info will be done after the adoption of this concept)

# How Has This Been Tested?

1. Assembly `edge-orchestration` in `secure` mode by command:
```shell
$ ./build.sh secure
```
2. Run Edge Orchestration container
```shell
$ docker run -it -d --privileged --network="host" --name edge-orchestration \
                -v /var/edge-orchestration/:/var/edge-orchestration/:rw \
                -v /var/run/docker.sock:/var/run/docker.sock:rw \
                -v /proc/:/process/:ro edge-orchestration:baobab
``` 

3. Send the next REST API requests
  3.1 Successful hello-world container launch
```shell
curl -X POST "127.0.0.1:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
```

  3.2 Failed emazzotta/simple-fileserver-docker container launch
```shell
curl -X POST "127.0.0.1:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"Simple-server\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"-v\", \"/:/app\", \"-p\", \"80:8000\", \"-p\", \"emazzotta/simple-fileserver-docker\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
```

**Test Configuration**:
* Software version: Ubuntu 16.04, etc.)
* Hardware: x86-64
* Toolchain: Docker and Go recommended versions
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
