### PR TITLE
Remove all references to glide from the documentation

### DIFF
--- a/Builder/Dockerfile
+++ b/Builder/Dockerfile
@@ -46,7 +46,6 @@ RUN	cd /usr/src/gtest && cmake . && make && mv *.a /usr/lib && \
 
 
 # Install go tools and packages
-RUN add-apt-repository ppa:masterminds/glide && apt-get update && apt-get install -y glide
 RUN curl -s https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar -v -C /usr/local -xz
 # Environment
 ENV HOME /home
@@ -71,7 +70,7 @@ RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip &&
 	unzip sdk-tools-linux-4333796.zip -d $ANDROID_HOME && \
 	rm -rf sdk-tools-linux-4333796.zip
 ENV PATH $PATH:$ANDROID_HOME/tools/bin
-RUN apt-get -y install openjdk-8-jdk
+RUN apt-get update && apt-get -y install openjdk-8-jdk
 RUN yes | sdkmanager "platform-tools" "platforms;android-28"
 # Install gradle
 RUN wget https://services.gradle.org/distributions/gradle-5.4.1-bin.zip && \

--- a/doc/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/doc/platforms/raspberry_pi3/raspberry_pi3.md
@@ -72,13 +72,6 @@ $ export GOPATH=$HOME/go
 $ export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
 ```
 
-- glide ([package manager for Go](https://glide.readthedocs.io/en/latest/))  
-
-```sh
-$ sudo apt install golang-glide
-```
-> To add 3rd-party packages need to add them to the `glide.yaml` (format is described [here](https://glide.readthedocs.io/en/latest/glide.yaml/))
-
 - edge-orchestration source code
 
 ```sh

--- a/doc/platforms/x86_64_linux/x86_64_android.md
+++ b/doc/platforms/x86_64_linux/x86_64_android.md
@@ -102,7 +102,6 @@ tree /home/virtual-pc/projects/edge-home-orchestration-go/src/interfaces/javaapi
  Clean up 3rdParty directory
 -------------------------------------
 rm -rf /home/virtual-pc/projects/edge-home-orchestration-go/vendor
-rm -rf /home/virtual-pc/projects/edge-home-orchestration-go/glide.lock
 virtual-pc@virtualpc-VirtualBox:~/projects/edge-home-orchestration-go$ ls /home/virtual-pc/projects/edge-home-orchestration-go/src/interfaces/javaapi/output
 liborchestration.aar  liborchestration-sources.jar
 ```

--- a/doc/platforms/x86_64_linux/x86_64_linux.md
+++ b/doc/platforms/x86_64_linux/x86_64_linux.md
@@ -45,15 +45,6 @@ Please see the below [How to work](#how-to-work) to know how to run Edge Orchest
 `$ export GOPATH=$HOME/go`  
 `$ export PATH=$PATH:$GOPATH/bin`
 
-- glide ([package manager for Go](https://glide.readthedocs.io/en/latest/))  
-To install `glide`, you need to add appropriate repository to apt list. To do that, execute following shell commands:
-
-```shell
-$ sudo add-apt-repository -y ppa:masterminds/glide && sudo apt-get update
-$ sudo apt-get install -y glide
-```
-> To add 3rd-party packages need to add them to the `glide.yaml` (format is described [here](https://glide.readthedocs.io/en/latest/glide.yaml/))
-
 - extra linux utilities
 ```
 $ sudo apt-get install tree jq


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Due to no longer using the `glide`, removing all references to it.

## Type of change

- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
