### PR TITLE
Delete connection refused device info from netDB

### DIFF
--- a/src/common/resourceutil/roundtriptime.go
+++ b/src/common/resourceutil/roundtriptime.go
@@ -19,7 +19,7 @@
 package resourceutil
 
 import (
-	"fmt"
+	"log"
 	"time"
 
 	"restinterface/resthelper"
@@ -76,7 +76,7 @@ func checkRTT(ip string) (rtt float64) {
 	reqTime := time.Now()
 	_, _, err := helper.DoGet(targetURL)
 	if err != nil {
-		fmt.Println(err.Error())
+		log.Println(err.Error())
 		return
 	}
 

--- a/src/common/resourceutil/roundtriptime.go
+++ b/src/common/resourceutil/roundtriptime.go
@@ -61,8 +61,13 @@ func processRTT() {
 				}
 				go func(info netDB.NetworkInfo) {
 					result := selectMinRTT(ch, totalCount)
-					info.RTT = result
-					netDBExecutor.Update(info)
+					if info.RTT < 0 && result < 0 {
+						log.Println(logPrefix, "Delete", info.ID)
+						netDBExecutor.Delete(info.ID)
+					} else {
+						info.RTT = result
+						netDBExecutor.Update(info)
+					}
 				}(netInfo)
 			}
 			time.Sleep(time.Duration(defaultRttDuration) * time.Second)
@@ -77,7 +82,7 @@ func checkRTT(ip string) (rtt float64) {
 	_, _, err := helper.DoGet(targetURL)
 	if err != nil {
 		log.Println(err.Error())
-		return
+		return -1
 	}
 
 	return time.Now().Sub(reqTime).Seconds()


### PR DESCRIPTION
# Description

The Edge Orchestrator deletes the offline device info from netDB if RTT fails twice in a row.
This PR sets the RTT value to a negative when RTT first fails, and deletes device information if RTT fails consecutively.

Fixes #109 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Set up a connection between devices.
2. Check logs after keeping a device offline
```
2020/07/20 06:28:58 helper.go:99: [http://10.113.71.53:56002/api/v1/ping] reqeust get failed !!, err = Get "http://10.113.71.53:56002/api/v1/ping": dial tcp 10.113.71.53:56002: connect: connection refused
2020/07/20 06:28:58 roundtriptime.go:84: Get "http://10.113.71.53:56002/api/v1/ping": dial tcp 10.113.71.53:56002: connect: connection refused
2020/07/20 06:29:03 helper.go:99: [http://10.113.71.53:56002/api/v1/ping] reqeust get failed !!, err = Get "http://10.113.71.53:56002/api/v1/ping": dial tcp 10.113.71.53:56002: connect: connection refused
2020/07/20 06:29:03 roundtriptime.go:84: Get "http://10.113.71.53:56002/api/v1/ping": dial tcp 10.113.71.53:56002: connect: connection refused
2020/07/20 06:29:03 roundtriptime.go:65: resourceutil Delete edge-orchestration-f323e2a4-624b-4eb7-8da2-a6b9b2813415
```

**Test Configuration**:
* Firmware version: Ubuntu 16.04
* Hardware: x86-64
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules