### PR TITLE
Updated discoverymgr mocks and unit test cases for GetDeviceID() method

### DIFF
--- a/src/controller/discoverymgr/discovery_test.go
+++ b/src/controller/discoverymgr/discovery_test.go
@@ -248,6 +248,7 @@ func TestDeviceDetectionRoutine(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 
+		discoveryInstance := GetInstance()
 		//declare mock argument
 		devicesubchan := make(chan *wrapper.Entity, 20)
 
@@ -296,7 +297,7 @@ func TestDeviceDetectionRoutine(t *testing.T) {
 
 			presence := false
 
-			deviceID, err := getDeviceID()
+			deviceID, err := discoveryInstance.GetDeviceID()
 			log.Println(deviceID)
 			if err != nil {
 				t.Fatal(err.Error())
@@ -374,7 +375,7 @@ func TestAddNewServiceName(t *testing.T) {
 			}
 			presence := false
 
-			deviceID, err := getDeviceID()
+			deviceID, err := discoveryInstance.GetDeviceID()
 			if err != nil {
 				t.Fatal(err.Error())
 			}
@@ -420,7 +421,7 @@ func TestRemoveServiceName(t *testing.T) {
 
 			isPresence := false
 
-			deviceID, err := getDeviceID()
+			deviceID, err := discoveryInstance.GetDeviceID()
 			if err != nil {
 				t.Fatal(err.Error())
 			}
@@ -459,7 +460,7 @@ func TestResetServiceName(t *testing.T) {
 			mockWrapper.EXPECT().SetText(gomock.Any()).Return()
 			discoveryInstance.ResetServiceName()
 
-			deviceID, err := getDeviceID()
+			deviceID, err := discoveryInstance.GetDeviceID()
 			if err != nil {
 				t.Fatal(err.Error())
 			}
@@ -554,6 +555,9 @@ func TestDetectNetworkChgRoutine(t *testing.T) {
 	defer ctrl.Finish()
 
 	createMockIns(ctrl)
+
+	discoveryInstance := GetInstance()
+
 	addDevice(false)
 
 	shutdownChan = make(chan struct{})
@@ -569,7 +573,7 @@ func TestDetectNetworkChgRoutine(t *testing.T) {
 		ipsub <- []net.IP{net.ParseIP("192.0.2.1")}
 
 		time.Sleep(time.Millisecond * time.Duration(10))
-		deviceID, err := getDeviceID()
+		deviceID, err := discoveryInstance.GetDeviceID()
 		if err != nil {
 			t.Error(err.Error())
 		}

--- a/src/controller/discoverymgr/mocks/mocks_discoverymgr.go
+++ b/src/controller/discoverymgr/mocks/mocks_discoverymgr.go
@@ -102,6 +102,21 @@ func (mr *MockDiscoveryMockRecorder) DeleteDeviceWithIP(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDeviceWithIP", reflect.TypeOf((*MockDiscovery)(nil).DeleteDeviceWithIP), arg0)
 }
 
+// GetDeviceID mocks base method.
+func (m *MockDiscovery) GetDeviceID() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceID")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeviceID indicates an expected call of GetDeviceID.
+func (mr *MockDiscoveryMockRecorder) GetDeviceID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceID", reflect.TypeOf((*MockDiscovery)(nil).GetDeviceID))
+}
+
 // GetOrchestrationInfo mocks base method.
 func (m *MockDiscovery) GetOrchestrationInfo() (string, string, []string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Signed-off-by: ayush.kumar <ayush.kumar@samsung.com>

# Description

Since getDeviceID() method has been moved to Discovery interface with declaration as GetDeviceID() in #158 ,the mocks for discoverymgr along with the test cases are updated accordingly

## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?
1. Ran the test build for discovery module.
```
$ ./build.sh test controller/discoverymgr
```
2. Observe the following result:
```
PASS
coverage: 82.9% of statements
ok      controller/discoverymgr 24.946s coverage: 82.9% of statements
gocov report coverage.out

controller/discoverymgr/discovery.go     DiscoveryImpl.requestDeviceInfo                 100.00% (32/32)
controller/discoverymgr/discovery.go     convertToDBInfo                                 100.00% (12/12)
controller/discoverymgr/discovery.go     init                                            100.00% (8/8)
controller/discoverymgr/discovery.go     getIndexToDelete                                100.00% (8/8)
controller/discoverymgr/discovery.go     DiscoveryImpl.StartDiscovery                    100.00% (8/8)
controller/discoverymgr/discovery.go     mdnsTXTSizeChecker                              100.00% (7/7)
controller/discoverymgr/discovery.go     serviceNameChecker                              100.00% (7/7)
controller/discoverymgr/discovery.go     appendServiceToTXT                              100.00% (6/6)
controller/discoverymgr/discovery.go     setDeviceArgument                               100.00% (5/5)
controller/discoverymgr/discovery.go     DiscoveryImpl.GetOrchestrationInfo              100.00% (5/5)
controller/discoverymgr/discovery.go     getNetworkDB                                    100.00% (4/4)
controller/discoverymgr/discovery.go     DiscoveryImpl.MNEDCReconciledCallback           100.00% (4/4)
controller/discoverymgr/discovery.go     @120:5                                          100.00% (3/3)
controller/discoverymgr/discovery.go     deviceDetectionRoutine                          100.00% (1/1)
controller/discoverymgr/discovery.go     GetInstance                                     100.00% (1/1)
controller/discoverymgr/discovery.go     DiscoveryImpl.SetRestResource                   100.00% (1/1)
controller/discoverymgr/discovery.go     shutdownDiscoverymgr                            100.00% (1/1)
controller/discoverymgr/discovery.go     @538:5                                          92.31% (24/26)
controller/discoverymgr/discovery.go     setDeviceID                                     90.91% (10/11)
controller/discoverymgr/discovery.go     isIPPresent                                     88.89% (8/9)
controller/discoverymgr/discovery.go     detectNetworkChgRoutine                         87.50% (14/16)
controller/discoverymgr/discovery.go     SetNetwotkArgument                              87.50% (7/8)
controller/discoverymgr/discovery.go     startServer                                     83.33% (15/18)
controller/discoverymgr/discovery.go     DiscoveryImpl.AddDeviceInfo                     83.33% (5/6)
controller/discoverymgr/discovery.go     DiscoveryImpl.RemoveServiceName                 76.92% (10/13)
controller/discoverymgr/discovery.go     clearMap                                        75.00% (9/12)
controller/discoverymgr/discovery.go     setSystemDB                                     75.00% (9/12)
controller/discoverymgr/discovery.go     getServiceList                                  75.00% (6/8)
controller/discoverymgr/discovery.go     getExecType                                     75.00% (3/4)
controller/discoverymgr/discovery.go     serverPresenceChecker                           75.00% (3/4)
controller/discoverymgr/discovery.go     getPlatform                                     75.00% (3/4)
controller/discoverymgr/discovery.go     DiscoveryImpl.GetDeviceID                       75.00% (3/4)
controller/discoverymgr/discovery.go     DiscoveryImpl.NotifyMNEDCBroadcastServer        74.19% (23/31)
controller/discoverymgr/discovery.go     DiscoveryImpl.AddNewServiceName                 71.43% (10/14)
controller/discoverymgr/discovery.go     DiscoveryImpl.ResetServiceName                  70.59% (12/17)
controller/discoverymgr/discovery.go     deleteDevice                                    70.00% (7/10)
controller/discoverymgr/discovery.go     DiscoveryImpl.StopDiscovery                     66.67% (4/6)
controller/discoverymgr/discovery.go     DiscoveryImpl.DeleteDeviceWithID                66.67% (4/6)
controller/discoverymgr/discovery.go     setConfigurationDB                              66.67% (2/3)
controller/discoverymgr/discovery.go     setNetworkDB                                    66.67% (2/3)
controller/discoverymgr/discovery.go     setServiceDB                                    66.67% (2/3)
controller/discoverymgr/discovery.go     DiscoveryImpl.setNewServiceList                 63.64% (7/11)
controller/discoverymgr/discovery.go     getSystemDB                                     60.00% (3/5)
controller/discoverymgr/discovery.go     @492:5                                          50.00% (3/6)
controller/discoverymgr/discovery.go     activeDiscovery                                 0.00% (0/2)
controller/discoverymgr/discovery.go     DiscoveryImpl.MNEDCClosedCallback               0.00% (0/1)
controller/discoverymgr/discovery.go     resetServer                                     0.00% (0/1)
controller/discoverymgr/discovery.go     DiscoveryImpl.DeleteDeviceWithIP                0.00% (0/0)
controller/discoverymgr                  ----------------------------------------        82.95% (321/387)

Total Coverage: 82.95% (321/387)

```
3. Also checked the complete test build
```
./build.sh test
``` 
4. Full test build also passed.

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
