### PR TITLE
Fix the architecture for building a container on RPi directly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -376,7 +376,13 @@ function build_docker_container() {
             CONTAINER_ARCH="arm64v8"
             ;;
         *)
-            echo "Target arch isn't supported" && exit 1
+            if [ "$(uname -m)" == "x86_64" ]; then
+                CONTAINER_ARCH="amd64"
+            elif [ "$(uname -m)" == "armv7l" ]; then
+                CONTAINER_ARCH="arm32v7"
+            else
+                echo "Target arch isn't supported" && exit 1
+            fi
             ;;
     esac
 
@@ -475,7 +481,7 @@ case "$1" in
         install_prerequisite
         install_3rdparty_packages
         build_binary
-        build_docker_container "x86_64"
+        build_docker_container
         run_docker_container
         ;;
     "secure")
@@ -483,15 +489,15 @@ case "$1" in
         install_prerequisite
         install_3rdparty_packages
         build_binary
-        build_docker_container "x86_64"
+        build_docker_container
         run_docker_container
         ;;
     *)
         echo "build script"
         echo "Usage:"
         echo "-------------------------------------------------------------------------------------------------------------------------------------------"
-        echo "  $0                         : build edge-orchestration by default Docker container for x86_64"
-        echo "  $0 secure                  : build edge-orchestration by default Docker container with secure option for x86_64"
+        echo "  $0                         : build edge-orchestration by default Docker container"
+        echo "  $0 secure                  : build edge-orchestration by default Docker container with secure option"
         echo "  $0 container [Arch]        : build Docker container Arch:{x86, x86_64, arm, arm64}"
         echo "  $0 container secure [Arch] : build Docker container  with secure option Arch:{x86, x86_64, arm, arm64}"
         echo "  $0 object [Arch]           : build object (c-object, java-object), Arch:{x86, x86_64, arm, arm64} (default:all)"

--- a/doc/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/doc/platforms/raspberry_pi3/raspberry_pi3.md
@@ -116,8 +116,8 @@ edge-orchestration         baobab              502e3c07b01f        3 seconds ago
 build script
 Usage:
 -------------------------------------------------------------------------------------------------------------------------------------------
-  ./build.sh                         : build edge-orchestration by default Docker container for x86_64
-  ./build.sh secure                  : build edge-orchestration by default Docker container with secure option for x86_64
+  ./build.sh                         : build edge-orchestration by default Docker container
+  ./build.sh secure                  : build edge-orchestration by default Docker container with secure option
   ./build.sh container [Arch]        : build Docker container Arch:{x86, x86_64, arm, arm64}
   ./build.sh container secure [Arch] : build Docker container  with secure option Arch:{x86, x86_64, arm, arm64}
   ./build.sh object [Arch]           : build object (c-object, java-object), Arch:{x86, x86_64, arm, arm64} (default:all)

--- a/doc/platforms/x86_64_linux/x86_64_linux.md
+++ b/doc/platforms/x86_64_linux/x86_64_linux.md
@@ -107,8 +107,8 @@ edge-orchestration         baobab              502e3c07b01f        3 seconds ago
 build script
 Usage:
 -------------------------------------------------------------------------------------------------------------------------------------------
-  ./build.sh                         : build edge-orchestration by default Docker container for x86_64
-  ./build.sh secure                  : build edge-orchestration by default Docker container with secure option for x86_64
+  ./build.sh                         : build edge-orchestration by default Docker container
+  ./build.sh secure                  : build edge-orchestration by default Docker container with secure option
   ./build.sh container [Arch]        : build Docker container Arch:{x86, x86_64, arm, arm64}
   ./build.sh container secure [Arch] : build Docker container  with secure option Arch:{x86, x86_64, arm, arm64}
   ./build.sh object [Arch]           : build object (c-object, java-object), Arch:{x86, x86_64, arm, arm64} (default:all)


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

This patch allows RPi to build the source code directly for own system. 

Fixes #119 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] This change requires a documentation update

# How Has This Been Tested?
Build the edge-orchestration on RPi2 and on Ubuntu 16.04
 $ ./build

**Test Configuration**:
* Firmware version: Ubuntu 16.04, RPi2
* Hardware: x86-64, armv7l
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
