### PR TITLE
Drop the logic for creating a log file

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -106,7 +106,6 @@ import:
     version: v1.7.2
   - package: github.com/grandcat/zeroconf
     version: 85eadb44205c14827ae7cbb129bc7eed4488dd25
-  - package: github.com/leemcloughlin/logfile
   - package: github.com/miekg/dns
     version: v1.1.11
   - package: github.com/satori/go.uuid

--- a/src/common/logmgr/logmgr.go
+++ b/src/common/logmgr/logmgr.go
@@ -21,8 +21,6 @@ package logmgr
 import (
 	"log"
 	"os"
-
-	"github.com/leemcloughlin/logfile"
 )
 
 var logFileName = "logmgr.log"
@@ -36,17 +34,5 @@ func Init(logFilePath string) {
 		}
 	}
 
-	logFile, err := logfile.New(
-		&logfile.LogFile{
-			FileName:    logFilePath + "/" + logFileName,
-			FileMode:    0644,
-			MaxSize:     500 * 1024, // 500K
-			OldVersions: 3,
-			Flags:       logfile.OverWriteOnStart | logfile.RotateOnStart})
-	if err != nil {
-		log.Panicf("Failed to create logFile %s: %s\n", logFileName, err)
-	}
-
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
-	log.SetOutput(logFile)
 }


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Drop the logic for creating a log file
Fixes #182 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. build the edge-orchestration
2. check that the logmgr.log is in /var/edge-orchestration/log/

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
