### PR TITLE
TC for discoverymgr/mnedc

### DIFF
--- a/src/controller/discoverymgr/mnedc/clientcontrol_test.go
+++ b/src/controller/discoverymgr/mnedc/clientcontrol_test.go
@@ -21,9 +21,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/lf-edge/edge-home-orchestration-go/src/controller/discoverymgr/mnedc/client"
 	clientMocks "github.com/lf-edge/edge-home-orchestration-go/src/controller/discoverymgr/mnedc/client/mocks"
-	discoveryMocks "github.com/lf-edge/edge-home-orchestration-go/src/controller/discoverymgr/mocks"
 
 	"github.com/golang/mock/gomock"
 )
@@ -31,10 +29,9 @@ import (
 var (
 	defaultConfigPath       = "server.config"
 	defaultDeviceID         = "dummyID"
-	defaultDeviceIDFilePath = "deviceID.txt"
+	defaultDeviceIDFilePath = "testdata/deviceID.txt"
 
 	mockMnedcClient *clientMocks.MockMNEDCClient
-	mockDiscovery   *discoveryMocks.MockDiscovery
 )
 
 func init() {
@@ -48,28 +45,22 @@ func TestStartMNEDCClient(t *testing.T) {
 
 	t.Run("CreateClientError", func(t *testing.T) {
 		c := GetClientInstance()
-
-		mockDiscovery.EXPECT().GetDeviceID().Return(defaultDeviceID, nil)
+		mockMnedcClient.EXPECT().SetClient(gomock.Any())
 		mockMnedcClient.EXPECT().CreateClient(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New(""))
 		c.StartMNEDCClient(defaultDeviceIDFilePath, defaultConfigPath)
 	})
 	t.Run("Success", func(t *testing.T) {
 		c := GetClientInstance()
-
-		mockDiscovery.EXPECT().GetDeviceID().Return(defaultDeviceID, nil)
-		mockMnedcClient.EXPECT().CreateClient(gomock.Any(), gomock.Any(), gomock.Any()).Return(&client.Client{}, nil)
+		mockMnedcClient.EXPECT().SetClient(gomock.Any())
+		mockMnedcClient.EXPECT().CreateClient(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 		mockMnedcClient.EXPECT().Run()
-		mockDiscovery.EXPECT().NotifyMNEDCBroadcastServer().Return(errors.New("")).AnyTimes()
+		mockMnedcClient.EXPECT().NotifyBroadcastServer(gomock.Any()).Return(nil).AnyTimes()
 
 		c.StartMNEDCClient(defaultDeviceIDFilePath, defaultConfigPath)
-
 	})
-
 }
 
 func createMockIns(ctrl *gomock.Controller) {
 	mockMnedcClient = clientMocks.NewMockMNEDCClient(ctrl)
 	mnedcClientIns = mockMnedcClient
-	mockDiscovery = discoveryMocks.NewMockDiscovery(ctrl)
-	discoveryIns = mockDiscovery
 }

--- a/src/controller/discoverymgr/mnedc/servercontrol_test.go
+++ b/src/controller/discoverymgr/mnedc/servercontrol_test.go
@@ -21,13 +21,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	networkmocks "github.com/lf-edge/edge-home-orchestration-go/src/common/networkhelper/mocks"
-	discoverymocks "github.com/lf-edge/edge-home-orchestration-go/src/controller/discoverymgr/mocks"
 	"github.com/lf-edge/edge-home-orchestration-go/src/controller/discoverymgr/mnedc/server"
 	serverMocks "github.com/lf-edge/edge-home-orchestration-go/src/controller/discoverymgr/mnedc/server/mocks"
 	ciphermock "github.com/lf-edge/edge-home-orchestration-go/src/restinterface/cipher/mocks"
@@ -61,13 +59,11 @@ func TestStartMNEDCServer(t *testing.T) {
 
 	t.Run("ServerError", func(t *testing.T) {
 		s := GetServerInstance()
-		mockDiscovery.EXPECT().GetDeviceID().Return(defaultDeviceID, nil)
 		mockMnedcServer.EXPECT().CreateServer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New(""))
 		s.StartMNEDCServer(defaultDeviceIDFilePath)
 	})
 	t.Run("GetOutboundIPError", func(t *testing.T) {
 		s := GetServerInstance()
-		mockDiscovery.EXPECT().GetDeviceID().Return(defaultDeviceID, nil)
 		mockMnedcServer.EXPECT().CreateServer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&server.Server{}, nil)
 		mockMnedcServer.EXPECT().Run()
 		mockNetwork.EXPECT().GetOutboundIP().Return("", errors.New(""))
@@ -75,7 +71,6 @@ func TestStartMNEDCServer(t *testing.T) {
 	})
 	t.Run("Success", func(t *testing.T) {
 		s := GetServerInstance()
-		mockDiscovery.EXPECT().GetDeviceID().Return(defaultDeviceID, nil)
 		mockMnedcServer.EXPECT().CreateServer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&server.Server{}, nil)
 		mockMnedcServer.EXPECT().Run()
 		mockNetwork.EXPECT().GetOutboundIP().Return(defaultOutboundIP, nil)
@@ -141,8 +136,6 @@ func TestRequestHandler(t *testing.T) {
 func createServerMockIns(ctrl *gomock.Controller) {
 	mockNetwork = networkmocks.NewMockNetwork(ctrl)
 	mockMnedcServer = serverMocks.NewMockMNEDCServer(ctrl)
-	mockDiscovery = discoverymocks.NewMockDiscovery(ctrl)
 	mnedcServerIns = mockMnedcServer
 	networkIns = mockNetwork
-	discoveryIns = mockDiscovery
 }

--- a/src/controller/discoverymgr/mnedc/testdata/deviceID.txt
+++ b/src/controller/discoverymgr/mnedc/testdata/deviceID.txt
@@ -1,0 +1,1 @@
+dummyID


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

TC of `discoverymgr/mnedc` have been modified.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
$ go test -v ./src/controller/discoverymgr/mnedc

## Result
```
=== RUN   TestStartMNEDCClient
=== RUN   TestStartMNEDCClient/CreateClientError
INFO[2021-01-21T17:32:42+09:00]clientcontrol.go:108 getDeviceID [GetDeviceID] Got the UUID
INFO[2021-01-21T17:32:42+09:00]clientcontrol.go:67 StartMNEDCClient [mnedcmgr] Couldn't start MNEDC client
=== RUN   TestStartMNEDCClient/Success
INFO[2021-01-21T17:32:42+09:00]clientcontrol.go:108 getDeviceID [GetDeviceID] Got the UUID
--- PASS: TestStartMNEDCClient (0.00s)
    --- PASS: TestStartMNEDCClient/CreateClientError (0.00s)
    --- PASS: TestStartMNEDCClient/Success (0.00s)
=== RUN   TestStartMNEDCServer
=== RUN   TestStartMNEDCServer/ServerError
INFO[2021-01-21T17:32:42+09:00]clientcontrol.go:108 getDeviceID [GetDeviceID] Got the UUID
INFO[2021-01-21T17:32:42+09:00]servercontrol.go:72 StartMNEDCServer [mnedcmgr] Couldn't start MNEDC server
=== RUN   TestStartMNEDCServer/GetOutboundIPError
INFO[2021-01-21T17:32:42+09:00]clientcontrol.go:108 getDeviceID [GetDeviceID] Got the UUID
INFO[2021-01-21T17:32:42+09:00]servercontrol.go:80 StartMNEDCServer [mnedcmgr] Couldn't start MNEDC server, Error in getting private IP
=== RUN   TestStartMNEDCServer/Success
INFO[2021-01-21T17:32:42+09:00]clientcontrol.go:108 getDeviceID [GetDeviceID] Got the UUID
--- PASS: TestStartMNEDCServer (0.00s)
    --- PASS: TestStartMNEDCServer/ServerError (0.00s)
    --- PASS: TestStartMNEDCServer/GetOutboundIPError (0.00s)
    --- PASS: TestStartMNEDCServer/Success (0.00s)
=== RUN   TestRequestHandler
INFO[2021-01-21T17:32:42+09:00]servercontrol.go:100 handleClientInfo Registered
INFO[2021-01-21T17:32:42+09:00]servercontrol.go:129 broadcastPeers [mnedcmgr] map content:  3.3.3.3 4.4.4.4
--- PASS: TestRequestHandler (0.00s)
PASS
ok      github.com/lf-edge/edge-home-orchestration-go/src/controller/discoverymgr/mnedc 0.003s
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
