### PR TITLE
x86 platform build guide doc revision - the wrong spacing

### DIFF
--- a/doc/platforms/x86_64_linux/x86_64_linux.md
+++ b/doc/platforms/x86_64_linux/x86_64_linux.md
@@ -19,7 +19,7 @@ If it succeeds, you can see the Docker image as follows:
 ```shell
 $ docker images
 REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
-edge-orchestration         coconut             502e3c07b01f        3 minutes ago       132MB
+edge-orchestration         coconut             502e3c07b01f        3 minutes ago       185MB
 ```
 
 #### 4. Run with Docker image
@@ -80,7 +80,7 @@ and the built image as follows:
 ```shell
 $ docker images
 REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
-edge-orchestration         coconut             502e3c07b01f        3 seconds ago       132MB
+edge-orchestration         coconut             502e3c07b01f        3 seconds ago       185MB
 ```
 
 - All Build Options


### PR DESCRIPTION
# Description

The updated document for building the latest `coconut` release on x86_64_linux was written with a wrong spacing. This PR fixes that wrong space as the right one.

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

# How Has This Been Tested?
Since this is the document update (just for the better readability for developers), we have validated the PR with the expected representation in the Chrome web browser and the concerning `x86_64_linux.md` file.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
