### PR TITLE
[MNEDC] Fix TC of mnedc/client

### DIFF
--- a/src/controller/discoverymgr/mnedc/client/client_test.go
+++ b/src/controller/discoverymgr/mnedc/client/client_test.go
@@ -19,7 +19,6 @@ package client
 
 import (
 	"errors"
-	"log"
 	"net"
 	"os"
 	"testing"
@@ -91,12 +90,10 @@ func TestMNEDCClosedAndReestablished(t *testing.T) {
 	createMockIns(ctrl)
 	t.Run("NotifyClose", func(t *testing.T) {
 		client := GetInstance()
-		mockDiscovery.EXPECT().MNEDCClosedCallback().Return()
 		client.NotifyClose()
 	})
 	t.Run("ConnectionEstablished", func(t *testing.T) {
 		client := GetInstance()
-		mockDiscovery.EXPECT().MNEDCReconciledCallback().Return()
 		client.ConnectionReconciled()
 	})
 }
@@ -190,7 +187,6 @@ func TestStartRecvRoutineError(t *testing.T) {
 		deleteDeviceIDFile()
 		gomock.InOrder(
 			mockNetworkUtil.EXPECT().ReadFrom(gomock.Any()).Return(5, []byte(defaultMessage), errors.New("")),
-			mockDiscovery.EXPECT().MNEDCClosedCallback().Return(),
 		)
 
 		go client.StartRecvRoutine()
@@ -216,7 +212,6 @@ func TestStartRecvRoutineError(t *testing.T) {
 
 		gomock.InOrder(
 			mockNetworkUtil.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(errors.New(defaultMessage)),
-			mockDiscovery.EXPECT().MNEDCClosedCallback().Return(),
 		)
 
 		go client.StartSendRoutine()
@@ -331,7 +326,6 @@ func TestHandleErrorNegativeRead(t *testing.T) {
 
 	t.Run("ReadFromError", func(t *testing.T) {
 		gomock.InOrder(
-			mockDiscovery.EXPECT().MNEDCClosedCallback(),
 			mockNetworkUtil.EXPECT().ConnectToHost(gomock.Any(), gomock.Any(), gomock.Any()).Return(conn, nil).AnyTimes(),
 			mockNetworkUtil.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
 			mockNetworkUtil.EXPECT().ReadFrom(gomock.Any()).Return(1, []byte(""), errors.New("")).Return(8, []byte(defaultVirtualIP), nil),
@@ -386,14 +380,12 @@ func TestHadError(t *testing.T) {
 		configPath:  defaultConfigPath,
 	}
 	gomock.InOrder(
-		mockDiscovery.EXPECT().MNEDCClosedCallback(),
 		mockNetworkUtil.EXPECT().ConnectToHost(gomock.Any(), gomock.Any(), gomock.Any()).Return(conn, nil),
 		mockNetworkUtil.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(nil),
 		mockNetworkUtil.EXPECT().ReadFrom(gomock.Any()).Return(8, []byte(defaultVirtualIP), nil),
 		mockTun.EXPECT().CreateTUN().Return(tunIntf, nil),
 		mockTun.EXPECT().SetTUNIP(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 		mockTun.EXPECT().SetTUNStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
-		mockDiscovery.EXPECT().MNEDCReconciledCallback().Return().AnyTimes(),
 	)
 
 	c.HandleError(errors.New("Read Error"))
@@ -496,7 +488,6 @@ func TestClose(t *testing.T) {
 		intf:    tunIntf,
 		isAlive: true,
 	}
-	mockDiscovery.EXPECT().MNEDCClosedCallback().Return()
 	err = client.Close()
 
 	if err != nil {
@@ -512,7 +503,6 @@ func createMockIns(ctrl *gomock.Controller) {
 	tunIns = mockTun
 	networkUtilIns = mockNetworkUtil
 	mockDiscovery = discoveryMocks.NewMockDiscovery(ctrl)
-	discoveryIns = mockDiscovery
 }
 
 func startConnection() {


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Comment out MNEDCClosedCallback() and MNEDCReconciledCallback() since client of mnedc doesn't call them at the moment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
$ go test -v -cover ./src/controller/discoverymgr/mnedc/client

## Result of TC
```
=== RUN   TestParseVirtualIP
=== RUN   TestParseVirtualIP/IPError
=== RUN   TestParseVirtualIP/Success
--- PASS: TestParseVirtualIP (0.00s)
    --- PASS: TestParseVirtualIP/IPError (0.00s)
    --- PASS: TestParseVirtualIP/Success (0.00s)
=== RUN   TestMNEDCClosedAndReestablished
=== RUN   TestMNEDCClosedAndReestablished/NotifyClose
INFO[2021-01-18T16:22:47+09:00]client.go:415 NotifyClose [NotifyClose] MNEDC connection closed
=== RUN   TestMNEDCClosedAndReestablished/ConnectionEstablished
INFO[2021-01-18T16:22:47+09:00]client.go:422 ConnectionReconciled [connectionReIstablish] MNEDC connection reistablished
INFO[2021-01-18T16:22:47+09:00]client.go:431 NotifyBroadcastServer [mnedcclient] Registering to Broadcast server
INFO[2021-01-18T16:22:47+09:00]networkhelper.go:125 GetVirtualIP [networkmgr] Virtual IP asked
INFO[2021-01-18T16:22:47+09:00]client.go:435 NotifyBroadcastServer [RegisterBroadcast] Cant register to Broadcast server, virtual IP error not found error : Virtual Network Not Found
--- PASS: TestMNEDCClosedAndReestablished (0.00s)
    --- PASS: TestMNEDCClosedAndReestablished/NotifyClose (0.00s)
    --- PASS: TestMNEDCClosedAndReestablished/ConnectionEstablished (0.00s)
=== RUN   TestStartSendRoutine
=== RUN   TestStartSendRoutine/SendRoutine
--- PASS: TestStartSendRoutine (2.00s)
    --- PASS: TestStartSendRoutine/SendRoutine (2.00s)
=== RUN   TestStartRecvRoutine
=== RUN   TestStartRecvRoutine/RecvRoutine
--- PASS: TestStartRecvRoutine (1.00s)
    --- PASS: TestStartRecvRoutine/RecvRoutine (1.00s)
=== RUN   TestStartRecvRoutineError
=== RUN   TestStartRecvRoutineError/RecvRoutineErr
INFO[2021-01-18T16:22:54+09:00]client.go:229 StartRecvRoutine Read error
INFO[2021-01-18T16:22:54+09:00]client.go:289 HandleError [mnedcclient] [hadError]  , Connection problem detected. Re-connecting.
INFO[2021-01-18T16:22:54+09:00]client.go:415 NotifyClose [NotifyClose] MNEDC connection closed
INFO[2021-01-18T16:22:54+09:00]client.go:311 HandleError Cannot read config file,open : no such file or directory
=== RUN   TestStartRecvRoutineError/SendRoutineErr
INFO[2021-01-18T16:22:57+09:00]client.go:209 StartSendRoutine error in send:  dummy
INFO[2021-01-18T16:22:57+09:00]client.go:289 HandleError [mnedcclient] [hadError] dummy , Connection problem detected. Re-connecting.
INFO[2021-01-18T16:22:57+09:00]client.go:415 NotifyClose [NotifyClose] MNEDC connection closed
INFO[2021-01-18T16:22:57+09:00]client.go:311 HandleError Cannot read config file,open : no such file or directory
--- PASS: TestStartRecvRoutineError (8.00s)
    --- PASS: TestStartRecvRoutineError/RecvRoutineErr (1.00s)
    --- PASS: TestStartRecvRoutineError/SendRoutineErr (3.00s)
=== RUN   TestTunWriteRoutine
=== RUN   TestTunWriteRoutine/Success
--- PASS: TestTunWriteRoutine (5.00s)
    --- PASS: TestTunWriteRoutine/Success (3.00s)
=== RUN   TestTunReadRoutine
=== RUN   TestTunReadRoutine/Success
--- PASS: TestTunReadRoutine (5.00s)
    --- PASS: TestTunReadRoutine/Success (3.00s)
=== RUN   TestHandleErrorNegativeRead
=== RUN   TestHandleErrorNegativeRead/isAliveFalse
INFO[2021-01-18T16:23:12+09:00]client.go:289 HandleError [mnedcclient] [hadError]  , Connection problem detected. Re-connecting.
=== RUN   TestHandleErrorNegativeRead/ReadFromError
INFO[2021-01-18T16:23:12+09:00]client.go:289 HandleError [mnedcclient] [hadError]  , Connection problem detected. Re-connecting.
INFO[2021-01-18T16:23:12+09:00]client.go:415 NotifyClose [NotifyClose] MNEDC connection closed
INFO[2021-01-18T16:23:12+09:00]client.go:340 HandleError [hadError] TUN error:
--- PASS: TestHandleErrorNegativeRead (4.01s)
    --- PASS: TestHandleErrorNegativeRead/isAliveFalse (0.00s)
    --- PASS: TestHandleErrorNegativeRead/ReadFromError (0.00s)
=== RUN   TestHadError
INFO[2021-01-18T16:23:16+09:00]client.go:289 HandleError [mnedcclient] [hadError] Read Error , Connection problem detected. Re-connecting.
INFO[2021-01-18T16:23:16+09:00]client.go:415 NotifyClose [NotifyClose] MNEDC connection closed
INFO[2021-01-18T16:23:19+09:00]client.go:422 ConnectionReconciled [connectionReIstablish] MNEDC connection reistablished
--- PASS: TestHadError (7.00s)
INFO[2021-01-18T16:23:19+09:00]client.go:431 NotifyBroadcastServer [mnedcclient] Registering to Broadcast server
=== RUN   TestCreateClient
INFO[2021-01-18T16:23:19+09:00]networkhelper.go:125 GetVirtualIP [networkmgr] Virtual IP asked
INFO[2021-01-18T16:23:19+09:00]client.go:435 NotifyBroadcastServer [RegisterBroadcast] Cant register to Broadcast server, virtual IP error not found error : Virtual Network Not Found
INFO[2021-01-18T16:23:23+09:00]client.go:139 CreateClient Write Successful
INFO[2021-01-18T16:23:23+09:00]client_test.go:447 TestCreateClient Connection Status:  true
--- PASS: TestCreateClient (5.00s)
=== RUN   TestRun
--- PASS: TestRun (0.00s)
=== RUN   TestClose
INFO[2021-01-18T16:23:28+09:00]client.go:415 NotifyClose [NotifyClose] MNEDC connection closed
INFO[2021-01-18T16:23:28+09:00]client_test.go:543 closeConnection Close called
--- PASS: TestClose (4.00s)
PASS
coverage: 72.4% of statements
ok      github.com/lf-edge/edge-home-orchestration-go/src/controller/discoverymgr/mnedc/client  (cached)        coverage: 72.4% of statements
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
