### PR TITLE
Rsa authentication external api

### DIFF
--- a/doc/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/doc/platforms/raspberry_pi3/raspberry_pi3.md
@@ -203,7 +203,7 @@ RESTAPI
    ```  
    To add the `EDGE_ORCHESTRATION_TOKEN` variable to the environment execute the next command:
    ```
-   $ . tools/jwt_gen.sh
+   $ . tools/jwt_gen.sh HS256
    ```
    To add your container hash to the container white list `/var/edge-erchestration/data/cwl/containerwhitelist.txt`, you need to add a hash line to the end file.  
    ```

--- a/doc/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/doc/platforms/raspberry_pi3/raspberry_pi3.md
@@ -197,7 +197,7 @@ RESTAPI
     ```
   ---
    If the `edge-orchestration` was assembled with `secure` option.
-   You need to add a JSON Web Token into request header `Authorization: {token}` and a image digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](doc/secure_manager.md).
+   You need to add a JSON Web Token into request header `Authorization: {token}` and a image digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](../../doc/secure_manager.md).
    ```
    $ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
    ```  

--- a/doc/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/doc/platforms/raspberry_pi3/raspberry_pi3.md
@@ -197,7 +197,7 @@ RESTAPI
     ```
   ---
    If the `edge-orchestration` was assembled with `secure` option.
-   You need to add a JSON Web Token into request header `Authorization: {token}` and a image digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](../../doc/secure_manager.md).
+   You need to add a JSON Web Token into request header `Authorization: {token}` and a image digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](../../secure_manager.md).
    ```
    $ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
    ```  

--- a/doc/platforms/x86_64_linux/x86_64_linux.md
+++ b/doc/platforms/x86_64_linux/x86_64_linux.md
@@ -208,7 +208,7 @@ RESTAPI
    ```  
    To add the `EDGE_ORCHESTRATION_TOKEN` variable to the environment execute the next command:
    ```
-   $ . tools/jwt_gen.sh
+   $ . tools/jwt_gen.sh HS256
    ```
    To add your container hash to the container white list `/var/edge-erchestration/data/cwl/containerwhitelist.txt`, you need to add a hash line to the end file.  
    ```

--- a/doc/platforms/x86_64_linux/x86_64_linux.md
+++ b/doc/platforms/x86_64_linux/x86_64_linux.md
@@ -202,7 +202,7 @@ RESTAPI
     ```
   ---
    If the `edge-orchestration` was assembled with `secure` option.
-   You need to add a JSON Web Token into request header `Authorization: {token}` and a image digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](../../doc/secure_manager.md).
+   You need to add a JSON Web Token into request header `Authorization: {token}` and a image digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](../../secure_manager.md).
    ```
    $ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
    ```  

--- a/doc/platforms/x86_64_linux/x86_64_linux.md
+++ b/doc/platforms/x86_64_linux/x86_64_linux.md
@@ -202,7 +202,7 @@ RESTAPI
     ```
   ---
    If the `edge-orchestration` was assembled with `secure` option.
-   You need to add a JSON Web Token into request header `Authorization: {token}` and a image digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](doc/secure_manager.md).
+   You need to add a JSON Web Token into request header `Authorization: {token}` and a image digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](../../doc/secure_manager.md).
    ```
    $ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
    ```  

--- a/doc/secure_manager.md
+++ b/doc/secure_manager.md
@@ -134,7 +134,7 @@ If the `"fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"` hash
 
 ## 3. Authenticator
 ### 3.1 Description
-The **Authenticator** provides access to resources only for authenticated users (services). The current implementation is based on the use of [JSON Web Tokens](https://tools.ietf.org/html/rfc7519) (JWT). The Authenticator uses the `HMAC` algorithm to generate the JWTs. The key phrase (secret) is stored in `/var/edge-orchestration/data/passPhraseJWT.txt` file. 
+The **Authenticator** provides access to resources only for authenticated users (services). The current implementation is based on the use of [JSON Web Tokens](https://tools.ietf.org/html/rfc7519) (JWT). The Authenticator uses the `HMAC` or `RSA256` algorithms to generate the JWTs. The key phrase (secret) is stored in `/var/edge-orchestration/data/jwt/passPhraseJWT.txt` file for HMAC and the pubkey is stored in `/var/edge-orchestration/data/jwt/app_rsa.pub` for RSA256.
 > The distribution of the key phrase is not yet in the field of implementation and should be done manually (especially considering the fact that external REST API requests can only be from the `localhost` or `127.0.0.1`).
 ---
 

--- a/doc/secure_manager.md
+++ b/doc/secure_manager.md
@@ -170,15 +170,29 @@ node "Home Edge Node #1" {
 
 ### 3.3 JWT generation
 
-To create a JWT, you can use the script [tools/jwt_gen.sh](../tools/jwt_gen.sh) by running it as shown below.
+To create a JWT, you can use the script [tools/jwt_gen.sh](../tools/jwt_gen.sh) by running it as shown below:
+For `HMAC`
 ```shell
-$ . tools/jwt_gen.sh
+$ . tools/jwt_gen.sh HS256
 ```
+or for `RSA256`
+```shell
+$ . tools/jwt_gen.sh RS256
+```
+
 The generated token is exported to the shell environment variable: `EDGE_ORCHESTRATION_TOKEN`.
 Enter the following command to display the token:
 ```shell
 $ echo $EDGE_ORCHESTRATION_TOKEN
 ```
+
+> If you want to use the `RSA256` algorithm, you need to generate keys using the commands:
+```
+$ cd /var/edge-orchestration/data/jwt
+$ openssl genrsa -out app_rsa.key keysize
+$ openssl rsa -in app_rsa.key -pubout > app_rsa.pub
+```
+
 ---
 ### 3.4 JWT usage
 To use a JWT, you must include it in the header of the request: `Authorization: {token}`.


### PR DESCRIPTION
# Description

Asymmetric algorithm (RSA) for request authentication added.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Generate keys using the commands:
```
$ cd /var/edge-orchestration/data/jwt
$ openssl genrsa -out app_rsa.key keysize
$ openssl rsa -in app_rsa.key -pubout > app_rsa.pub
```
2. Create a JWT, you can use the script [tools/jwt_gen.sh](../tools/jwt_gen.sh) by running it as shown below:
```shell
$ . tools/jwt_gen.sh RS256
```
3. To use a JWT, you must include it in the header of the request: `Authorization: {token}`.
```
$ curl -X POST "127.0.0.1:56001/api/v1/orchestration/securemgr" -H "accept: applicationnt-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"SecureMgr\": \"Verifier\", \"CmdType\": \"printAllHashCWL\", \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
```

**Test Configuration**:
* Firmware version: Ubuntu 16.04
* Hardware: x86-64
* Toolchain: Docker and Go recommended versions
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
