### PR TITLE
Add signalmgr to manage the edge orchestrator by signal

### DIFF
--- a/GoMain/run.sh
+++ b/GoMain/run.sh
@@ -1,2 +1,10 @@
 #!/bin/bash
-/edge-orchestration/edge-orchestration
+/edge-orchestration/edge-orchestration &
+
+edge_pid=$!
+# Trap to forward SIGTERM to the child edge container
+trap 'kill -TERM $edge_pid' TERM
+wait $edge_pid
+# Restore SIGTERM to its default behavior
+trap - TERM
+wait $edge_pid

--- a/GoMain/src/main/main.go
+++ b/GoMain/src/main/main.go
@@ -21,9 +21,9 @@ package main
 import (
 	"errors"
 	"log"
-	"time"
 
 	"common/logmgr"
+	"common/sigmgr"
 
 	configuremgr "controller/configuremgr/container"
 	"controller/discoverymgr"
@@ -74,10 +74,7 @@ func main() {
 	if err := orchestrationInit(); err != nil {
 		log.Fatalf("[%s] Orchestaration initalize fail : %s", logPrefix, err.Error())
 	}
-
-	for {
-		time.Sleep(1000)
-	}
+	sigmgr.Watch()
 }
 
 // orchestrationInit runs orchestration service and discovers other orchestration services in other devices
@@ -163,10 +160,6 @@ func orchestrationInit() error {
 	restEdgeRouter.Start()
 
 	log.Println(logPrefix, "orchestration init done")
-
-	// TODO remove this line
-	// this line is for wait to initialize the mDNS server.
-	time.Sleep(time.Second * 2)
 
 	return nil
 }

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ PKG_LIST=(
         "common/resourceutil/cpu"
         "common/resourceutil/native"
         "common/resourceutil/types/servicemgrtypes"
+        "common/sigmgr"
         "common/types/configuremgrtypes"
         "common/types/servicemgrtypes"
         "controller/configuremgr"

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,10 @@ package: .
 excludeDirs:
   - CMain
 ignore:
+  - common/commandvalidator
+  - common/commandvalidator/blacklist
+  - common/commandvalidator/commands
+  - common/commandvalidator/injectionchecker
   - common/errormsg
   - common/errors
   - common/logmgr
@@ -13,12 +17,9 @@ ignore:
   - common/resourceutil/cpu
   - common/resourceutil/native
   - common/resourceutil/types/servicemgrtypes
+  - common/sigmgr
   - common/types/configuremgrtypes
   - common/types/servicemgrtypes
-  - common/commandvalidator
-  - common/commandvalidator/blacklist
-  - common/commandvalidator/commands
-  - common/commandvalidator/injectionchecker
   - controller/configuremgr
   - controller/configuremgr/container
   - controller/configuremgr/native

--- a/src/common/sigmgr/sigmgr.go
+++ b/src/common/sigmgr/sigmgr.go
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+
+package sigmgr
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+const (
+	logPrefix          = "[sigmgr]"
+)
+
+// Watch operating system signals
+func Watch() {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM)
+	s := <-sig
+	log.Println(logPrefix, "Received Signal:", s)
+}


### PR DESCRIPTION
Signed-off-by: t25kim <t25.kim@samsung.com>

# Description

As [@MoonkiHong's advise](https://github.com/lf-edge/edge-home-orchestration-go/issues/107#issuecomment-657982824), I've made the signal manager at the common folder.
This PR includes initial step of sigmgr code and the scenario that the edge orchestrator will be terminated if sigmgr detects SIGINT, SIGKILL and SIGTERM.
Fixes #107 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This PR has been tested as below.
1. Run the edge orchestrator
2-1. Produce SIGTERM ( $ docker stop edge-orchestration )
2-2. Produce SIGINT ( input "Ctrl + c" at the edge-orchestration container )

**Test Configuration**:
* Firmware version: Ubuntu 16.04
* Hardware: x86-64
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
