### PR TITLE
Leave TC of sigmgr with MNEDC as comments

### DIFF
--- a/src/common/sigmgr/sigmgr_test.go
+++ b/src/common/sigmgr/sigmgr_test.go
@@ -18,8 +18,6 @@
 package sigmgr
 
 import (
-	"io/ioutil"
-	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -28,44 +26,8 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/src/controller/discoverymgr/mnedc/server"
 )
 
-const (
-	deviceID   = "edge-orchestration-fake"
-	configFile = "client.config"
-	saddr      = "localhost"
-	sport      = "3334"
-)
-
 func TestWatch(t *testing.T) {
-	t.Run("Watch with MNEDC", func(t *testing.T) {
-		defer func() {
-			err := os.Remove(configFile)
-			if err != nil {
-				log.Println("Could not delete file")
-			}
-		}()
-		_, err := server.GetInstance().CreateServer(saddr, sport, false)
-		if err != nil {
-			t.Error(err.Error())
-		} else {
-			server.GetInstance().Run()
-			if _, err := os.Stat(configFile); err != nil {
-				err = ioutil.WriteFile(configFile, []byte(saddr+"\n"+sport), 0644)
-				if err != nil {
-					log.Panicf("Failed to create a mnedc config file %s: %s\n", configFile, err)
-				}
-			}
-			_, err = client.GetInstance().CreateClient(deviceID, configFile, false)
-			if err != nil {
-				t.Error(err.Error())
-			}
-			go func() {
-				time.Sleep(1 * time.Second)
-					syscall.Kill(syscall.Getpid(), syscall.SIGINT)
-			}()
-			Watch()
-		}
-	})
-
+	// TC without MNEDC running
 	t.Run("Watch without MNEDC", func(t *testing.T) {
 		go func() {
 			time.Sleep(1 * time.Second)
@@ -75,4 +37,5 @@ func TestWatch(t *testing.T) {
 		}()
 		Watch()
 	})
+	// TODO: TC needs to be implemented when MNEDC server and client are running.
 }


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description
Leave TC of sigmgr with MNEDC as `TODO` comments because [TC of sigmgr with MNEDC](https://github.com/lf-edge/edge-home-orchestration-go/blob/f7dc122498f3eb9e938a835103fd250c28d4ae6c/src/common/sigmgr/sigmgr_test.go#L39) runs correctly only with 'root' privilege.

## Type of change
- [x] Code cleanup/refactoring

# How Has This Been Tested?
$ go test -v -cover ./src/common/sigmgr/

```
=== RUN   TestWatch
=== RUN   TestWatch/Watch_without_MNEDC
INFO[2021-01-25T10:45:19+09:00]sigmgr.go:43 Watch [sigmgr] Received Signal: interrupt
INFO[2021-01-25T10:45:19+09:00]sigmgr.go:46 Watch [sigmgr] [MNEDC Server] Server not alive
INFO[2021-01-25T10:45:19+09:00]sigmgr.go:52 Watch [sigmgr] [MNEDC Client] Client not alive
--- PASS: TestWatch (1.00s)
    --- PASS: TestWatch/Watch_without_MNEDC (1.00s)
PASS
coverage: 83.3% of statements
ok      github.com/lf-edge/edge-home-orchestration-go/src/common/sigmgr (cached)        coverage: 83.3% of statements
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes