### PR TITLE
The Configuration DB manages the lists of services installed on the edge devices

### DIFF
--- a/src/controller/discoverymgr/discovery_test.go
+++ b/src/controller/discoverymgr/discovery_test.go
@@ -87,23 +87,21 @@ func createMockIns(ctrl *gomock.Controller) {
 }
 
 func addDevice(Another bool) {
-	deviceID, confInfo, netInfo, serviceInfo := convertToDBInfo(defaultMyDeviceEntity)
+	deviceID, confInfo, netInfo := convertToDBInfo(defaultMyDeviceEntity)
 
 	log.Println(logPrefix, "[addDevice]", deviceID)
 	setSystemDB(deviceID, defaultPlatform, defaultExecutionType)
 	setConfigurationDB(confInfo)
 	setNetworkDB(netInfo)
-	setServiceDB(serviceInfo)
 
 	if !Another {
 		return
 	}
 
-	deviceID, confInfo, netInfo, serviceInfo = convertToDBInfo(anotherEntity)
+	deviceID, confInfo, netInfo = convertToDBInfo(anotherEntity)
 
 	setConfigurationDB(confInfo)
 	setNetworkDB(netInfo)
-	setServiceDB(serviceInfo)
 }
 
 func checkPresence(t *testing.T, deviceID string) {
@@ -115,11 +113,6 @@ func checkPresence(t *testing.T, deviceID string) {
 	}
 
 	_, err = netQuery.Get(deviceID)
-	if err != nil {
-		t.Error(err.Error())
-	}
-
-	_, err = serviceQuery.Get(deviceID)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -136,11 +129,6 @@ func checkNotPresence(t *testing.T, deviceID string) {
 	}
 
 	_, err = netQuery.Get(deviceID)
-	if err == nil {
-		t.Error()
-	}
-
-	_, err = serviceQuery.Get(deviceID)
 	if err == nil {
 		t.Error()
 	}
@@ -163,11 +151,6 @@ func checkClearMap(t *testing.T) {
 	netInfos, err := netQuery.GetList()
 	if len(netInfos) != 1 || err != nil {
 		t.Error("Not Cleared : Network Map")
-	}
-
-	serviceInfos, err := serviceQuery.GetList()
-	if len(serviceInfos) != 1 || err != nil {
-		t.Error("Not Cleared : Service Map")
 	}
 }
 
@@ -257,11 +240,10 @@ func TestDeviceDetectionRoutine(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		t.Run("SuccessClearMap", func(t *testing.T) {
-			_, confInfo, netInfo, serviceInfo := convertToDBInfo(anotherEntity)
+			_, confInfo, netInfo := convertToDBInfo(anotherEntity)
 
 			setConfigurationDB(confInfo)
 			setNetworkDB(netInfo)
-			setServiceDB(serviceInfo)
 
 			devicesubchan <- nil
 			time.Sleep(1 * time.Second)
@@ -270,11 +252,10 @@ func TestDeviceDetectionRoutine(t *testing.T) {
 			checkPresence(t, defaultMyDeviceID)
 		})
 		t.Run("SuccessDeleteDevice", func(t *testing.T) {
-			_, confInfo, netInfo, serviceInfo := convertToDBInfo(anotherEntity)
+			_, confInfo, netInfo := convertToDBInfo(anotherEntity)
 
 			setConfigurationDB(confInfo)
 			setNetworkDB(netInfo)
-			setServiceDB(serviceInfo)
 
 			tmpEntity := anotherEntity
 			tmpEntity.TTL = 0
@@ -374,12 +355,12 @@ func TestAddNewServiceName(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			serviceInfo, err := serviceQuery.Get(deviceID)
+			confInfo, err := confQuery.Get(deviceID)
 			if err != nil {
 				t.Fatal(err.Error())
 			}
 
-			for _, service := range serviceInfo.Services {
+			for _, service := range confInfo.Services {
 				if service == newServiceName {
 					presence = true
 				}
@@ -420,12 +401,12 @@ func TestRemoveServiceName(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			serviceInfo, err := serviceQuery.Get(deviceID)
+			confInfo, err := confQuery.Get(deviceID)
 			if err != nil {
 				t.Fatal(err.Error())
 			}
 
-			for _, service := range serviceInfo.Services {
+			for _, service := range confInfo.Services {
 				if service == defaultService {
 					isPresence = true
 				}
@@ -459,12 +440,12 @@ func TestResetServiceName(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			serviceInfo, err := serviceQuery.Get(deviceID)
+			confInfo, err := confQuery.Get(deviceID)
 			if err != nil {
 				t.Fatal(err.Error())
 			}
 
-			if len(serviceInfo.Services) != 0 {
+			if len(confInfo.Services) != 0 {
 				t.Error("Reset failed")
 			}
 		})

--- a/src/controller/discoverymgr/types.go
+++ b/src/controller/discoverymgr/types.go
@@ -34,9 +34,8 @@ type OrchestrationInformation struct {
 	Platform      string `json:"Platform"`
 	ExecutionType string `json:"ExecutionType"`
 
-	//interface-ip 형태의 구조체 리스트로.
-	IPv4 []string `json:"IPv4"`
-	// IPv6     []string   `json:"IPv6"`
+	IPv4        []string `json:"IPv4"`
+	// IPv6     []string `json:"IPv6"`
 	ServiceList []string `json:"ServiceList"`
 }
 

--- a/src/db/bolt/configuration/configuration.go
+++ b/src/db/bolt/configuration/configuration.go
@@ -26,9 +26,10 @@ import (
 const bucketName = "configuration"
 
 type Configuration struct {
-	ID       string `json:"id"`
-	Platform string `json:"platform"`
-	ExecType string `json:"executionType"`
+	ID       string   `json:"id"`
+	Platform string   `json:"platform"`
+	ExecType string   `json:"executionType"`
+	Services []string `json:"services"`
 }
 
 type DBInterface interface {
@@ -125,6 +126,7 @@ func (conf Configuration) convertToMap() map[string]interface{} {
 		"id":            conf.ID,
 		"platform":      conf.Platform,
 		"executionType": conf.ExecType,
+		"services":      conf.Services,
 	}
 }
 


### PR DESCRIPTION
# Description

This PR suggest the Configuration db stores the lists of services installed on the devices instead of ServiceInfo db.
If this PR is accepted, Edge Orchestration might use the ServiceInfo db to manage services installed on its own device.
It is related on the issue #129 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- Run the Edge Orchestration as container or native.
- Test discoverymgr testcast
```
./build.sh test discoverymgr
```

**Test Configuration**:
* Firmware version: Ubuntu 16.04, RPi2
* Hardware: x86-64, ARM
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
