### PR TITLE
Add init version of RBAC

### DIFF
--- a/GoMain/src/main/main.go
+++ b/GoMain/src/main/main.go
@@ -29,6 +29,7 @@ import (
 	"controller/discoverymgr"
 	"controller/scoringmgr"
 	"controller/securemgr/authenticator"
+	"controller/securemgr/authorizer"
 	"controller/securemgr/verifier"
 	"controller/servicemgr"
 	executor "controller/servicemgr/executor/containerexecutor"
@@ -60,6 +61,7 @@ const (
 	certificateFilePath    = edgeDir + "/data/cert"
 	containerWhiteListPath = edgeDir + "/data/cwl"
 	passPhraseJWTPath      = edgeDir + "/data/jwt"
+	rbacRulePath           = edgeDir + "/data/rbac"
 
 	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
 	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"
@@ -96,6 +98,7 @@ func orchestrationInit() error {
 	if isSecured {
 		verifier.Init(containerWhiteListPath)
 		authenticator.Init(passPhraseJWTPath)
+		authorizer.Init(rbacRulePath)
 	}
 
 	restIns := restclient.GetRestClient()

--- a/build.sh
+++ b/build.sh
@@ -109,6 +109,7 @@ function install_prerequisite() {
         "golang.org/x/mobile/cmd/gomobile"
         "golang.org/x/mobile/cmd/gobind"
         "github.com/dgrijalva/jwt-go"
+        "github.com/casbin/casbin"
     )
     idx=1
     for pkg in "${pkg_list[@]}"; do

--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,7 @@ PKG_LIST=(
         "controller/scoringmgr"
         "controller/securemgr/verifier"
         "controller/securemgr/authenticator"
+        "controller/securemgr/authorizer"
         "controller/servicemgr"
         "controller/servicemgr/executor"
         "controller/servicemgr/executor/androidexecutor"

--- a/doc/platforms/x86_64_linux/x86_64_linux.md
+++ b/doc/platforms/x86_64_linux/x86_64_linux.md
@@ -205,11 +205,11 @@ RESTAPI
    ```  
    To add the `EDGE_ORCHESTRATION_TOKEN` variable to the environment execute the next command:
    ```
-   $ . tools/jwt_gen.sh HS256
+   $ . tools/jwt_gen.sh HS256 Admin
    ```
-   To add your container hash to the container white list `/var/edge-erchestration/data/cwl/containerwhitelist.txt`, you need to add a hash line to the end file.  
+   To add your container hash to the container white list `/var/edge-orchestration/data/cwl/containerwhitelist.txt`, you need to add a hash line to the end file.  
    ```
-   # echo "fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752" >> /var/edge-erchestration/data/cwl/containerwhitelist.txt
+   # echo "fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752" >> /var/edge-orchestration/data/cwl/containerwhitelist.txt
    ```
   ---
 

--- a/doc/platforms/x86_64_linux/x86_64_native.md
+++ b/doc/platforms/x86_64_linux/x86_64_native.md
@@ -204,7 +204,7 @@ You need to add a JSON Web Token into request header `Authorization: {token}`. M
 
 > To add the `EDGE_ORCHESTRATION_TOKEN` variable to the environment execute the next command:
 ```
-$ . tools/jwt_gen.sh HS256
+$ . tools/jwt_gen.sh HS256 Admin
 ```
 
 ```

--- a/glide.yaml
+++ b/glide.yaml
@@ -70,6 +70,8 @@ import:
       - runconfig
   - package: github.com/docker/distribution
     version: edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
+  - package: github.com/casbin/casbin
+    version: v1.9.1
   - package: github.com/docker/go-connections
     version: v0.3.0
   - package: github.com/docker/go-units

--- a/src/controller/securemgr/authorizer/authorizer.go
+++ b/src/controller/securemgr/authorizer/authorizer.go
@@ -1,0 +1,141 @@
+/*******************************************************************************
+* Copyright 2020 Samsung Electronics All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*******************************************************************************/
+package authorizer
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/casbin/casbin"
+)
+
+// AuthorizerImpl structure
+type AuthorizerImpl struct{}
+
+const (
+	rbacPolicyFileName = "policy.csv"
+	policy_template    = "p, admin, /*, *\n" +
+		"p, member, /api/v1/orchestration/services, *\n"
+	rbacAuthModelFileName = "auth_model.conf"
+	auth_model_template   = "[request_definition]\n" +
+		"r = sub, obj, act\n\n" +
+		"[policy_definition]\n" +
+		"p = sub, obj, act\n\n" +
+		"[policy_effect]\n" +
+		"e = some(where (p.eft == allow))\n\n" +
+		"[matchers]\n" +
+		"m = r.sub == p.sub && keyMatch(r.obj, p.obj) && (r.act == p.act || p.act == \"*\")\n"
+)
+
+var (
+	logPrefix             = "[securemgr: RBAC]"
+	rbacPolicyFilePath    = ""
+	rbacAuthModelFilePath = ""
+	authorizerIns         *AuthorizerImpl
+	initialized           = false
+	users                 Users
+	enf                   *casbin.Enforcer
+)
+
+func init() {
+	authorizerIns = new(AuthorizerImpl)
+}
+
+type User struct {
+	Name string
+	Role string
+}
+
+// Users is a list of users
+type Users []User
+
+// findByName returns the user with the given name
+func (u Users) findByName(name string) (User, error) {
+	for _, user := range u {
+		if user.Name == name {
+			return user, nil
+		}
+	}
+	return User{}, errors.New("User is not found")
+}
+
+// Init sets the environments for securemgr
+func Init(rbacRulePath string) {
+	if _, err := os.Stat(rbacRulePath); err != nil {
+		err := os.MkdirAll(rbacRulePath, os.ModePerm)
+		if err != nil {
+			log.Panicf("Failed to create rbacRulePath %s: %s\n", rbacRulePath, err)
+			return
+		}
+	}
+	rbacPolicyFilePath = rbacRulePath + "/" + rbacPolicyFileName
+	if _, err := os.Stat(rbacPolicyFilePath); err != nil {
+		err = ioutil.WriteFile(rbacPolicyFilePath, []byte(policy_template), 0666)
+		if err != nil {
+			log.Println(logPrefix, "Cannot create "+rbacPolicyFilePath+": ", err)
+		}
+	}
+
+	rbacAuthModelFilePath = rbacRulePath + "/" + rbacAuthModelFileName
+	if _, err := os.Stat(rbacAuthModelFilePath); err != nil {
+		err = ioutil.WriteFile(rbacAuthModelFilePath, []byte(auth_model_template), 0666)
+		if err != nil {
+			log.Println(logPrefix, "Cannot create "+rbacAuthModelFilePath+": ", err)
+		}
+	}
+
+	users = append(users, User{Name: "Admin", Role: "admin"})
+	users = append(users, User{Name: "Member", Role: "member"})
+
+	enf = casbin.NewEnforcer(rbacAuthModelFilePath, rbacPolicyFilePath)
+
+	initialized = true
+}
+
+func Authorizer(name string, r *http.Request) error {
+	user, err := users.findByName(name)
+	if err != nil {
+		log.Println(logPrefix, err)
+		return err
+	}
+
+	role := user.Role
+	if role == "" {
+		role = "unknow"
+	}
+
+	// log.Print("user.Name = ", user.Name)
+	// log.Print("user.Role = ", user.Role)
+	// log.Print("r.URL.Path = ", r.URL.Path)
+	// log.Print("r.Method = ", r.Method)
+
+	// casbin enforce
+	res, err := enf.EnforceSafe(role, r.URL.Path, r.Method)
+	if err != nil {
+		log.Println(logPrefix, "Error: ", err)
+		return err
+	}
+	if res {
+		return nil
+	} else {
+		log.Println(logPrefix, "Unauthorized request")
+		return errors.New("Unauthorized request")
+	}
+}

--- a/src/controller/securemgr/authorizer/authorizer_test.go
+++ b/src/controller/securemgr/authorizer/authorizer_test.go
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright 2020 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+package authorizer
+
+import (
+	"net/http"
+	"os"
+	"testing"
+)
+
+const (
+	fakerbacPath              = "fakerbac"
+	fakerbacPolicyFilePath    = fakerbacPath + "/" + rbacPolicyFileName
+	fakerbacAuthModelFilePath = fakerbacPath + "/" + rbacAuthModelFileName
+)
+
+func TestInit(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		defer os.RemoveAll(fakerbacPath)
+
+		Init("./")
+		if _, err := os.Stat(rbacPolicyFileName); err != nil {
+			t.Error("unexpected success")
+		}
+		if _, err := os.Stat(rbacAuthModelFileName); err != nil {
+			t.Error("unexpected success")
+		}
+
+		if err := os.Remove(rbacPolicyFileName); err != nil {
+			t.Error(err.Error())
+		}
+		if err := os.Remove(rbacAuthModelFileName); err != nil {
+			t.Error(err.Error())
+		}
+
+		Init(fakerbacPath)
+		if _, err := os.Stat(fakerbacPath); err != nil {
+			t.Error(err.Error())
+		}
+
+		if _, err := os.Stat(fakerbacPolicyFilePath); os.IsNotExist(err) {
+			t.Error(err.Error())
+		}
+		if _, err := os.Stat(fakerbacAuthModelFilePath); os.IsNotExist(err) {
+			t.Error(err.Error())
+		}
+	})
+}
+
+func TestFindByName(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		if _, err := users.findByName("Admin"); err != nil {
+			t.Error("unexpected success")
+		}
+	})
+	t.Run("Error", func(t *testing.T) {
+		if _, err := users.findByName("admin"); err == nil {
+			t.Error("unexpected success")
+		}
+	})
+
+}
+
+func TestAuthorizer(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "/api/v1/orchestration/securemgr", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := Authorizer("Admin", req); err != nil {
+			t.Error("unexpected fail")
+		}
+	})
+	t.Run("Error", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "/api/v1/orchestration/securemgr", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := Authorizer("admin", req); err == nil {
+			t.Error("unexpected success")
+		}
+
+		if err := Authorizer("Member", req); err == nil {
+			t.Error("unexpected success")
+		}
+
+		users = append(users, User{Name: "Member1", Role: ""})
+		if err := Authorizer("Member1", req); err == nil {
+			t.Error("unexpected success")
+		}
+	})
+}

