### PR TITLE
Add support ubuntu_16.04 ubuntu_20.04 to Build workflow

### DIFF
--- a/.github/workflows/edge-home-orchestration-go.yml
+++ b/.github/workflows/edge-home-orchestration-go.yml
@@ -4,7 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
 
@@ -23,5 +27,5 @@ jobs:
 
       - name: Run the Test Suite
         run: |
-          docker stop edge-orchestration
+          docker stop edge-orchestration || true
           gocov test $(go list ./src/... | grep -v src/controller/discoverymgr | grep -v src/controller/servicemgr/executor/containerexecutor | grep -v src/orchestrationapi | grep -v src/common/sigmgr) -coverprofile=/dev/null


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Add Build, Test Suite launch (github->Actions->workflow) on different Ubuntu versions (16.04, 18.04, 20.04) . This will allow you to immediately detect the required dependencies for Edge-Orchestration

## Type of change

- [x] CI update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
