### PR TITLE
Fix copyright date

### DIFF
--- a/GoMain/src/main/main.go
+++ b/GoMain/src/main/main.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/networkhelper/networkhelper.go
+++ b/src/common/networkhelper/networkhelper.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/common/networkhelper/networkhelper_test.go
+++ b/src/common/networkhelper/networkhelper_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/controller/discoverymgr/discovery.go
+++ b/src/controller/discoverymgr/discovery.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/controller/discoverymgr/discovery_test.go
+++ b/src/controller/discoverymgr/discovery_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/controller/discoverymgr/types.go
+++ b/src/controller/discoverymgr/types.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/controller/scoringmgr/mocks/mocks_scoringmgr.go
+++ b/src/controller/scoringmgr/mocks/mocks_scoringmgr.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/interfaces/capi/main.go
+++ b/src/interfaces/capi/main.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,22 +18,6 @@
 // Package main provides C interface for orchestration
 package main
 
-///*******************************************************************************
-// * Copyright 2020 Samsung Electronics All Rights Reserved.
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// * http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// *
-// *******************************************************************************/
 /*
 #include <stdlib.h>
 

--- a/src/interfaces/javaapi/javaapi.go
+++ b/src/interfaces/javaapi/javaapi.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/orchestrationapi/orchestration.go
+++ b/src/orchestrationapi/orchestration.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/orchestrationapi/orchestration_api.go
+++ b/src/orchestrationapi/orchestration_api.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/orchestrationapi/orchestration_test.go
+++ b/src/orchestrationapi/orchestration_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/orchestrationapi/orchestrationapi_test.go
+++ b/src/orchestrationapi/orchestrationapi_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ package orchestrationapi
 
 import (
 	"errors"
+
 	"github.com/golang/mock/gomock"
 
 	"testing"

--- a/src/restinterface/client/client.go
+++ b/src/restinterface/client/client.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/restinterface/client/mocks/mocks_client.go
+++ b/src/restinterface/client/mocks/mocks_client.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/restinterface/client/restclient/restclient.go
+++ b/src/restinterface/client/restclient/restclient.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Samsung Electronics All Rights Reserved.
+* Copyright 2019-2020 Samsung Electronics All Rights Reserved.
 *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/restinterface/client/restclient/restclient_test.go
+++ b/src/restinterface/client/restclient/restclient_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/restinterface/internalhandler/internalhandler.go
+++ b/src/restinterface/internalhandler/internalhandler.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,6 @@ func init() {
 			Pattern:     "/api/v1/discoverymgr/orchestrationinfo",
 			HandlerFunc: handler.APIV1DiscoverymgrOrchestrationInfoGet,
 		},
-
 	}
 }
 

--- a/src/restinterface/internalhandler/internalhandler_test.go
+++ b/src/restinterface/internalhandler/internalhandler_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Samsung Electronics All Rights Reserved.
+ * Copyright 2019-2020 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

The correction concerns the copyright date. Since according to the rules, after changing the file, the year of change is added and not corrected. for example the file was created in 2016, in 2019 and in 2020 was edited then the entry should be 2016, 2019-2020.
This must be strictly followed as this can lead to ownership disputes.

P.S. If you know more files where this was fixed from 2019 to 2020, please make the edits.

## Type of change

- [x] Code cleanup/refactoring

# Checklist:

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