--- a/src/interfaces/capi/main.go
+++ b/src/interfaces/capi/main.go
@@ -104,6 +104,7 @@ import (
 	"controller/discoverymgr"
 	scoringmgr "controller/scoringmgr"
 	"controller/securemgr/authenticator"
+	"controller/securemgr/authorizer"
 	"controller/securemgr/verifier"
 	"controller/servicemgr"
 	"controller/servicemgr/executor/nativeexecutor"
@@ -136,6 +137,7 @@ const (
 	certificateFilePath    = edgeDir + "/data/cert"
 	containerWhiteListPath = edgeDir + "/data/cwl"
 	passPhraseJWTPath      = edgeDir + "/data/jwt"
+	rbacRulePath           = edgeDir + "/data/rbac"
 
 	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
 	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"
@@ -172,6 +174,7 @@ func OrchestrationInit() C.int {
 	if isSecured {
 		verifier.Init(containerWhiteListPath)
 		authenticator.Init(passPhraseJWTPath)
+		authorizer.Init(rbacRulePath)
 	}
 
 	restIns := restclient.GetRestClient()

--- a/src/interfaces/javaapi/javaapi.go
+++ b/src/interfaces/javaapi/javaapi.go
@@ -30,6 +30,7 @@ import (
 	"controller/discoverymgr"
 	scoringmgr "controller/scoringmgr"
 	"controller/securemgr/authenticator"
+	"controller/securemgr/authorizer"
 	"controller/securemgr/verifier"
 	"controller/servicemgr"
 	"controller/servicemgr/executor/androidexecutor"
@@ -56,6 +57,7 @@ const (
 	certificateFile        = "/data/cert"
 	containerWhiteListPath = "/data/cwl"
 	passPhraseJWTPath      = "/data/jwt"
+	rbacRulePath           = "/data/rbac"
 
 	cipherKeyFile = "/user/orchestration_userID.txt"
 	deviceIDFile  = "/device/orchestration_deviceID.txt"
@@ -166,6 +168,8 @@ func OrchestrationInit(executeCallback ExecuteCallback, edgeDir string, isSecure
 	if isSecured {
 		verifier.Init(containerWhiteListPath)
 		authenticator.Init(passPhraseJWTPath)
+		authorizer.Init(rbacRulePath)
+
 	}
 
 	restIns := restclient.GetRestClient()

--- a/tools/jwt_gen.sh
+++ b/tools/jwt_gen.sh
@@ -8,7 +8,8 @@ device_id=`cat /var/edge-orchestration/device/orchestration_deviceID.txt`
 payload="{
 	\"exp\": $(($(date +%s)+60)),
 	\"iat\": $(date +%s),
-	\"deviceid\": \"${device_id}\"
+	\"deviceid\": \"${device_id}\",
+	\"aud\": \"$2\"
 }"
 
 header="{
@@ -52,10 +53,10 @@ case $1 in
 		;;
     *)
         echo "Usage:"
-        echo "----------------------------------------------------------"
-        echo "  $ . jwt_gen.sh HS256    : Genereate JWT based on HS256"
-        echo "  $ . jwt_gen.sh RS256    : Genereate JWT based on RS256"
-        echo "----------------------------------------------------------"
+        echo "-------------------------------------------------------------------------------------------------"
+        echo "  $ . jwt_gen.sh [Algo] [User]  : Genereate JWT based on Algo:{HS256, RS256} User:{Admin, Member}"
+        echo "  $ . jwt_gen.sh RS256 Admin    : Genereate JWT based on RS256 and User - Admin                  "
+        echo "-------------------------------------------------------------------------------------------------"
 		return 1
         ;;
 esac


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description
Implemented init version of **Role based Access Control (RBAC)** based on open-source access control library  `casbin`.

Fixes #147 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

0. Build Edge-Orchestration in secure mode
```
$ ./build.sh secure
```
1. For Admin:
```
$ . tools/jwt_gen.sh HS256 Admin
$ curl -X POST "127.0.0.1:56001/api/v1/orchestration/securemgr" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"SecureMgr\": \"Verifier\", \"CmdType\": \"printAllHashCWL\", \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
$ curl -X POST "127.0.0.1:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
```
both requests are allowed!

2. For Member:
```
$ . tools/jwt_gen.sh HS256 Member
$ curl -X POST "127.0.0.1:56001/api/v1/orchestration/securemgr" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"SecureMgr\": \"Verifier\", \"CmdType\": \"printAllHashCWL\", \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
$ curl -X POST "127.0.0.1:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
```
the first request is forbidden, second request is allowed!

Example
1. Describe the reproduction procedures freely.
2. Or list up the test description like :
  - [x] Unittest
  - [x] Execution of Container
  - [x] Execution on top of Native
  - [ ] Execution on top of Android

**Test Configuration**:
* Firmware version: Ubuntu 16.04
* Hardware: x86-64, ARM
* Toolchain: Docker and Go recommended versions 
* Edge Orchestration Release: Baobab

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
