### PR TITLE
Let the container's log print while it's running

### DIFF
--- a/src/controller/servicemgr/executor/containerexecutor/ce_docker.go
+++ b/src/controller/servicemgr/executor/containerexecutor/ce_docker.go
@@ -85,6 +85,7 @@ func (ce CEDocker) Logs(id string) (io.ReadCloser, error) {
 		ShowStdout: true,
 		ShowStderr: true,
 		Timestamps: true,
+		Follow: true,
 	}
 	return ce.client.ContainerLogs(ce.ctx, id, opts)
 }

--- a/src/controller/servicemgr/executor/containerexecutor/containerexecutor.go
+++ b/src/controller/servicemgr/executor/containerexecutor/containerexecutor.go
@@ -98,6 +98,14 @@ func (c ContainerExecutor) Execute(s executor.ServiceExecutionInfo) error {
 		return err
 	}
 
+	// @Note : get log of container
+	out, err := c.ceImplIns.Logs(resp.ID)
+	if err != nil {
+		log.Println(logPrefix, err.Error())
+	} else {
+		stdcopy.StdCopy(os.Stdout, os.Stderr, out)
+	}
+
 	// @Note : Waiting Container execution status
 	var executionStatus string
 	statusCh, errCh := c.ceImplIns.Wait(resp.ID, container.WaitConditionNotRunning)
@@ -110,14 +118,6 @@ func (c ContainerExecutor) Execute(s executor.ServiceExecutionInfo) error {
 		if status.StatusCode == 0 {
 			executionStatus = servicemgr.ConstServiceStatusFinished
 		}
-	}
-
-	// @Note : get log of container
-	out, err := c.ceImplIns.Logs(resp.ID)
-	if err != nil {
-		log.Println(logPrefix, err.Error())
-	} else {
-		stdcopy.StdCopy(os.Stdout, os.Stderr, out)
 	}
 
 	// @Note : make notification

--- a/src/controller/servicemgr/executor/containerexecutor/containerexecutor_test.go
+++ b/src/controller/servicemgr/executor/containerexecutor/containerexecutor_test.go
@@ -108,8 +108,8 @@ func TestExecute(t *testing.T) {
 		con.EXPECT().ImagePull(gomock.Any()).Return(nil),
 		con.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(resp, nil),
 		con.EXPECT().Start(containerID).Return(nil),
-		con.EXPECT().Wait(containerID, container.WaitConditionNotRunning).Return(statusChan, errCh),
 		con.EXPECT().Logs(containerID).Return(readCloser, nil),
+		con.EXPECT().Wait(containerID, container.WaitConditionNotRunning).Return(statusChan, errCh),
 		noti.EXPECT().InvokeNotification(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes(),
 		con.EXPECT().Remove(containerID),
 	)
@@ -168,8 +168,8 @@ func TestExecuteWaitInvokedError(t *testing.T) {
 		con.EXPECT().ImagePull(gomock.Any()).Return(nil),
 		con.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(resp, nil),
 		con.EXPECT().Start(containerID).Return(nil),
-		con.EXPECT().Wait(containerID, container.WaitConditionNotRunning).Return(statusChan, errCh),
 		con.EXPECT().Logs(containerID).Return(readCloser, nil),
+		con.EXPECT().Wait(containerID, container.WaitConditionNotRunning).Return(statusChan, errCh),
 		noti.EXPECT().InvokeNotification(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes(),
 		con.EXPECT().Remove(containerID),
 	)


### PR DESCRIPTION
Signed-off-by: t25kim <t25.kim@samsung.com>

# Description

The log from the container is printed after finishing the service. 
This PR is for printing the log stream while the container is running.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1.  Request to execute a service such as httpd.
```shell
curl -X POST "localhost:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"httpd\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-p\", \"8080:80\", \"-v\", \"/var/run:/var/run:rw\", \"httpd\"]}]}"
```
2. Send a GET request on the web browser as below.
```shell
http://localhost:8080/
```

**Test Configuration**:
* Firmware version: Ubuntu 16.04
* Hardware: x86-64
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules