### PR TITLE
[Builder] Moved DataStorage init and configuration to builder

### DIFF
--- a/GoMain/src/main/main.go
+++ b/GoMain/src/main/main.go
@@ -141,6 +141,11 @@ func orchestrationInit() error {
 	builder.SetExecutor(executor.GetInstance())
 	builder.SetClient(restIns)
 
+	if _, err := os.Stat(dataStorageFilePath); err == nil {
+		sd := storagedriver.StorageDriver{}
+		builder.SetDataStorage(sd)
+	}
+
 	orcheEngine := builder.Build()
 	if orcheEngine == nil {
 		log.Fatalf("[%s] Orchestaration initalize fail", logPrefix)
@@ -182,11 +187,8 @@ func orchestrationInit() error {
 	restEdgeRouter.Add(ehandle)
 
 	restEdgeRouter.Start()
-
-	if _, err := os.Stat(dataStorageFilePath); err == nil {
-		sd := storagedriver.StorageDriver{}
-		go startup.Bootstrap(dataStorageService, device.Version, &sd)
-	}
+	storageIns := internalapi.GetStorageInstance()
+	go startup.Bootstrap(dataStorageService, device.Version, &storageIns)
 
 	log.Println(logPrefix, "orchestration init done")
 

--- a/src/orchestrationapi/orchestration_api.go
+++ b/src/orchestrationapi/orchestration_api.go
@@ -18,6 +18,7 @@
 package orchestrationapi
 
 import (
+	"controller/storagemgr/storagedriver"
 	"errors"
 	"log"
 	"sort"
@@ -44,12 +45,13 @@ import (
 type orcheImpl struct {
 	Ready bool
 
-	verifierIns     verifier.VerifierConf
-	serviceIns      servicemgr.ServiceMgr
-	scoringIns      scoringmgr.Scoring
-	discoverIns     discoverymgr.Discovery
-	watcher         configuremgr.Watcher
-	notificationIns notification.Notification
+	verifierIns      verifier.VerifierConf
+	serviceIns       servicemgr.ServiceMgr
+	scoringIns       scoringmgr.Scoring
+	discoverIns      discoverymgr.Discovery
+	watcher          configuremgr.Watcher
+	notificationIns  notification.Notification
+	storageDriverIns storagedriver.StorageDriver
 
 	networkhelper networkhelper.Network
 


### PR DESCRIPTION
Added code to initialize Datastorage in builder

Signed-off-by: Sunchit Sharma <sun.sharma@samsung.com>

# Description
Changes made to move Data Storage Conf. to Builder

Fixes  #137 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested ?

-  Change the configutartion.toml with the ips of a Machine B, place them in /var/edge-orchestration/datastorage/ folder
-  Run Edge Orchestration on Machine A. Using ./build.sh
-  On Machine B run edgex using ./edgex-launch
-  The Mongo DB can be verified for device profile and readings.
-  Metadata values attached for reference
![meta](https://user-images.githubusercontent.com/63772873/100438389-1216ab00-30c8-11eb-9545-f5e350c3ba82.PNG)
 

**Test Configuration**:
* Firmware version: Ubuntu 16.04
* Edge Orchestration Release:  Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
