### PR TITLE
Added architecture option in build script for building objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ clean-tmp-packages:
 build-object-java:
 	mkdir -p $(ANDROID_LIBRARY_OUT_DIR)
 	$(GOMOBILE) init
-	$(GOMOBILE) bind $(GO_MOBILE_LDFLAGS) -o $(ANDROID_LIBRARY_OUT_DIR)/$(ANDROID_LIBRARY_FILE) -target=android -androidapi=23 $(ANDROID_SRC_DIR) || exit 1
+	$(GOMOBILE) bind $(GO_MOBILE_LDFLAGS) -o $(ANDROID_LIBRARY_OUT_DIR)/$(ANDROID_LIBRARY_FILE) -target=$(ANDROID_TARGET) -androidapi=23 $(ANDROID_SRC_DIR) || exit 1
 	ls -al $(ANDROID_LIBRARY_OUT_DIR)
 
 ## edge-orchestration container build

--- a/build.sh
+++ b/build.sh
@@ -213,6 +213,32 @@ function draw_callvis() {
     go-callvis -http localhost:7010 -group pkg,type -nostd ./GoMain/src/main/main.go &
 }
 
+function build_objects() {
+    case $1 in
+        x86)
+            build_object_x86
+            export ANDROID_TARGET="android/386";;
+        x86_64)
+            build_object_x86-64
+            export ANDROID_TARGET="android/amd64";;
+        arm)
+            build_object_arm
+            export ANDROID_TARGET="android/arm";;
+        arm64)
+            build_object_aarch64
+            export ANDROID_TARGET="android/arm64";;
+        *)
+            build_object_x86
+            build_object_x86-64
+            build_object_arm
+            build_object_aarch64
+            export ANDROID_TARGET="android";;
+    esac
+
+    build_android
+}
+
+
 function build_object_x86() {
     echo ""
     echo ""
@@ -357,17 +383,15 @@ case "$1" in
         run_docker_container
         ;;
     "object")
-        if [ "$2" == "secure" ]; then
-            set_secure_option
-        fi
         install_prerequisite
         install_3rdparty_packages
         build_clean
-        build_android
-        build_object_x86
-        build_object_aarch64
-        build_object_arm
-        build_object_x86-64
+        if [ "$2" == "secure" ]; then
+            set_secure_option
+            build_objects $3
+        else
+            build_objects $2
+        fi
         build_object_result
         ;;
     "test")
@@ -405,16 +429,16 @@ case "$1" in
     *)
         echo "build script"
         echo "Usage:"
-        echo "----------------------------------------------------------------------------------------------"
-        echo "  $0                  : build edge-orchestration by default container"
-        echo "  $0 secure           : build edge-orchestration by default container with secure option"
-        echo "  $0 container        : build Docker container as build system environmet"
-        echo "  $0 container secure : build Docker container as build system environmet with secure option"
-        echo "  $0 object           : build object (c-object, java-object)"
-        echo "  $0 object secure    : build object (c-object, java-object) with secure option"
-        echo "  $0 clean            : build clean"
-        echo "  $0 test [PKG_NAME]  : run unittests (optional for PKG_NAME)"
-        echo "----------------------------------------------------------------------------------------------"
+        echo "-------------------------------------------------------------------------------------------------------------------------------------------"
+        echo "  $0                      : build edge-orchestration by default container"
+        echo "  $0 secure               : build edge-orchestration by default container with secure option"
+        echo "  $0 container            : build Docker container as build system environmet"
+        echo "  $0 container secure     : build Docker container as build system environmet with secure option"
+        echo "  $0 object [Arch]        : build object (c-object, java-object), Arch:{x86, x86_64, arm, arm64} (default:all)"
+        echo "  $0 object secure [Arch] : build object (c-object, java-object) with secure option, Arch:{x86, x86_64, arm, arm64} (default:all)"
+        echo "  $0 clean                : build clean"
+        echo "  $0 test [PKG_NAME]      : run unittests (optional for PKG_NAME)"
+        echo "-------------------------------------------------------------------------------------------------------------------------------------------"
         exit 0
         ;;
 esac


### PR DESCRIPTION
# Description

This change is build script enhancement. Currently, script build objects for all the architectures which may not be suitable for a user who wants to build for a particular architecture. With this change it gives option to user to specify architecture for which he/she wants to build binary. 

**Benefits:** 
- Give option to user to build for particular architecture.
- Reduce build time.
- It will not break current script as it is optional flag.

## Type of change
- [ ] Build script enhancement
- [ ] It will not break existing build script as flag is optional 

# How Has This Been Tested?
Tested build script changes for all the scenarios:

- [ ] For secured mode
     - ./build.sh object secure   
        - It will build for all architectures
     - ./build.sh object secure x86
     - ./build.sh object secure x86_64
     - ./build.sh object secure arm
     - ./build.sh object secure arm64 

- [ ] For Unsecured mode
     - ./build.sh object   
         - It will build for all architectures
     - ./build.sh object x86
     - ./build.sh object x86_64
     - ./build.sh object arm
     - ./build.sh object arm64 

**Test Configuration**:
* Firmware version: (Ubuntu 18.04)
* Hardware: (x86-64)
* Toolchain: (Go versions: 1.13.8)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works