### PR TITLE
Remove Glide from workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,11 +28,5 @@ jobs:
       with:
         go-version: '1.15.2'
 
-    - name: Install glide
-      run: |
-        sudo add-apt-repository -y ppa:masterminds/glide
-        sudo apt-get update
-        sudo apt-get install -y glide
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/edge-home-orchestration-go.yml
+++ b/.github/workflows/edge-home-orchestration-go.yml
@@ -8,11 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install glide
-        run: |
-          sudo add-apt-repository -y ppa:masterminds/glide
-          sudo apt-get update
-          sudo apt-get install -y glide
-
       - name: Build the project
         run: ./build.sh


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Because of Go Modules, we don't need Glide any more.

## Type of change

Please delete options that are not relevant.

- [x] Code cleanup/refactoring

# How Has This Been Tested?
Look at the `Github Actions` tab.

## Result
![image](https://user-images.githubusercontent.com/5847128/104671385-0c7d2f00-5721-11eb-8009-eb200a3d9be3.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
