### PR TITLE
Update golang recommended version for RPi

### DIFF
--- a/doc/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/doc/platforms/raspberry_pi3/raspberry_pi3.md
@@ -57,10 +57,13 @@ $ newgrp docker
 > For [execution of docker commands with non-root privileges](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) you need to add `$USER` to docker group.  
 `$ sudo usermod -aG docker $USER`
 
-- go compiler
+- go compiler (install a version not lower than 1.12.5, recommended v1.14.x)
 
 ```sh 
-$ sudo apt install golang
+$ wget https://dl.google.com/go/go1.14.5.linux-armv6l.tar.gz
+$ sudo tar -C /usr/local -xvf go1.14.5.linux-armv6l.tar.gz
+$ export GOPATH=$HOME/go
+$ export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
 ```
 
 - glide ([package manager for Go](https://glide.readthedocs.io/en/latest/))  


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Fix #156 issue: 
_RPi instruction guides developers to install golang with command sudo apt install golang.
RPi install 1.11 version of golang and it fails to build the project._

It is recommended to use golang versions from 1.12.5 to 1.14.x
The golang 1.15 version is not fully tested and there may be bugs for Gorilla Mux.

Fixes #156 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
pi@raspberrypi:~/edge-home-orchestration-go $ go version
go version go1.14.5 linux/arm
pi@raspberrypi:~/edge-home-orchestration-go $ ./build.sh
```
The expected result is a successful build
```

**Test Configuration**:
* Firmware version: (OS Raspbian)
* Hardware: ARM
* Toolchain: Docker recommended and Go 1.12 - 1.14 versions
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
