### PR TITLE
Fix ability build directly on different target platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -376,13 +376,23 @@ function build_docker_container() {
             CONTAINER_ARCH="arm64v8"
             ;;
         *)
-            if [ "$(uname -m)" == "x86_64" ]; then
-                CONTAINER_ARCH="amd64"
-            elif [ "$(uname -m)" == "armv7l" ]; then
-                CONTAINER_ARCH="arm32v7"
-            else
-                echo "Target arch isn't supported" && exit 1
-            fi
+            case "$(uname -m)" in
+                "i386"|"i686")
+                    CONTAINER_ARCH="i386"
+                    ;;
+                "x86_64")
+                    CONTAINER_ARCH="amd64"
+                    ;;
+                "armv7l")
+                    CONTAINER_ARCH="arm32v7"
+                    ;;
+                "aarch64")
+                    CONTAINER_ARCH="arm64v8"
+                    ;;
+                *)
+                    echo "Target arch isn't supported" && exit 1
+                    ;;
+            esac
             ;;
     esac
 


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Added the ability to build the edge-orchestration directly on different target platforms: i386/i686, aarch64.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
Need to run the `./build.sh` script directly on target platform (Ex: i386/i686 or aarch64)
 
 - [x] Execution of Container

```

**Test Configuration**:
* Firmware version: Ubuntu 16.04
* Hardware: x86, aarch64
* Toolchain: Docker and Go recomended versions
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
