### PR TITLE
Remove the getDeviceID() in mnedc duplicated with the GetDeviceID() in discoverymgr

### DIFF
--- a/src/controller/mnedcmgr/clientcontrol.go
+++ b/src/controller/mnedcmgr/clientcontrol.go
@@ -18,7 +18,6 @@
 package mnedcmgr
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -35,9 +34,11 @@ type ClientImpl struct {
 	tls.HasCertificate
 }
 
-var clientIns *ClientImpl
-var mnedcClientIns client.MNEDCClient
-var discoveryIns discoverymgr.Discovery
+var (
+	clientIns *ClientImpl
+	mnedcClientIns client.MNEDCClient
+	discoveryIns discoverymgr.Discovery
+)
 
 func init() {
 	clientIns = new(ClientImpl)
@@ -53,7 +54,7 @@ func GetClientInstance() *ClientImpl {
 //StartMNEDCClient starts the MNEDC client
 func (c *ClientImpl) StartMNEDCClient(deviceIDPath string, configPath string) {
 
-	deviceID, err := getDeviceID(deviceIDPath)
+	deviceID, err := discoveryIns.GetDeviceID()
 	if err != nil {
 		log.Println(logPrefix, "Couldn't start MNEDC client", err.Error())
 		return
@@ -107,19 +108,4 @@ func waitInterrupt(fatalErrChan chan error) {
 	case err := <-fatalErrChan:
 		log.Println(logPrefix, "Fatal internal error: ", err)
 	}
-}
-
-func getDeviceID(path string) (string, error) {
-
-	UUIDv4, err := ioutil.ReadFile(path)
-
-	if err != nil {
-		log.Println(logPrefix, "No saved UUID : ", err.Error())
-		return "", err
-	}
-
-	log.Println(logPrefix, "Got the UUID")
-	UUIDstr := "edge-orchestration-" + string(UUIDv4)
-
-	return UUIDstr, nil
 }

--- a/src/controller/mnedcmgr/servercontrol.go
+++ b/src/controller/mnedcmgr/servercontrol.go
@@ -62,7 +62,7 @@ func GetServerInstance() *ServerImpl {
 //StartMNEDCServer starts the MNEDC server on the machine
 func (ServerImpl) StartMNEDCServer(deviceIDPath string) {
 
-	deviceID, err := getDeviceID(deviceIDPath)
+	deviceID, err := discoveryIns.GetDeviceID()
 	if err != nil {
 		log.Println(logPrefix, "Couldn't start MNEDC server", err.Error())
 		return


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Remove the getDeviceID() in mnedc duplicated with the GetDeviceID() in discoverymgr.

## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?
1. Build the code with the option mnedcclient or mnedcserver.
 $ ./build mnedcclient 
 $ ./build mnedcserver

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
