### PR TITLE
TC for containerexecutor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,5 +51,5 @@ require (
 	google.golang.org/grpc v1.34.0 // indirect
 	gopkg.in/ini.v1 v1.62.0
 	gotest.tools v2.2.0+incompatible // indirect
-	gotest.tools/v3 v3.0.3 // indirect
+	gotest.tools/v3 v3.0.3
 )


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25kim@samsung.com>

# Description

TC of `containerexecutor` has been modified for docker engine v19.03.14  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
$ go test -v -cover ./src/controller/servicemgr/executor/containerexecutor/

## Result
```
t25kim@t25kim:~/edge-home-orchestration-go$ go test -v -cover ./src/controller/servicemgr/executor/containerexecutor/
=== RUN   TestValidateAttach
--- PASS: TestValidateAttach (0.00s)
=== RUN   TestParseRunLinks
--- PASS: TestParseRunLinks (0.00s)
=== RUN   TestParseRunAttach
--- PASS: TestParseRunAttach (0.00s)
=== RUN   TestParseRunWithInvalidArgs
--- PASS: TestParseRunWithInvalidArgs (0.00s)
=== RUN   TestParseWithVolumes
--- PASS: TestParseWithVolumes (0.00s)
=== RUN   TestParseWithMacAddress
--- PASS: TestParseWithMacAddress (0.00s)
=== RUN   TestRunFlagsParseWithMemory
--- PASS: TestRunFlagsParseWithMemory (0.00s)
=== RUN   TestParseWithMemorySwap
--- PASS: TestParseWithMemorySwap (0.00s)
=== RUN   TestParseHostname
--- PASS: TestParseHostname (0.00s)
=== RUN   TestParseHostnameDomainname
--- PASS: TestParseHostnameDomainname (0.00s)
=== RUN   TestParseWithExpose
--- PASS: TestParseWithExpose (0.00s)
=== RUN   TestParseDevice
--- PASS: TestParseDevice (0.00s)
=== RUN   TestParseNetworkConfig
=== RUN   TestParseNetworkConfig/single-network-legacy
=== RUN   TestParseNetworkConfig/single-network-advanced
=== RUN   TestParseNetworkConfig/single-network-legacy-with-options
=== RUN   TestParseNetworkConfig/multiple-network-advanced-mixed
=== RUN   TestParseNetworkConfig/single-network-advanced-with-options
=== RUN   TestParseNetworkConfig/multiple-networks
=== RUN   TestParseNetworkConfig/conflict-network
=== RUN   TestParseNetworkConfig/conflict-options
=== RUN   TestParseNetworkConfig/invalid-mixed-network-types
--- PASS: TestParseNetworkConfig (0.00s)
    --- PASS: TestParseNetworkConfig/single-network-legacy (0.00s)
    --- PASS: TestParseNetworkConfig/single-network-advanced (0.00s)
    --- PASS: TestParseNetworkConfig/single-network-legacy-with-options (0.00s)
    --- PASS: TestParseNetworkConfig/multiple-network-advanced-mixed (0.00s)
    --- PASS: TestParseNetworkConfig/single-network-advanced-with-options (0.00s)
    --- PASS: TestParseNetworkConfig/multiple-networks (0.00s)
    --- PASS: TestParseNetworkConfig/conflict-network (0.00s)
    --- PASS: TestParseNetworkConfig/conflict-options (0.00s)
    --- PASS: TestParseNetworkConfig/invalid-mixed-network-types (0.00s)
=== RUN   TestParseModes
--- PASS: TestParseModes (0.00s)
=== RUN   TestRunFlagsParseShmSize
--- PASS: TestRunFlagsParseShmSize (0.00s)
=== RUN   TestParseRestartPolicy
--- PASS: TestParseRestartPolicy (0.00s)
=== RUN   TestParseRestartPolicyAutoRemove
--- PASS: TestParseRestartPolicyAutoRemove (0.00s)
=== RUN   TestParseHealth
--- PASS: TestParseHealth (0.00s)
=== RUN   TestParseLoggingOpts
--- PASS: TestParseLoggingOpts (0.00s)
=== RUN   TestParseEntryPoint
--- PASS: TestParseEntryPoint (0.00s)
=== RUN   TestValidateDevice
--- PASS: TestValidateDevice (0.00s)
=== RUN   TestParseSystemPaths
--- PASS: TestParseSystemPaths (0.00s)
=== RUN   TestParsePortOpts
--- PASS: TestParsePortOpts (0.00s)
=== RUN   TestSetClient
--- PASS: TestSetClient (0.00s)
=== RUN   TestExecute
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:69 Execute [containerexecutor] alpine [docker run -v /var/run/:/var/run:rw -p 8080:8080 alpine] 
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:70 Execute [containerexecutor] parameter length : 7     
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:90 Execute [containerexecutor] create container : fakeimage1 
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:116 Execute [containerexecutor] container execution status : 0 
--- PASS: TestExecute (0.00s)
=== RUN   TestExecuteFailedStartInvokedError
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:69 Execute [containerexecutor] alpine [docker run -v /var/run/:/var/run:rw -p 8080:8080 alpine] 
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:70 Execute [containerexecutor] parameter length : 7     
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:90 Execute [containerexecutor] create container : fakeimage1 
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:96 Execute err : invoked error                          
INFO[2021-01-16T00:03:01+09:00]containerexecutor_test.go:156 func1 invoked error                                
--- PASS: TestExecuteFailedStartInvokedError (0.00s)
=== RUN   TestExecuteWaitInvokedError
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:69 Execute [containerexecutor] alpine [docker run -v /var/run/:/var/run:rw -p 8080:8080 alpine] 
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:70 Execute [containerexecutor] parameter length : 7     
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:90 Execute [containerexecutor] create container : fakeimage1 
INFO[2021-01-16T00:03:01+09:00]containerexecutor.go:113 Execute [containerexecutor] wait error               
--- PASS: TestExecuteWaitInvokedError (0.00s)
=== RUN   TestSuccessConvertConfigWithAttach
--- PASS: TestSuccessConvertConfigWithAttach (0.00s)
=== RUN   TestSuccessConvertConfigWithBlkIO
--- PASS: TestSuccessConvertConfigWithBlkIO (0.00s)
=== RUN   TestSuccessConvertConfigWithBlkIODev
--- PASS: TestSuccessConvertConfigWithBlkIODev (0.00s)
=== RUN   TestSuccessConvertConfigWithCapAdd
--- PASS: TestSuccessConvertConfigWithCapAdd (0.00s)
=== RUN   TestSuccessConvertConfigWithCapDrop
--- PASS: TestSuccessConvertConfigWithCapDrop (0.00s)
=== RUN   TestSuccessConvertConfigWithCgroupParent
--- PASS: TestSuccessConvertConfigWithCgroupParent (0.00s)
=== RUN   TestSuccessConvertConfigWithCIDFile
--- PASS: TestSuccessConvertConfigWithCIDFile (0.00s)
=== RUN   TestSuccessConvertConfigWithCPUOption
=== RUN   TestSuccessConvertConfigWithCPUOption/CPUPeriod
=== RUN   TestSuccessConvertConfigWithCPUOption/CPUQuota
=== RUN   TestSuccessConvertConfigWithCPUOption/CPURealtimePeriod
=== RUN   TestSuccessConvertConfigWithCPUOption/CPURealtimeRunTime
=== RUN   TestSuccessConvertConfigWithCPUOption/CPUShares
=== RUN   TestSuccessConvertConfigWithCPUOption/CPUs
=== RUN   TestSuccessConvertConfigWithCPUOption/CPUSetCPUs
=== RUN   TestSuccessConvertConfigWithCPUOption/CPUSetMems
--- PASS: TestSuccessConvertConfigWithCPUOption (0.00s)
    --- PASS: TestSuccessConvertConfigWithCPUOption/CPUPeriod (0.00s)
    --- PASS: TestSuccessConvertConfigWithCPUOption/CPUQuota (0.00s)
    --- PASS: TestSuccessConvertConfigWithCPUOption/CPURealtimePeriod (0.00s)
    --- PASS: TestSuccessConvertConfigWithCPUOption/CPURealtimeRunTime (0.00s)
    --- PASS: TestSuccessConvertConfigWithCPUOption/CPUShares (0.00s)
    --- PASS: TestSuccessConvertConfigWithCPUOption/CPUs (0.00s)
    --- PASS: TestSuccessConvertConfigWithCPUOption/CPUSetCPUs (0.00s)
    --- PASS: TestSuccessConvertConfigWithCPUOption/CPUSetMems (0.00s)
=== RUN   TestSuccessConvertConfigDeviceOption
=== RUN   TestSuccessConvertConfigDeviceOption/Device
=== RUN   TestSuccessConvertConfigDeviceOption/DeviceCGroupRule
=== RUN   TestSuccessConvertConfigDeviceOption/DeviceReadBps
=== RUN   TestSuccessConvertConfigDeviceOption/DeviceWriteBps
=== RUN   TestSuccessConvertConfigDeviceOption/DeviceReadIOps
=== RUN   TestSuccessConvertConfigDeviceOption/DeviceWriteIOps
--- PASS: TestSuccessConvertConfigDeviceOption (0.00s)
    --- PASS: TestSuccessConvertConfigDeviceOption/Device (0.00s)
    --- PASS: TestSuccessConvertConfigDeviceOption/DeviceCGroupRule (0.00s)
    --- PASS: TestSuccessConvertConfigDeviceOption/DeviceReadBps (0.00s)
    --- PASS: TestSuccessConvertConfigDeviceOption/DeviceWriteBps (0.00s)
    --- PASS: TestSuccessConvertConfigDeviceOption/DeviceReadIOps (0.00s)
    --- PASS: TestSuccessConvertConfigDeviceOption/DeviceWriteIOps (0.00s)
=== RUN   TestSuccessConvertConfigDNSOption
=== RUN   TestSuccessConvertConfigDNSOption/DNS
=== RUN   TestSuccessConvertConfigDNSOption/DNSOption
=== RUN   TestSuccessConvertConfigDNSOption/DNSSearch
--- PASS: TestSuccessConvertConfigDNSOption (0.00s)
    --- PASS: TestSuccessConvertConfigDNSOption/DNS (0.00s)
    --- PASS: TestSuccessConvertConfigDNSOption/DNSOption (0.00s)
    --- PASS: TestSuccessConvertConfigDNSOption/DNSSearch (0.00s)
=== RUN   TestSuccessConvertConfigWithEntryPoint
INFO[2021-01-16T00:03:01+09:00]containerexecutor_test.go:425 TestSuccessConvertConfigWithEntryPoint [/bin/bash]                                  
--- PASS: TestSuccessConvertConfigWithEntryPoint (0.00s)
=== RUN   TestSuccessConvertConfigEnvOption
=== RUN   TestSuccessConvertConfigEnvOption/Env
=== RUN   TestSuccessConvertConfigEnvOption/EnvFile
INFO[2021-01-16T00:03:01+09:00]containerexecutor_test.go:451 func2 [PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"] 
--- PASS: TestSuccessConvertConfigEnvOption (0.00s)
    --- PASS: TestSuccessConvertConfigEnvOption/Env (0.00s)
    --- PASS: TestSuccessConvertConfigEnvOption/EnvFile (0.00s)
=== RUN   TestSuccessConvertConfigWithExpose
--- PASS: TestSuccessConvertConfigWithExpose (0.00s)
=== RUN   TestSuccessConvertConfigWithGroupAdd
--- PASS: TestSuccessConvertConfigWithGroupAdd (0.00s)
=== RUN   TestSuccessConvertConfigHealthOption
=== RUN   TestSuccessConvertConfigHealthOption/HealthCmd
=== RUN   TestSuccessConvertConfigHealthOption/HealthInterval
=== RUN   TestSuccessConvertConfigHealthOption/HealthRetries
=== RUN   TestSuccessConvertConfigHealthOption/HealthStartPeriod
=== RUN   TestSuccessConvertConfigHealthOption/HealthTimeout
=== RUN   TestSuccessConvertConfigHealthOption/NoHealthCheck
--- PASS: TestSuccessConvertConfigHealthOption (0.00s)
    --- PASS: TestSuccessConvertConfigHealthOption/HealthCmd (0.00s)
    --- PASS: TestSuccessConvertConfigHealthOption/HealthInterval (0.00s)
    --- PASS: TestSuccessConvertConfigHealthOption/HealthRetries (0.00s)
    --- PASS: TestSuccessConvertConfigHealthOption/HealthStartPeriod (0.00s)
    --- PASS: TestSuccessConvertConfigHealthOption/HealthTimeout (0.00s)
    --- PASS: TestSuccessConvertConfigHealthOption/NoHealthCheck (0.00s)
=== RUN   TestSuccessConvertConfigWithHostname
--- PASS: TestSuccessConvertConfigWithHostname (0.00s)
=== RUN   TestSuccessConvertConfigWithInit
--- PASS: TestSuccessConvertConfigWithInit (0.00s)
=== RUN   TestSuccessConvertConfigWithInteractive
--- PASS: TestSuccessConvertConfigWithInteractive (0.00s)
=== RUN   TestSuccessConvertConfigIP
=== RUN   TestSuccessConvertConfigIP/IP
=== RUN   TestSuccessConvertConfigIP/IP6
=== RUN   TestSuccessConvertConfigIP/LinkLocalIP
--- PASS: TestSuccessConvertConfigIP (0.00s)
    --- PASS: TestSuccessConvertConfigIP/IP (0.00s)
    --- PASS: TestSuccessConvertConfigIP/IP6 (0.00s)
    --- PASS: TestSuccessConvertConfigIP/LinkLocalIP (0.00s)
=== RUN   TestSuccessConvertConfigWithIPC
--- PASS: TestSuccessConvertConfigWithIPC (0.00s)
=== RUN   TestSuccessConvertConfigWithIsolation
--- PASS: TestSuccessConvertConfigWithIsolation (0.00s)
=== RUN   TestSuccessConvertConfigLabelOption
=== RUN   TestSuccessConvertConfigLabelOption/Label
=== RUN   TestSuccessConvertConfigLabelOption/LabelFile
--- PASS: TestSuccessConvertConfigLabelOption (0.00s)
    --- PASS: TestSuccessConvertConfigLabelOption/Label (0.00s)
    --- PASS: TestSuccessConvertConfigLabelOption/LabelFile (0.00s)
=== RUN   TestSuccessConvertConfigWithLink
--- PASS: TestSuccessConvertConfigWithLink (0.00s)
=== RUN   TestSuccessConvertConfigLogOption
=== RUN   TestSuccessConvertConfigLogOption/LogDriver
=== RUN   TestSuccessConvertConfigLogOption/LogOpt
--- PASS: TestSuccessConvertConfigLogOption (0.00s)
    --- PASS: TestSuccessConvertConfigLogOption/LogDriver (0.00s)
    --- PASS: TestSuccessConvertConfigLogOption/LogOpt (0.00s)
=== RUN   TestSuccessConvertConfigWithMacAddr
--- PASS: TestSuccessConvertConfigWithMacAddr (0.00s)
=== RUN   TestSuccessConvertConfigMemoryOption
=== RUN   TestSuccessConvertConfigMemoryOption/KerenlMemory
=== RUN   TestSuccessConvertConfigMemoryOption/Memory
=== RUN   TestSuccessConvertConfigMemoryOption/MemoryReservation
=== RUN   TestSuccessConvertConfigMemoryOption/MemorySwap
=== RUN   TestSuccessConvertConfigMemoryOption/memroySwappiness
--- PASS: TestSuccessConvertConfigMemoryOption (0.00s)
    --- PASS: TestSuccessConvertConfigMemoryOption/KerenlMemory (0.00s)
    --- PASS: TestSuccessConvertConfigMemoryOption/Memory (0.00s)
    --- PASS: TestSuccessConvertConfigMemoryOption/MemoryReservation (0.00s)
    --- PASS: TestSuccessConvertConfigMemoryOption/MemorySwap (0.00s)
    --- PASS: TestSuccessConvertConfigMemoryOption/memroySwappiness (0.00s)
=== RUN   TestSuccessConvertConfigWithMount
--- PASS: TestSuccessConvertConfigWithMount (0.00s)
=== RUN   TestSuccessConvertConfigNetworkOption
=== RUN   TestSuccessConvertConfigNetworkOption/Network
=== RUN   TestSuccessConvertConfigNetworkOption/NetworkAlias
--- PASS: TestSuccessConvertConfigNetworkOption (0.00s)
    --- PASS: TestSuccessConvertConfigNetworkOption/Network (0.00s)
    --- PASS: TestSuccessConvertConfigNetworkOption/NetworkAlias (0.00s)
=== RUN   TestSuccessConvertConfigOOMOption
=== RUN   TestSuccessConvertConfigOOMOption/OOMKilldisable
=== RUN   TestSuccessConvertConfigOOMOption/OOMScoreAdj
--- PASS: TestSuccessConvertConfigOOMOption (0.00s)
    --- PASS: TestSuccessConvertConfigOOMOption/OOMKilldisable (0.00s)
    --- PASS: TestSuccessConvertConfigOOMOption/OOMScoreAdj (0.00s)
=== RUN   TestSuccessConvertConfigPIDOption
=== RUN   TestSuccessConvertConfigPIDOption/PID
=== RUN   TestSuccessConvertConfigPIDOption/PIDsLimit
INFO[2021-01-16T00:03:01+09:00]containerexecutor_test.go:841 func2 0xc0001f1a10                                 
--- PASS: TestSuccessConvertConfigPIDOption (0.00s)
    --- PASS: TestSuccessConvertConfigPIDOption/PID (0.00s)
    --- PASS: TestSuccessConvertConfigPIDOption/PIDsLimit (0.00s)
=== RUN   TestSuccessConvertConfigWithPrivileged
--- PASS: TestSuccessConvertConfigWithPrivileged (0.00s)
=== RUN   TestSuccessConvertConfigPublishOption
=== RUN   TestSuccessConvertConfigPublishOption/PublishAll
--- PASS: TestSuccessConvertConfigPublishOption (0.00s)
    --- PASS: TestSuccessConvertConfigPublishOption/PublishAll (0.00s)
=== RUN   TestSuccessConvertConfigWithReadOnly
--- PASS: TestSuccessConvertConfigWithReadOnly (0.00s)
=== RUN   TestSuccessConvertConfigWithRestart
--- PASS: TestSuccessConvertConfigWithRestart (0.00s)
=== RUN   TestSuccessConvertConfigWithRM
--- PASS: TestSuccessConvertConfigWithRM (0.00s)
=== RUN   TestSuccessConvertConfigWithRuntime
--- PASS: TestSuccessConvertConfigWithRuntime (0.00s)
=== RUN   TestSuccessConvertConfigWithSecurityOpt
--- PASS: TestSuccessConvertConfigWithSecurityOpt (0.00s)
=== RUN   TestSuccessConvertConfigWithShmSize
--- PASS: TestSuccessConvertConfigWithShmSize (0.00s)
=== RUN   TestSuccessConvertConfigStopOption
=== RUN   TestSuccessConvertConfigStopOption/StopSignal
=== RUN   TestSuccessConvertConfigStopOption/StopTimeout
--- PASS: TestSuccessConvertConfigStopOption (0.00s)
    --- PASS: TestSuccessConvertConfigStopOption/StopSignal (0.00s)
    --- PASS: TestSuccessConvertConfigStopOption/StopTimeout (0.00s)
=== RUN   TestSuccessConvertConfigWithStorageOpt
--- PASS: TestSuccessConvertConfigWithStorageOpt (0.00s)
=== RUN   TestSuccessConvertConfigWithSysctl
--- PASS: TestSuccessConvertConfigWithSysctl (0.00s)
=== RUN   TestSuccessConvertConfigWithTmpfs
--- PASS: TestSuccessConvertConfigWithTmpfs (0.00s)
=== RUN   TestSuccessConvertConfigWithTTY
--- PASS: TestSuccessConvertConfigWithTTY (0.00s)
=== RUN   TestSuccessConvertConfigWithUlimit
--- PASS: TestSuccessConvertConfigWithUlimit (0.00s)
=== RUN   TestSuccessConvertConfigUserOption
=== RUN   TestSuccessConvertConfigUserOption/User
=== RUN   TestSuccessConvertConfigUserOption/Usern
--- PASS: TestSuccessConvertConfigUserOption (0.00s)
    --- PASS: TestSuccessConvertConfigUserOption/User (0.00s)
    --- PASS: TestSuccessConvertConfigUserOption/Usern (0.00s)
=== RUN   TestSuccessConvertConfigWithUTS
--- PASS: TestSuccessConvertConfigWithUTS (0.00s)
=== RUN   TestSuccessConvertConfigVolumeOption
=== RUN   TestSuccessConvertConfigVolumeOption/Volume
=== RUN   TestSuccessConvertConfigVolumeOption/VolumeDriver
=== RUN   TestSuccessConvertConfigVolumeOption/VolumesFrom
--- PASS: TestSuccessConvertConfigVolumeOption (0.00s)
    --- PASS: TestSuccessConvertConfigVolumeOption/Volume (0.00s)
    --- PASS: TestSuccessConvertConfigVolumeOption/VolumeDriver (0.00s)
    --- PASS: TestSuccessConvertConfigVolumeOption/VolumesFrom (0.00s)
=== RUN   TestSuccessConvertConfigWithWorkDir
--- PASS: TestSuccessConvertConfigWithWorkDir (0.00s)
PASS
coverage: 86.1% of statements
ok  	github.com/lf-edge/edge-home-orchestration-go/src/controller/servicemgr/executor/containerexecutor	0.057s	coverage: 86.1% of statements
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
