### PR TITLE
Use etcd-io/bbolt instead of boltdb/bolt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.15
 require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
-	github.com/boltdb/bolt v1.3.1
 	github.com/casbin/casbin v1.9.1
 	github.com/containerd/containerd v1.4.1-0.20201117152358-0edc412565dc // indirect
 	github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7 // indirect
@@ -48,6 +47,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20160323030313-93e72a773fad // indirect
+	go.etcd.io/bbolt v1.3.5
 	google.golang.org/grpc v1.34.0 // indirect
 	gopkg.in/ini.v1 v1.62.0
 	gotest.tools v2.2.0+incompatible // indirect

--- a/src/db/bolt/wrapper/wrapper.go
+++ b/src/db/bolt/wrapper/wrapper.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/lf-edge/edge-home-orchestration-go/src/common/errors"
 
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

[boltdb/bolt](https://github.com/boltdb/bolt) has been archived from Sep 2017.
This PR change from boltdb/bolt to [etcd-io/bbolt](https://github.com/etcd-io/bbolt) by [a message from the author recommend](https://github.com/boltdb/bolt#a-message-from-the-author).

## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?
Build and run the project.

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
