### PR TITLE
Fix the runtime error by checking the datastorage conf file.

### DIFF
--- a/GoMain/src/main/main.go
+++ b/GoMain/src/main/main.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"log"
 	"strings"
+	"os"
 
 	"common/logmgr"
 	"common/sigmgr"
@@ -69,10 +70,10 @@ const (
 	containerWhiteListPath = edgeDir + "/data/cwl"
 	passPhraseJWTPath      = edgeDir + "/data/jwt"
 
-	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
-	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"
-
-	mnedcServerConfig = edgeDir + "/mnedc/client.config"
+	cipherKeyFilePath      = edgeDir + "/user/orchestration_userID.txt"
+	deviceIDFilePath       = edgeDir + "/device/orchestration_deviceID.txt"
+	dataStorageFilePath    = edgeDir + "/datastorage/configuration.toml"
+	mnedcServerConfig      = edgeDir + "/mnedc/client.config"
 )
 
 var (
@@ -170,8 +171,10 @@ func orchestrationInit() error {
 
 	restEdgeRouter.Start()
 
-	sd := storagedriver.StorageDriver{}
-	startup.Bootstrap(dataStorageService, device.Version, &sd)
+	if _, err := os.Stat(dataStorageFilePath); err==nil {
+		sd := storagedriver.StorageDriver{}
+		startup.Bootstrap(dataStorageService, device.Version, &sd)
+	}
 
 	log.Println(logPrefix, "orchestration init done")
 

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ PKG_LIST=(
         "controller/mnedcmgr/connectionutil"
         "controller/mnedcmgr/server"
         "controller/mnedcmgr/tunmgr"
-		"controller/storagemgr/storagedriver"
+        "controller/storagemgr/storagedriver"
         "db/bolt/common"
         "db/bolt/configuration"
         "db/bolt/network"


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Fix the runtime error by checking the datastorage conf file.
If the configuration.toml file is not in /var/edge-orchestration/datastorage folder, 
edge-orchestration does not try to run the datastorage module.

### Problem
```
2020/10/29 10:57:50 route.go:113: ListenAndServe
Init: useRegistry:  profile:  confDir:
Loading configuration from: /edge-orchestration/res/configuration.toml

Load configuration from local file and bypassing registration in Registry...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9d1e7d]

goroutine 1 [running]:
github.com/edgexfoundry/device-sdk-go.NewService(0xb535b5, 0xb, 0xb5dda1, 0x1a, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/t25kim/work/edge-home-orchestration-go/vendor/src/github.com/edgexfoundry/device-sdk-go/service.go:287 +0x23d
github.com/edgexfoundry/device-sdk-go/pkg/startup.startService(0xb535b5, 0xb, 0xb5dda1, 0x1a, 0xc2f380, 0xc000093240, 0x0, 0x40fb58)
        /home/t25kim/work/edge-home-orchestration-go/vendor/src/github.com/edgexfoundry/device-sdk-go/pkg/startup/bootstrap.go:46 +0xd4
github.com/edgexfoundry/device-sdk-go/pkg/startup.Bootstrap(0xb535b5, 0xb, 0xb5dda1, 0x1a, 0xc2f380, 0xc000093240)
        /home/t25kim/work/edge-home-orchestration-go/vendor/src/github.com/edgexfoundry/device-sdk-go/pkg/startup/bootstrap.go:39 +0x10a
main.orchestrationInit(0xc000000180, 0xc00025ff78)
        /home/t25kim/work/edge-home-orchestration-go/GoMain/src/main/main.go:174 +0x87f
main.main()
        /home/t25kim/work/edge-home-orchestration-go/GoMain/src/main/main.go:84 +0x26
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. delete /var/edge-orchestration/datastorage/configuration.toml file
2. ./build.sh

**Test Configuration**:
* Firmware version: Ubuntu 18.04, etc.)
* Hardware: x86-64

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
