### PR TITLE
Fix the build error occurred for arm architecture on PC

### DIFF
--- a/GoMain/Dockerfile
+++ b/GoMain/Dockerfile
@@ -15,14 +15,16 @@ ENV ZEROCONF_PORT=42425
 ENV APP_MAIN_DIR=GoMain
 ENV APP_BIN_DIR=$APP_MAIN_DIR/bin
 ENV APP_NAME=edge-orchestration
-
-# install required tools 
-RUN apt update
-RUN apt install -y net-tools iproute2
+ENV APP_QEMU_DIR=$APP_BIN_DIR/qemu
 
 # copy files
 COPY $APP_BIN_DIR/$APP_NAME $APP_MAIN_DIR/run.sh $TARGET_DIR/
+COPY $APP_QEMU_DIR/ /usr/bin/
 RUN mkdir -p $TARGET_DIR/res/
+
+# install required tools
+RUN apt update
+RUN apt install -y net-tools iproute2
 
 # expose ports
 EXPOSE $HTTP_PORT $MDNS_PORT $ZEROCONF_PORT $MNEDC_PORT $MNEDC_BROADCAST_PORT

--- a/build.sh
+++ b/build.sh
@@ -392,6 +392,7 @@ function build_docker_container() {
 
     docker rm -f $DOCKER_IMAGE
     docker rmi -f $DOCKER_IMAGE:$CONTAINER_VERSION
+    mkdir -p $BASE_DIR/GoMain/bin/qemu
     case $1 in
         x86)
             CONTAINER_ARCH="i386"
@@ -401,9 +402,11 @@ function build_docker_container() {
             ;;
         arm)
             CONTAINER_ARCH="arm32v7"
+            cp /usr/bin/qemu-arm-static $BASE_DIR/GoMain/bin/qemu
             ;;
         arm64)
             CONTAINER_ARCH="arm64v8"
+            cp /usr/bin/qemu-aarch64-static $BASE_DIR/GoMain/bin/qemu
             ;;
         *)
             case "$(uname -m)" in

--- a/doc/platforms/hikey960/hikey960.md
+++ b/doc/platforms/hikey960/hikey960.md
@@ -41,6 +41,12 @@ This section provides how to download and run pre-built Docker image without bui
 ---
 
 ## How to build Edge-Orchestration
+
+Prerequisites: install the qemu packages
+```shell
+$ sudo apt-get install qemu binfmt-support qemu-user-static
+```
+
 Run the `./build.sh` script on your PC and specify the build parameters - `container`,  architecture - `arm64`  (in the case of building in protected mode, add `secure`), see examples below:
 ```shell
 $ ./build.sh container arm64

--- a/doc/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/doc/platforms/raspberry_pi3/raspberry_pi3.md
@@ -28,13 +28,19 @@ There are two options for building a edge-orchestration container:
 1. On your PC and downloading the edge-orchestration container image from the `edge-orchestration.tar` archive (recommended).
 2. Build directly on the Raspberry Pi 3 board.
 ### 1. Using your PC
-Run the `./build.sh` script and specify the build parameters - `container`,  architecture - `arm64`  (in the case of building in protected mode, add `secure`), see examples below:
+
+Prerequisites: install the qemu packages
 ```shell
-$ ./build.sh container arm64
+$ sudo apt-get install qemu binfmt-support qemu-user-static
+```
+
+Run the `./build.sh` script and specify the build parameters - `container`,  architecture - `arm`  (in the case of building in protected mode, add `secure`), see examples below:
+```shell
+$ ./build.sh container arm
 ```
 or for protected mode:
 ```shell
-$ ./build.sh container secure arm64
+$ ./build.sh container secure arm
 ```
 the build result will be `edge-orchestration.tar` archive that can be found `GoMain/bin/edge-orchestration.tar`
 


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Due to the installation of packages in a Dockerfile, the build for arm architectures was not successful. To fix the error, added the use of the Qemu. 
P.S. It should be noted that installing packages during container creation is not the best approach. It is better to use an image with the packages installed.

Fixes #155 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# How Has This Been Tested?
```
$ ./build.sh container arm
```
or
```
$ ./build.sh container arm64
```
Expected: successful build

**Test Configuration**:
* Firmware version: Ubuntu 16.04, Ubuntu 20.04
* Hardware: x86-64, ARM, ARM64
* Toolchain: Docker recommended version and Go 1.15.5 version
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
