### PR TITLE
Fix logmgr_test

### DIFF
--- a/src/common/logmgr/logmgr_test.go
+++ b/src/common/logmgr/logmgr_test.go
@@ -68,8 +68,6 @@ func TestInitFileFail(t *testing.T) {
 			if err != nil {
 				t.Error(err.Error())
 			}
-		} else {
-			t.Error(r)
 		}
 	}()
 


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

This logic is not an error in the `root` privilege.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
$ go test -v -cover ./src/common/logmgr/

## Result of TC

`user` privilege
```
=== RUN   TestInit
INFO[2021-01-19T08:43:10+09:00]logmgr_test.go:30 TestInit FilePath = /home/t25kim/edge-home-orchestration-go/src/common/logmgr
--- PASS: TestInit (0.00s)
=== RUN   TestInitFolderFail
PANI[2021-01-19T08:43:10+09:00]logmgr.go:60 InitLogfile Failed to create logFilePath : mkdir : no such file or directory
fail to create log : &{0xc0000d2070 map[] 2021-01-19 08:43:10.233391651 +0900 KST m=+0.000473713 panic 0xc0000d01e0 Failed to create logFilePath : mkdir : no such file or directory <nil> <nil> }
--- PASS: TestInitFolderFail (0.00s)
=== RUN   TestInitFileFail
LogFile failed to create /home/t25kim/edge-home-orchestration-go/src/common/logmgr/test/logmgr.log: open /home/t25kim/edge-home-orchestration-go/src/common/logmgr/test/logmgr.log: permission denied
PANI[2021-01-19T08:43:10+09:00]logmgr.go:72 InitLogfile Failed to create logFile logmgr.log: LogFile failed to create file /home/t25kim/edge-home-orchestration-go/src/common/logmgr/test/logmgr.log
fail to create log : &{0xc0000d2070 map[] 2021-01-19 08:43:10.233540575 +0900 KST m=+0.000622637 panic 0xc0000d0320 Failed to create logFile logmgr.log: LogFile failed to create file /home/t25kim/edge-home-orchestration-go/src/common/logmgr/test/logmgr.log <nil> <nil> }
--- PASS: TestInitFileFail (0.00s)
PASS
coverage: 100.0% of statements
ok      github.com/lf-edge/edge-home-orchestration-go/src/common/logmgr 0.002s  coverage: 100.0% of statements
```

`root` privilege
```
=== RUN   TestInit
INFO[2021-01-19T08:43:36+09:00]logmgr_test.go:30 TestInit FilePath = /home/t25kim/edge-home-orchestration-go/src/common/logmgr
--- PASS: TestInit (0.00s)
=== RUN   TestInitFolderFail
PANI[2021-01-19T08:43:36+09:00]logmgr.go:60 InitLogfile Failed to create logFilePath : mkdir : no such file or directory
fail to create log : &{0xc0000c0070 map[] 2021-01-19 08:43:36.58514269 +0900 KST m=+0.000450334 panic 0xc0000be1e0 Failed to create logFilePath : mkdir : no such file or directory <nil> <nil> }
--- PASS: TestInitFolderFail (0.00s)
=== RUN   TestInitFileFail
--- PASS: TestInitFileFail (0.00s)
PASS
coverage: 94.7% of statements
ok      github.com/lf-edge/edge-home-orchestration-go/src/common/logmgr 0.002s  coverage: 94.7% of statements
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
