### PR TITLE
Update storagemgr for the v1.4.0 "Hanoi" version of EdgeX Foundry Go Device SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ samples/native/test/edge-orchestration
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 *.html
+src/controller/discoverymgr/testDB/*
+src/controller/storagemgr/storagedriver/tests.log
 
 # VS Code
 .vscode/

--- a/go.mod
+++ b/go.mod
@@ -19,13 +19,13 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.4.0
-	github.com/edgexfoundry/device-sdk-go v1.1.2
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.36
+	github.com/edgexfoundry/device-sdk-go v1.4.0
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.115
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/golang/mock v1.4.4
 	github.com/gomodule/redigo v1.8.3
-	github.com/gorilla/mux v1.7.2
+	github.com/gorilla/mux v1.8.0
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/leemcloughlin/logfile v0.0.0-20201123203928-cff1c8a30a10

--- a/src/controller/storagemgr/storagedriver/storagedriver.go
+++ b/src/controller/storagemgr/storagedriver/storagedriver.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"github.com/lf-edge/edge-home-orchestration-go/src/common/logmgr"
 
-	sdk "github.com/edgexfoundry/device-sdk-go"
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	sdk "github.com/edgexfoundry/device-sdk-go/pkg/service"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
@@ -39,7 +39,7 @@ var (
 )
 
 // Initialize performs protocol-specific initialization for the device
-func (driver *StorageDriver) Initialize(logger logger.LoggingClient, asyncValues chan<- *dsModels.AsyncValues) error {
+func (driver *StorageDriver) Initialize(logger logger.LoggingClient, asyncValues chan<- *dsModels.AsyncValues, deviceCh chan<- []dsModels.DiscoveredDevice) error {
 	log.Println(logPrefix, "Device service intialize started")
 	driver.logger = logger
 	handler := NewStorageHandler(sdk.RunningService(), logger, asyncValues)

--- a/src/controller/storagemgr/storagedriver/storagehandler_test.go
+++ b/src/controller/storagemgr/storagedriver/storagehandler_test.go
@@ -26,15 +26,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	sdk "github.com/edgexfoundry/device-sdk-go"
 	"github.com/edgexfoundry/device-sdk-go/pkg/models"
+	sdk "github.com/edgexfoundry/device-sdk-go/pkg/service"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 )
 
 var handler *StorageHandler
 
 func TestMain(m *testing.M) {
-	service := &sdk.Service{}
+	service := &sdk.DeviceService{}
 	logger := logger.NewClient("test", false, "./tests.log", "DEBUG")
 	asyncValues := make(chan<- *models.AsyncValues)
 
@@ -65,6 +65,12 @@ func TestNewCommandValue(t *testing.T) {
 		{"Test A Bool true", "true", models.Bool, false},
 		{"Test A Bool false", "false", models.Bool, false},
 		{"Test A Bool error", "bad", models.Bool, true},
+		{"Test A Float32+", "123.456", models.Float32, false},
+		{"Test A Float32-", "-123.456", models.Float32, false},
+		{"Test A Float32 error", "-123.junk", models.Float32, true},
+		{"Test A Float64+", "456.123", models.Float64, false},
+		{"Test A Float64-", "-456.123", models.Float64, false},
+		{"Test A Float64 error", "Random", models.Float64, true},
 		{"Test A Uint8", "255", models.Uint8, false},
 		{"Test A Uint8 error", "FF", models.Uint8, true},
 		{"Test A Uint16", "65535", models.Uint16, false},
@@ -120,6 +126,18 @@ func TestNewCommandValue(t *testing.T) {
 					t.Fatal()
 				}
 				actual = strconv.FormatBool(value)
+			case models.Float32:
+				value, err := cmdVal.Float32Value()
+				if !assert.NoError(t, err) {
+					t.Fatal()
+				}
+				actual = strconv.FormatFloat(float64(value), 'f', 3, 32)
+			case models.Float64:
+				value, err := cmdVal.Float64Value()
+				if !assert.NoError(t, err) {
+					t.Fatal()
+				}
+				actual = strconv.FormatFloat(value, 'f', 3, 64)
 			case models.Uint8:
 				value, err := cmdVal.Uint8Value()
 				if !assert.NoError(t, err) {


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

This PR is intended to update pkgs of edgex foundry for Hanoi version.

## Type of change
- [x] Code cleanup/refactoring

# How Has This Been Tested?
Run edge-home-orchestration-go with [EdgeX Foundry Services](https://github.com/edgexfoundry/edgex-go#get-started).

## TC Result
$ go test -v -cover ./src/controller/storagemgr/storagedriver/
```
=== RUN   TestReadasBinary
--- PASS: TestReadasBinary (0.00s)
=== RUN   TestNewCommandValue
=== RUN   TestNewCommandValue/Test_A_Binary
=== RUN   TestNewCommandValue/Test_A_String_JSON
=== RUN   TestNewCommandValue/Test_A_String_Text
=== RUN   TestNewCommandValue/Test_A_Bool_true
=== RUN   TestNewCommandValue/Test_A_Bool_false
=== RUN   TestNewCommandValue/Test_A_Bool_error
=== RUN   TestNewCommandValue/Test_A_Uint8
=== RUN   TestNewCommandValue/Test_A_Uint8_error
=== RUN   TestNewCommandValue/Test_A_Uint16
=== RUN   TestNewCommandValue/Test_A_Uint16_error
=== RUN   TestNewCommandValue/Test_A_Uint32
=== RUN   TestNewCommandValue/Test_A_Uint32_error
=== RUN   TestNewCommandValue/Test_A_Uint64
=== RUN   TestNewCommandValue/Test_A_Uint64_error
=== RUN   TestNewCommandValue/Test_A_Int8+
=== RUN   TestNewCommandValue/Test_A_Int8-
=== RUN   TestNewCommandValue/Test_A_Int8_error
=== RUN   TestNewCommandValue/Test_A_Int16+
=== RUN   TestNewCommandValue/Test_A_Int16-
=== RUN   TestNewCommandValue/Test_A_Int16_error
=== RUN   TestNewCommandValue/Test_A_Int32+
=== RUN   TestNewCommandValue/Test_A_Int32-
=== RUN   TestNewCommandValue/Test_A_Int32_error
=== RUN   TestNewCommandValue/Test_A_Int64+
=== RUN   TestNewCommandValue/Test_A_Int64-
=== RUN   TestNewCommandValue/Test_A_Int64_error
--- PASS: TestNewCommandValue (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Binary (0.00s)
    --- PASS: TestNewCommandValue/Test_A_String_JSON (0.00s)
    --- PASS: TestNewCommandValue/Test_A_String_Text (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Bool_true (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Bool_false (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Bool_error (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Uint8 (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Uint8_error (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Uint16 (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Uint16_error (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Uint32 (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Uint32_error (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Uint64 (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Uint64_error (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int8+ (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int8- (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int8_error (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int16+ (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int16- (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int16_error (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int32+ (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int32- (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int32_error (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int64+ (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int64- (0.00s)
    --- PASS: TestNewCommandValue/Test_A_Int64_error (0.00s)
=== RUN   TestStorageDriver
INFO[2021-01-18T11:02:30+09:00]storagedriver.go:71 AddDevice [storagedriver] Device has been successfully added!!!!!! TestDevice
INFO[2021-01-18T11:02:30+09:00]storagedriver.go:63 Stop [storagedriver] StorageDriver.Stop called: true
--- PASS: TestStorageDriver (0.00s)
PASS
coverage: 59.8% of statements
ok      github.com/lf-edge/edge-home-orchestration-go/src/controller/storagemgr/storagedriver   (cached)        coverage: 59.8% of statements
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
