### PR TITLE
Get the modes of secure and mnedc from the os enviroment

### DIFF
--- a/GoMain/src/main/main.go
+++ b/GoMain/src/main/main.go
@@ -98,8 +98,16 @@ func orchestrationInit() error {
 	log.Println(">>> buildTags : ", buildTags)
 	wrapper.SetBoltDBPath(dbPath)
 
+	secure := os.Getenv("SECURE")
+	mnedc := os.Getenv("MNEDC")
+
 	isSecured := false
-	if strings.Contains(buildTags, "secure") {
+	if len(secure)>0 {
+		if strings.Compare(strings.ToLower(secure), "true")==0 {
+			log.Println("Orchestration init with secure option")
+			isSecured = true
+		}
+	} else if strings.Contains(buildTags, "secure") {
 		log.Println("Orchestration init with secure option")
 		isSecured = true
 	}
@@ -178,19 +186,36 @@ func orchestrationInit() error {
 
 	log.Println(logPrefix, "orchestration init done")
 
-	if strings.Contains(buildTags, "mnedcserver") {
-		if isSecured {
-			mnedcmgr.GetServerInstance().SetCipher(dummy.GetCipher(cipherKeyFilePath))
-			mnedcmgr.GetServerInstance().SetCertificateFilePath(certificateFilePath)
-		} else {
-			mnedcmgr.GetServerInstance().SetCipher(sha256.GetCipher(cipherKeyFilePath))
+	if len(mnedc) > 0 {
+                if strings.Compare(strings.ToLower(mnedc), "server") == 0 {
+                        if isSecured {
+                                mnedcmgr.GetServerInstance().SetCipher(dummy.GetCipher(cipherKeyFilePath))
+                                mnedcmgr.GetServerInstance().SetCertificateFilePath(certificateFilePath)
+                        } else {
+                                mnedcmgr.GetServerInstance().SetCipher(sha256.GetCipher(cipherKeyFilePath))
+                        }
+                        go mnedcmgr.GetServerInstance().StartMNEDCServer(deviceIDFilePath)
+                } else if strings.Compare(strings.ToLower(mnedc), "client") == 0 {
+                        if isSecured {
+                                mnedcmgr.GetClientInstance().SetCertificateFilePath(certificateFilePath)
+                        }
+                        go mnedcmgr.GetClientInstance().StartMNEDCClient(deviceIDFilePath, mnedcServerConfig)
+                }
+	} else {
+		if strings.Contains(buildTags, "mnedcserver") {
+			if isSecured {
+				mnedcmgr.GetServerInstance().SetCipher(dummy.GetCipher(cipherKeyFilePath))
+				mnedcmgr.GetServerInstance().SetCertificateFilePath(certificateFilePath)
+			} else {
+				mnedcmgr.GetServerInstance().SetCipher(sha256.GetCipher(cipherKeyFilePath))
+			}
+			go mnedcmgr.GetServerInstance().StartMNEDCServer(deviceIDFilePath)
+		} else if strings.Contains(buildTags, "mnedcclient") {
+			if isSecured {
+				mnedcmgr.GetClientInstance().SetCertificateFilePath(certificateFilePath)
+			}
+			go mnedcmgr.GetClientInstance().StartMNEDCClient(deviceIDFilePath, mnedcServerConfig)
 		}
-		go mnedcmgr.GetServerInstance().StartMNEDCServer(deviceIDFilePath)
-	} else if strings.Contains(buildTags, "mnedcclient") {
-		if isSecured {
-			mnedcmgr.GetClientInstance().SetCertificateFilePath(certificateFilePath)
-		}
-		go mnedcmgr.GetClientInstance().StartMNEDCClient(deviceIDFilePath, mnedcServerConfig)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description
There isan issue with the edge-orchestration setting the secure and mnedc options while building the project.
The edge-orchestration can modify the secure and mnedc options while initiating the program with this PR.

Fixes #168 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
Run the edge-orchestration with the environment values like below.
- SECURE : true or false
- MNEDC : server or client

```
 docker run -it --rm --privileged --network="host" --name edge-orchestration -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro -e SECURE=true -e MNEDC=server edge-orchestration:coconut
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
