### PR TITLE
Remove debug messages in tests

### DIFF
--- a/src/common/errormsg/errormsg_test.go
+++ b/src/common/errormsg/errormsg_test.go
@@ -39,8 +39,6 @@ func TestToString(t *testing.T) {
 
 func TestToInt(t *testing.T) {
 	err := ToError(ErrorNoNetworkInterface)
-	t.Log(ToString(err))
-
 	num := ToInt(err)
 	if num != ErrorNoNetworkInterface {
 		t.Errorf("%d != %d", num, ErrorNoNetworkInterface)

--- a/src/controller/servicemgr/types_test.go
+++ b/src/controller/servicemgr/types_test.go
@@ -59,8 +59,6 @@ func TestMapIter(t *testing.T) {
 	for {
 		msg := <-mapItem
 
-		t.Log(msg.Key, msg.Value)
-
 		if msg.Value == nil && msg.Key == 0 {
 			break
 		} else {


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Remove [`t.Log` debug messages](https://github.com/lf-edge/edge-home-orchestration-go/actions/runs/494517250) from [types_test.go](https://github.com/lf-edge/edge-home-orchestration-go/blob/f97a8222b745ca0951b7abdcb50797b1990f0437/src/controller/servicemgr/types_test.go#L62)  and [errormsg_test.go](https://github.com/lf-edge/edge-home-orchestration-go/blob/f97a8222b745ca0951b7abdcb50797b1990f0437/src/common/errormsg/errormsg_test.go#L42). 

![изображение](https://user-images.githubusercontent.com/45031429/105081274-9ff48e00-5a9a-11eb-9439-b9db2e3f07ba.png)

![изображение](https://user-images.githubusercontent.com/45031429/105081352-bc90c600-5a9a-11eb-96eb-7546e567c850.png)

Since the output of these messages is marked as an error, this can confuse developers, and for debugging it is better to use `fmt`  that immediately prints the message. The `t.Log` prints a message when the test ends.

## Type of change

- [x] Code cleanup/refactoring

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
