### PR TITLE
Reduction of excluded packages from Test Suite

### DIFF
--- a/.github/workflows/edge-home-orchestration-go.yml
+++ b/.github/workflows/edge-home-orchestration-go.yml
@@ -21,11 +21,12 @@ jobs:
         run: |
           go get github.com/axw/gocov/gocov
           echo "$HOME/go/bin" >> $GITHUB_PATH
-  
+          sudo mkdir -p /var/edge-orchestration/mnedc
+          echo -e '192.168.0.125\n3334' | sudo tee /var/edge-orchestration/mnedc/client.config
       - name: Build the project
         run: ./build.sh
 
       - name: Run the Test Suite
         run: |
           docker stop edge-orchestration || true
-          gocov test $(go list ./src/... | grep -v src/controller/discoverymgr | grep -v src/controller/servicemgr/executor/containerexecutor | grep -v src/orchestrationapi | grep -v src/common/sigmgr) -coverprofile=/dev/null
+          gocov test $(go list ./src/... | grep -v mnedc/client | grep -v mock) -coverprofile=/dev/null


### PR DESCRIPTION
Co-authored-by: Taewan Kim <t25kim@gmail.com>
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Due to the latest changes in the tests that were made by the @t25kim, the following packages were included for testing:
 * src/controller/discoverymgr
 * src/controller/servicemgr/executor/containerexecutor
 * src/orchestrationapi
 * src/common/sigmgr 

Only `mnedc/client` package is currently excluded 

## Type of change

- [x] Test Suite workflow update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
