### PR TITLE
Build orchestrator for container based on arm arch

### DIFF
--- a/GoMain/Dockerfile
+++ b/GoMain/Dockerfile
@@ -2,7 +2,8 @@
 # TODO - need to reduce base image of edge-orchestration
 ### ubuntu:16.04 image size is 119MB
 ### alpine:3.6 image size is 4MB
-FROM ubuntu:16.04
+ARG PLATFORM
+FROM $PLATFORM/ubuntu:16.04
 
 # environment variables
 ENV TARGET_DIR=/edge-orchestration

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ build-object-java:
 
 ## edge-orchestration container build
 build-container:
-	$(DOCKER) build --tag $(PKG_NAME):$(CONTAINER_VERSION) --file $(GOMAIN_DIR)/Dockerfile .
+	$(DOCKER) build --tag $(PKG_NAME):$(CONTAINER_VERSION) --file $(GOMAIN_DIR)/Dockerfile --build-arg PLATFORM=$(CONTAINER_ARCH) .
 
 ## go test and coverage
 test-go:

--- a/doc/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/doc/platforms/raspberry_pi3/raspberry_pi3.md
@@ -36,7 +36,27 @@ $ sudo cp {SampleKey.key} /var/edge-orchestration/data/cert/edge-orchestration.k
 ---
 
 ## How to build
+There are two options for building a edge-orchestration container:
+1. On your PC and downloading the edge-orchestration container image from the `edge-orchestration.tar` archive (recommended).
+2. Build directly on the Raspberry Pi 3 board.
+### 1. Using your PC
+Run the `./build.sh` script and specify the build parameters - `container`,  architecture - `arm64`  (in the case of building in protected mode, add `secure`), see examples below:
+```shell
+$ ./build.sh container arm64
+```
+or for protected mode:
+```shell
+$ ./build.sh container secure arm64
+```
+the build result will be `edge-orchestration.tar` archive that can be found `GoMain/bin/edge-orchestration.tar`
 
+Next, need to copy `edge-orchestration.tar` archive to the Paspberry Pi 3 board, install the docker container (see [here](#Build-Prerequisites)  only docker part) and load the image using the command:
+```shell
+$ docker load -i edge-orchestration.tar
+```
+The build is finished, how to run see [here](#How-to-work).
+
+### 2. Build directly on the Raspberry Pi 3 board.
 #### Build Prerequisites
 - docker
 
@@ -96,14 +116,14 @@ edge-orchestration         baobab              502e3c07b01f        3 seconds ago
 build script
 Usage:
 -------------------------------------------------------------------------------------------------------------------------------------------
-  ./build.sh                      : build edge-orchestration by default container
-  ./build.sh secure               : build edge-orchestration by default container with secure option
-  ./build.sh container            : build Docker container as build system environmet
-  ./build.sh container secure     : build Docker container as build system environmet with secure option
-  ./build.sh object [Arch]        : build object (c-object, java-object), Arch:{x86, x86_64, arm, arm64} (default:all)
-  ./build.sh object secure [Arch] : build object (c-object, java-object) with secure option, Arch:{x86, x86_64, arm, arm64} (default:all)
-  ./build.sh clean                : build clean
-  ./build.sh test [PKG_NAME]      : run unittests (optional for PKG_NAME)
+  ./build.sh                         : build edge-orchestration by default Docker container for x86_64
+  ./build.sh secure                  : build edge-orchestration by default Docker container with secure option for x86_64
+  ./build.sh container [Arch]        : build Docker container Arch:{x86, x86_64, arm, arm64}
+  ./build.sh container secure [Arch] : build Docker container  with secure option Arch:{x86, x86_64, arm, arm64}
+  ./build.sh object [Arch]           : build object (c-object, java-object), Arch:{x86, x86_64, arm, arm64} (default:all)
+  ./build.sh object secure [Arch]    : build object (c-object, java-object) with secure option, Arch:{x86, x86_64, arm, arm64} (default:all)
+  ./build.sh clean                   : build clean
+  ./build.sh test [PKG_NAME]         : run unittests (optional for PKG_NAME)
 -------------------------------------------------------------------------------------------------------------------------------------------
 ```
 ---

--- a/doc/platforms/x86_64_linux/x86_64_linux.md
+++ b/doc/platforms/x86_64_linux/x86_64_linux.md
@@ -107,14 +107,14 @@ edge-orchestration         baobab              502e3c07b01f        3 seconds ago
 build script
 Usage:
 -------------------------------------------------------------------------------------------------------------------------------------------
-  ./build.sh                      : build edge-orchestration by default container
-  ./build.sh secure               : build edge-orchestration by default container with secure option
-  ./build.sh container            : build Docker container as build system environmet
-  ./build.sh container secure     : build Docker container as build system environmet with secure option
-  ./build.sh object [Arch]        : build object (c-object, java-object), Arch:{x86, x86_64, arm, arm64} (default:all)
-  ./build.sh object secure [Arch] : build object (c-object, java-object) with secure option, Arch:{x86, x86_64, arm, arm64} (default:all)
-  ./build.sh clean                : build clean
-  ./build.sh test [PKG_NAME]      : run unittests (optional for PKG_NAME)
+  ./build.sh                         : build edge-orchestration by default Docker container for x86_64
+  ./build.sh secure                  : build edge-orchestration by default Docker container with secure option for x86_64
+  ./build.sh container [Arch]        : build Docker container Arch:{x86, x86_64, arm, arm64}
+  ./build.sh container secure [Arch] : build Docker container  with secure option Arch:{x86, x86_64, arm, arm64}
+  ./build.sh object [Arch]           : build object (c-object, java-object), Arch:{x86, x86_64, arm, arm64} (default:all)
+  ./build.sh object secure [Arch]    : build object (c-object, java-object) with secure option, Arch:{x86, x86_64, arm, arm64} (default:all)
+  ./build.sh clean                   : build clean
+  ./build.sh test [PKG_NAME]         : run unittests (optional for PKG_NAME)
 -------------------------------------------------------------------------------------------------------------------------------------------
 ```
 > If you build the edge-orchestration as c-object, then a more detailed description can be found [x86_64_native.md](x86_64_native.md)


### PR DESCRIPTION
# Description

Building an edge-orchestration container on a H/W board is a very complicated and inconvenient process. I added the ability to build the edge-orchestration container for different architectures on PC. Raspberry Pi 3 is an example.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

How to test is described in the `doc/platforms/raspberry_pi3/raspberry_pi3.md` file `#How to build` part.

```
Example
1. Describe the reproduction procedures freely.
2. Or list up the test description like :
  - [x] Unittest
  - [x] Execution of Container
  - [ ] Execution on top of Android
```

**Test Configuration**:
* Firmware version: Ubuntu 16.04
* Hardware: x86-64, ARM64
* Toolchain: (Docker and Go recommended versions
* Edge Orchestration Release: Baobab
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
