### PR TITLE
Bug Fix in Client Control

### DIFF
--- a/src/controller/discoverymgr/mnedc/clientcontrol.go
+++ b/src/controller/discoverymgr/mnedc/clientcontrol.go
@@ -54,7 +54,7 @@ func GetClientInstance() *ClientImpl {
 func (c *ClientImpl) StartMNEDCClient(deviceIDPath string, configPath string) {
 
 	//deviceID, err := discoveryIns.GetDeviceID()
-	deviceID, err := getDeviceID(configPath)
+	deviceID, err := getDeviceID(deviceIDPath)
 	if err != nil {
 		log.Println(logPrefix, "Couldn't start MNEDC client", err.Error())
 		return


### PR DESCRIPTION
Signed-off-by: Sunchit Sharma <sun.sharma@samsung.com>

# Description

In the clientcontrol.go file, during the start of the client, Config file path is wrongly passed instead of the DeviceID file path. This is reflecting in the logs when UUID is printed in the logs. Fixed that.

Fixes #219 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Made the change in clientcontrol.go file
2. Set Up one system in Main NAT as MNEDC server
3. Set up 2 system in Sub NAT as MNEDC Client
4. Checked the logs for correct UUID
5. Requested Service from Sub NAT system to Main NAT system
6. Worked Properly as expected. 


**Test environment configuration (please complete the following information):**
* Firmware version: Ubuntu 16.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
