### PR TITLE
Fix 10 alerts from LGTM (#171)

### DIFF
--- a/src/controller/discoverymgr/mnedc/client/client.go
+++ b/src/controller/discoverymgr/mnedc/client/client.go
@@ -348,11 +348,18 @@ func (c *Client) HandleError(err error) {
 
 		c.intf = intf
 		err = c.ParseVirtualIP(string(readBuf[0:n])) //unique TUN ip sent by server
-		if err == nil {
-			err = tunIns.SetTUNIP(c.intf.Name(), c.virtualIP, c.netMask, true)
-			err = tunIns.SetTUNStatus(c.intf.Name(), true, true)
+		if err != nil {
+			log.Println(logPrefix, "Parse Virtual IP error:", err.Error())
+			return
 		}
 
+		err = tunIns.SetTUNIP(c.intf.Name(), c.virtualIP, c.netMask, true)
+		if err != nil {
+			log.Println(logPrefix, "TUN error:", err.Error())
+			return
+		}
+
+		err = tunIns.SetTUNStatus(c.intf.Name(), true, true)
 		if err != nil {
 			log.Println(logPrefix, "TUN error:", err.Error())
 			return

--- a/src/controller/storagemgr/storagedriver/storagehandler.go
+++ b/src/controller/storagemgr/storagedriver/storagehandler.go
@@ -196,14 +196,14 @@ func deviceHandler(writer http.ResponseWriter, request *http.Request) {
 
 func (handler StorageHandler) newCommandValue(resourceName string, reading interface{}, valueType models.ValueType) (*models.CommandValue, error) {
 	var result = &models.CommandValue{}
-	var err error
+	var errn error
 	var timestamp = time.Now().UnixNano()
 	castError := "fail to parse %v reading, %v"
 
 	if !checkValueInRange(valueType, reading) {
-		err = fmt.Errorf("parse reading fail. Reading %v is out of the value type(%v)'s range", reading, valueType)
-		handler.logger.Error(err.Error())
-		return result, err
+		errn = fmt.Errorf("parse reading fail. Reading %v is out of the value type(%v)'s range", reading, valueType)
+		handler.logger.Error(errn.Error())
+		return result, errn
 	}
 
 	switch valueType {
@@ -212,82 +212,82 @@ func (handler StorageHandler) newCommandValue(resourceName string, reading inter
 		if !ok {
 			return nil, fmt.Errorf(castError, resourceName, "not []byte")
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.Bool:
 		val, err := cast.ToBoolE(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.String:
 		val, err := cast.ToStringE(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.Uint8:
 		val, err := cast.ToUint8E(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.Uint16:
 		val, err := cast.ToUint16E(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.Uint32:
 		val, err := cast.ToUint32E(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.Uint64:
 		val, err := cast.ToUint64E(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.Int8:
 		val, err := cast.ToInt8E(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.Int16:
 		val, err := cast.ToInt16E(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.Int32:
 		val, err := cast.ToInt32E(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 
 	case models.Int64:
 		val, err := cast.ToInt64E(reading)
 		if err != nil {
 			return nil, fmt.Errorf(castError, resourceName, err)
 		}
-		result, err = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
 	default:
-		err = fmt.Errorf("return result fail, none supported value type: %v", valueType)
+		errn = fmt.Errorf("return result fail, none supported value type: %v", valueType)
 	}
 
-	return result, err
+	return result, errn
 }
 
 func checkValueInRange(valueType models.ValueType, reading interface{}) bool {

--- a/src/interfaces/javaapi/javaapi.go
+++ b/src/interfaces/javaapi/javaapi.go
@@ -309,7 +309,7 @@ func EncryptToByteAndPost(data string, target string) int {
 	cipher := sha256.GetCipher(cipherKeyFilePath)
 	jsonStr, err := cipher.EncryptJSONToByte(jsonMap)
 	if err != nil {
-		log.Println("Error in encrypting jsonMap", err.Error())
+		log.Println(logPrefix, "Error in encrypting jsonMap:", err.Error())
 		return 1
 	}
 
@@ -317,6 +317,11 @@ func EncryptToByteAndPost(data string, target string) int {
 	url := fmt.Sprintf("http://%s%s", target+":56002", restapi)
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		log.Println(logPrefix, "Failed to create a new request:", err.Error())
+		return 1
+	}
+
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Mitigation of alerts from the LGTM. The local variable `err` in the `switch`operator does not pass the error value to the result of the function, therefore, when an error occurs, the function does not return an error.

Fixes #171

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
Example
  - [x] Unittest
 ```

**Test Configuration**:
* Firmware version: Ubuntu 16.04
* Hardware: x86-64
* Toolchain: Docker and Go recommended versions
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
