### PR TITLE
Calculate scores by collecting resource information from all edge devices

### DIFF
--- a/src/orchestrationapi/orchestration.go
+++ b/src/orchestrationapi/orchestration.go
@@ -57,6 +57,8 @@ type OrcheInternalAPI interface {
 	ExecuteAppOnLocal(appInfo map[string]interface{})
 	HandleNotificationOnLocal(serviceID float64, status string) error
 	GetScore(target string) (scoreValue float64, err error)
+	GetScoreWithResource(target map[string]interface{}) (scoreValue float64, err error)
+	GetResource(target string) (resourceMsg map[string]interface{}, err error)
 }
 
 var (
@@ -215,6 +217,16 @@ func (o orcheImpl) HandleNotificationOnLocal(serviceID float64, status string) e
 // GetScore gets a resource score of local device for specific app
 func (o orcheImpl) GetScore(devID string) (scoreValue float64, err error) {
 	return o.scoringIns.GetScore(devID)
+}
+
+// GetScoreWithResource gets a resource score of local device for specific app
+func (o orcheImpl) GetScoreWithResource(resource map[string]interface{}) (scoreValue float64, err error) {
+	return o.scoringIns.GetScoreWithResource(resource)
+}
+
+// GetResource gets resource values of local device for running apps
+func (o orcheImpl) GetResource(devID string) (resourceMsg map[string]interface{}, err error) {
+	return o.scoringIns.GetResource(devID)
 }
 
 // RequestVerifierConf setting up configuration of white list containers

--- a/src/orchestrationapi/orchestration_api.go
+++ b/src/orchestrationapi/orchestration_api.go
@@ -56,7 +56,7 @@ type orcheImpl struct {
 	clientAPI client.Clienter
 }
 
-type deviceScore struct {
+type deviceInfo struct {
 	id       string
 	endpoint string
 	score    float64
@@ -245,12 +245,12 @@ func (orcheEngine orcheImpl) getCandidate(appName string, execType []string) (de
 	return helper.GetDeviceInfoWithService(appName, execType)
 }
 
-func (orcheEngine orcheImpl) gatherDevicesScore(candidates []dbhelper.ExecutionCandidate, selfSelection bool) (deviceScores []deviceScore) {
+func (orcheEngine orcheImpl) gatherDevicesScore(candidates []dbhelper.ExecutionCandidate, selfSelection bool) (deviceScores []deviceInfo) {
 	count := len(candidates)
 	if !selfSelection {
 		count -= 1
 	}
-	scores := make(chan deviceScore, count)
+	scores := make(chan deviceInfo, count)
 
 	info, err := sysDBExecutor.Get(sysDB.ID)
 	if err != nil {
@@ -295,7 +295,7 @@ func (orcheEngine orcheImpl) gatherDevicesScore(candidates []dbhelper.ExecutionC
 
 			if len(cand.Endpoint) == 0 {
 				log.Println("[orchestrationapi] cannot getting score, cause by ip list is empty")
-				scores <- deviceScore{endpoint: "", score: float64(0.0), id: cand.Id}
+				scores <- deviceInfo{endpoint: "", score: float64(0.0), id: cand.Id}
 				return
 			}
 
@@ -310,7 +310,7 @@ func (orcheEngine orcheImpl) gatherDevicesScore(candidates []dbhelper.ExecutionC
 
 			if err != nil {
 				log.Println("[orchestrationapi] cannot getting score from :", cand.Endpoint[0], "cause by", err.Error())
-				scores <- deviceScore{endpoint: cand.Endpoint[0], score: float64(0.0), id: cand.Id}
+				scores <- deviceInfo{endpoint: cand.Endpoint[0], score: float64(0.0), id: cand.Id}
 				return
 			}
 			log.Printf("[orchestrationapi] deviceScore")
@@ -318,7 +318,7 @@ func (orcheEngine orcheImpl) gatherDevicesScore(candidates []dbhelper.ExecutionC
 			log.Printf("candidate ExecType : %v", cand.ExecType)
 			log.Printf("candidate Endpoint : %v", cand.Endpoint[0])
 			log.Printf("candidate score    : %v", score)
-			scores <- deviceScore{endpoint: cand.Endpoint[0], score: score, id: cand.Id, execType: cand.ExecType}
+			scores <- deviceInfo{endpoint: cand.Endpoint[0], score: score, id: cand.Id, execType: cand.ExecType}
 		}(candidate)
 	}
 
@@ -363,7 +363,7 @@ func addServiceClient(clientID int, appName string) (client *orcheClient) {
 	return
 }
 
-func sortByScore(deviceScores []deviceScore) []deviceScore {
+func sortByScore(deviceScores []deviceInfo) []deviceInfo {
 	sort.Slice(deviceScores, func(i, j int) bool {
 		return deviceScores[i].score > deviceScores[j].score
 	})

--- a/src/orchestrationapi/orchestration_api.go
+++ b/src/orchestrationapi/orchestration_api.go
@@ -73,6 +73,7 @@ type orcheClient struct {
 type RequestServiceInfo struct {
 	ExecutionType string
 	ExeCmd        []string
+	ExeOption     map[string]interface{}
 }
 
 type ReqeustService struct {

--- a/src/restinterface/client/client.go
+++ b/src/restinterface/client/client.go
@@ -32,6 +32,7 @@ type Clienter interface {
 
 	// for scoringmgr
 	DoGetScoreRemoteDevice(devID string, endpoint string) (scoreValue float64, err error)
+	DoGetResourceRemoteDevice(devID string, endpoint string) (respMsg map[string]interface{}, err error)
 }
 
 // Setter interface

--- a/src/restinterface/externalhandler/externalhandler.go
+++ b/src/restinterface/externalhandler/externalhandler.go
@@ -210,6 +210,11 @@ func (h *Handler) APIV1RequestServicePost(w http.ResponseWriter, r *http.Request
 		for idy, cmd := range exeCmd {
 			serviceInfos.ServiceInfo[idx].ExeCmd[idy] = cmd.(string)
 		}
+
+		exeOption, ok := tmp["ExecOption"].(interface{})
+		if ok {
+			serviceInfos.ServiceInfo[idx].ExeOption = exeOption.(map[string]interface{})
+		}
 	}
 
 	resp = h.api.RequestService(serviceInfos)


### PR DESCRIPTION
# Description
This is one of PRs related on the issue #121.
An edge orchestration is able to calculate all the scores based on the resource information gathered from other devices.
This function runs only when ExecOption's scoringType in REST API for executing a service is "resource" like below.
```
curl -X POST "localhost:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world\"], \"ExecOption\": {\"scoringType\":\"resource\"}}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
```
```
{
    "ServiceName": "hello-world",
    "ServiceInfo": [
    {
        "ExecutionType": "container",
        "ExecCmd": [
            "docker",
            "run",
            "-v", "/var/run:/var/run:rw",
            "hello-world"
        ],
        "ExecOption": { "scoringType": "resource" }
    }],
    "StatusCallbackURI": "http://localhost:8888/api/v1/services/notification"
}
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
This PR is tested on the container by the REST API for executing a service.
1. scoringType is "resource"
```
2020/08/26 09:09:09 externalhandler.go:89: [RestExternalInterface] APIV1RequestServicePost
2020/08/26 09:09:09 externalhandler.go:153: port:  54414
2020/08/26 09:09:09 senderresolver.go:70: returning:  curl
2020/08/26 09:09:09 externalhandler.go:158: requester:  curl
2020/08/26 09:09:09 orchestration_api.go:124: [RequestService] hello-world: [{container [docker run -v /var/run:/var/run:rw hello-world] map[scoringType:resource]}]
2020/08/26 09:09:09 orchestration_api.go:150: [RequestService] getCandidate
2020/08/26 09:09:09 orchestration_api.go:152: [0] Id       : edge-orchestration-1ffe80c4-6b60-4ae2-8b3a-68b9d803c243
2020/08/26 09:09:09 orchestration_api.go:153: [0] ExecType : container
2020/08/26 09:09:09 orchestration_api.go:154: [0] Endpoint : [10.113.70.227]
2020/08/26 09:09:09 orchestration_api.go:155:
2020/08/26 09:09:09 orchestration_api.go:152: [1] Id       : edge-orchestration-f323e2a4-624b-4eb7-8da2-a6b9b2813415
2020/08/26 09:09:09 orchestration_api.go:153: [1] ExecType : container
2020/08/26 09:09:09 orchestration_api.go:154: [1] Endpoint : [10.113.71.53]
2020/08/26 09:09:09 orchestration_api.go:155:
2020/08/26 09:09:09 restclient.go:157: [restclient] DoGetResourceRemoteDevice : endpoint[10.113.70.227]
2020/08/26 09:09:09 orchestration_api.go:417: [orchestrationapi] deviceResource
2020/08/26 09:09:09 orchestration_api.go:418: candidate Id       : edge-orchestration-f323e2a4-624b-4eb7-8da2-a6b9b2813415
2020/08/26 09:09:09 orchestration_api.go:419: candidate ExecType : container
2020/08/26 09:09:09 orchestration_api.go:420: candidate Endpoint : 10.113.71.53
2020/08/26 09:09:09 orchestration_api.go:421: candidate resource : map[cpuUsage:0.7594936708860759 cpuCount:4 cpuFreq:900 netBandwidth:1000 rtt:0.003407767]
2020/08/26 09:09:09 restclient.go:182: [restclient] respMsg From [10.113.70.227] : map[cpuCount:8 cpuFreq:4200 cpuUsage:0 netBandwidth:500 rtt:0.002952915]
2020/08/26 09:09:09 orchestration_api.go:417: [orchestrationapi] deviceResource
2020/08/26 09:09:09 orchestration_api.go:418: candidate Id       : edge-orchestration-1ffe80c4-6b60-4ae2-8b3a-68b9d803c243
2020/08/26 09:09:09 orchestration_api.go:419: candidate ExecType : container
2020/08/26 09:09:09 orchestration_api.go:420: candidate Endpoint : 10.113.70.227
2020/08/26 09:09:09 orchestration_api.go:421: candidate resource : map[netBandwidth:500 rtt:0.002952915 cpuCount:8 cpuFreq:4200 cpuUsage:0]
2020/08/26 09:09:09 restclient.go:62: [restclient] DoExecuteRemoteDevice : endpoint[10.113.70.227]
2020/08/26 09:09:09 restclient.go:85: [restclient] respMsg From [10.113.70.227] : map[Status:Started]
2020/08/26 09:09:09 orchestration_api.go:240: [orchestrationapi]  [{edge-orchestration-1ffe80c4-6b60-4ae2-8b3a-68b9d803c243 10.113.70.227 16.784057707434982 map[cpuCount:8 cpuFreq:4200 cpuUsage:0 netBandwidth:500 rtt:0.002952915] container} {edge-orchestration-f323e2a4-624b-4eb7-8da2-a6b9b2813415 10.113.71.53 11.653885351967045 map[rtt:0.003407767 cpuUsage:0.7594936708860759 cpuCount:4 cpuFreq:900 netBandwidth:1000] container}]
2020/08/26 09:09:09 route.go:125: From [10.113.71.53:54414] POST /api/v1/orchestration/services APIV1RequestServicePost 150.217346ms
2020/08/26 09:09:14 internalhandler.go:189: [RestInternalInterface] APIV1ServicemgrServicesNotificationServiceIDPost
2020/08/26 09:09:14 route.go:125: From [10.113.70.227:54600] POST /api/v1/servicemgr/services/notification/2 APIV1ServicemgrServicesNotificationServiceIDPost 1.574221ms
2020/08/26 09:09:14 orchestration_api.go:444: [orchestrationapi] service status changed [appNames:hello-world][status:Finished]

```
2. scoringType is not included
```
2020/08/26 09:07:26 externalhandler.go:89: [RestExternalInterface] APIV1RequestServicePost
2020/08/26 09:07:26 externalhandler.go:153: port:  54350
2020/08/26 09:07:26 senderresolver.go:70: returning:  curl
2020/08/26 09:07:26 externalhandler.go:158: requester:  curl
2020/08/26 09:07:26 orchestration_api.go:124: [RequestService] hello-world: [{container [docker run -v /var/run:/var/run:rw hello-world] map[]}]
2020/08/26 09:07:26 orchestration_api.go:150: [RequestService] getCandidate
2020/08/26 09:07:26 orchestration_api.go:152: [0] Id       : edge-orchestration-1ffe80c4-6b60-4ae2-8b3a-68b9d803c243
2020/08/26 09:07:26 orchestration_api.go:153: [0] ExecType : container
2020/08/26 09:07:26 orchestration_api.go:154: [0] Endpoint : [10.113.70.227]
2020/08/26 09:07:26 orchestration_api.go:155:
2020/08/26 09:07:26 orchestration_api.go:152: [1] Id       : edge-orchestration-f323e2a4-624b-4eb7-8da2-a6b9b2813415
2020/08/26 09:07:26 orchestration_api.go:153: [1] ExecType : container
2020/08/26 09:07:26 orchestration_api.go:154: [1] Endpoint : [10.113.71.53]
2020/08/26 09:07:26 orchestration_api.go:155:
2020/08/26 09:07:26 restclient.go:121: [restclient] DoGetScoreRemoteDevice : endpoint[10.113.70.227]
2020/08/26 09:07:26 orchestration_api.go:334: [orchestrationapi] deviceScore
2020/08/26 09:07:26 orchestration_api.go:335: candidate Id       : edge-orchestration-f323e2a4-624b-4eb7-8da2-a6b9b2813415
2020/08/26 09:07:26 orchestration_api.go:336: candidate ExecType : container
2020/08/26 09:07:26 orchestration_api.go:337: candidate Endpoint : 10.113.71.53
2020/08/26 09:07:26 orchestration_api.go:338: candidate score    : 10.519956207454118
2020/08/26 09:07:26 restclient.go:146: [restclient] respMsg From [10.113.70.227] : map[ScoreValue:16.821653074808697]
2020/08/26 09:07:26 orchestration_api.go:334: [orchestrationapi] deviceScore
2020/08/26 09:07:26 orchestration_api.go:335: candidate Id       : edge-orchestration-1ffe80c4-6b60-4ae2-8b3a-68b9d803c243
2020/08/26 09:07:26 orchestration_api.go:336: candidate ExecType : container
2020/08/26 09:07:26 orchestration_api.go:337: candidate Endpoint : 10.113.70.227
2020/08/26 09:07:26 orchestration_api.go:338: candidate score    : 16.821653074808697
2020/08/26 09:07:26 restclient.go:62: [restclient] DoExecuteRemoteDevice : endpoint[10.113.70.227]
2020/08/26 09:07:26 restclient.go:85: [restclient] respMsg From [10.113.70.227] : map[Status:Started]
2020/08/26 09:07:26 orchestration_api.go:240: [orchestrationapi]  [{edge-orchestration-1ffe80c4-6b60-4ae2-8b3a-68b9d803c243 10.113.70.227 16.821653074808697 map[] container} {edge-orchestration-f323e2a4-624b-4eb7-8da2-a6b9b2813415 10.113.71.53 10.519956207454118 map[] container}]
2020/08/26 09:07:26 route.go:125: From [10.113.71.53:54350] POST /api/v1/orchestration/services APIV1RequestServicePost 179.182239ms
2020/08/26 09:07:31 internalhandler.go:189: [RestInternalInterface] APIV1ServicemgrServicesNotificationServiceIDPost
2020/08/26 09:07:31 orchestration_api.go:444: [orchestrationapi] service status changed [appNames:hello-world][status:Finished]
2020/08/26 09:07:31 route.go:125: From [10.113.70.227:54508] POST /api/v1/servicemgr/services/notification/1 APIV1ServicemgrServicesNotificationServiceIDPost 2.064848ms
```

**Test Configuration**:
* Firmware version: Ubuntu 16.04, RPi2
* Hardware: x86-64, ARM
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
