### PR TITLE
Fix Native and Android Build Failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GO_MOBILE_LDFLAGS	:= -ldflags '-X main.version=$(VERSION) -X main.commitID=$(GO_
 
 # Target parameters
 PKG_NAME		:= edge-orchestration
-OBJ_SRC_DIR		:= interfaces/capi
+OBJ_SRC_DIR		:= $(BASE_DIR)/src/interfaces/capi
 
 # GoMain target
 GOMAIN_DIR      := $(BASE_DIR)/GoMain
@@ -54,7 +54,7 @@ BUILD_VENDOR_DIR	:= $(BASE_DIR)/vendor
 ANDROID_LIBRARY_NAME          := liborchestration
 ANDROID_LIBRARY_FILE          := liborchestration.aar
 ANDROID_JAR_FILE              := liborchestration-sources.jar
-ANDROID_SRC_DIR               := interfaces/javaapi
+ANDROID_SRC_DIR               := $(BASE_DIR)/src/interfaces/javaapi
 ANDROID_LIBRARY_OUT_DIR       := $(BASE_DIR)/src/interfaces/javaapi/output
 
 .DEFAULT_GOAL := help
@@ -82,7 +82,7 @@ build-result:
 ## edge-orchestration android library build
 build-object-java:
 	mkdir -p $(ANDROID_LIBRARY_OUT_DIR)
-	$(GOMOBILE) init
+	rm -rf $(BUILD_VENDOR_DIR)
 	$(GOMOBILE) bind $(GO_MOBILE_LDFLAGS) -o $(ANDROID_LIBRARY_OUT_DIR)/$(ANDROID_LIBRARY_FILE) -target=$(ANDROID_TARGET) -androidapi=23 $(ANDROID_SRC_DIR) || exit 1
 	ls -al $(ANDROID_LIBRARY_OUT_DIR)
 
@@ -101,6 +101,7 @@ test-go:
 ## build clean
 clean:
 	$(GOCLEAN)
+	-rm -rf $(BUILD_VENDOR_DIR)
 	-rm -rf $(INTERFACE_OUT_DIR)
 	-rm -rf $(ANDROID_LIBRARY_OUT_DIR)
 

--- a/build.sh
+++ b/build.sh
@@ -325,6 +325,7 @@ function build_android() {
     echo "-------------------------------------------"
     echo " Create Android archive from Java interface"
     echo "-------------------------------------------"
+
     make build-object-java || exit 1
 }
 
@@ -455,8 +456,8 @@ case "$1" in
                 set_mnedc_client_option $3
                 ;;
         esac
-        go_mod_vendor
         build_clean
+        go_mod_vendor
         if [ "$2" == "secure" ]; then
             build_objects $3
         else

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20160323030313-93e72a773fad // indirect
 	go.etcd.io/bbolt v1.3.5
+	golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f // indirect
 	google.golang.org/grpc v1.34.0 // indirect
 	gopkg.in/ini.v1 v1.62.0
 	gotest.tools v2.2.0+incompatible // indirect


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Native and Android build scripts are modified according to Go Modules.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Install Android SDK and NDK ([Installation Guide](https://github.com/lf-edge/edge-home-orchestration-go/blob/77a6ff585d68f72077a30de601a3c2e0ec16b30b/doc/platforms/x86_64_linux/x86_64_android.md)) 
  **Tested by `ndk;21.3.6528147`, Do not use `ndk;22.0.7026061`.**
2. Run a command below.
$ ./build.sh object x86_64

### Result
```
-----------------------------------
 Build clean
-----------------------------------
GO111MODULE=on go clean
rm -rf /home/t25kim/work/edge-home-orchestration-go/vendor
rm -rf /home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi/output
rm -rf /home/t25kim/work/edge-home-orchestration-go/src/interfaces/javaapi/output

-----------------------------------
 Go Mod Vendor
-----------------------------------
GO111MODULE=on go mod vendor


**********************************
 Target Binary arch is amd64
**********************************

----------------------------------------
 Create Static object of Orchestration
----------------------------------------
mkdir -p /home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi/output/inc/linux_x86-64 /home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi/output/lib/linux_x86-64
CGO_ENABLED=1 GO111MODULE=on go build -ldflags '-extldflags "-static" -X main.version= -X main.commitID=02e6da1 -X main.buildTime=20210127.1850 -X main.buildTags=' -o /home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi/output/lib/linux_x86-64/liborchestration.a -buildmode=c-archive /home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi || exit 1
mv /home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi/output/lib/linux_x86-64/liborchestration.h /home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi/output/inc/linux_x86-64/orchestration.h
ls -al /home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi/output/lib/linux_x86-64
total 37080
drwxrwxr-x 2 t25kim t25kim     4096  1월 27 18:50 .
drwxrwxr-x 3 t25kim t25kim     4096  1월 27 18:50 ..
-rw-rw-r-- 1 t25kim t25kim 37960302  1월 27 18:50 liborchestration.a

**********************************
 Target Binary is for Android
**********************************

-------------------------------------------
 Create Android archive from Java interface
-------------------------------------------
mkdir -p /home/t25kim/work/edge-home-orchestration-go/src/interfaces/javaapi/output
gomobile bind -ldflags '-X main.version= -X main.commitID=02e6da1 -X main.buildTime=20210127.1850 -X main.buildTags=' -o /home/t25kim/work/edge-home-orchestration-go/src/interfaces/javaapi/output/liborchestration.aar -target=android/amd64 -androidapi=23 /home/t25kim/work/edge-home-orchestration-go/src/interfaces/javaapi || exit 1
ls -al /home/t25kim/work/edge-home-orchestration-go/src/interfaces/javaapi/output
total 8388
drwxrwxr-x 2 t25kim t25kim    4096  1월 27 18:50 .
drwxrwxr-x 3 t25kim t25kim    4096  1월 27 18:50 ..
-rw-rw-r-- 1 t25kim t25kim 8566527  1월 27 18:50 liborchestration.aar
-rw-rw-r-- 1 t25kim t25kim   10432  1월 27 18:50 liborchestration-sources.jar


**********************************
 Edge-orchestration Archive
**********************************
tree /home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi/output
/home/t25kim/work/edge-home-orchestration-go/src/interfaces/capi/output
├── inc
│   └── linux_x86-64
│       └── orchestration.h
└── lib
    └── linux_x86-64
        └── liborchestration.a

4 directories, 2 files
tree /home/t25kim/work/edge-home-orchestration-go/src/interfaces/javaapi/output
/home/t25kim/work/edge-home-orchestration-go/src/interfaces/javaapi/output
├── liborchestration.aar
└── liborchestration-sources.jar

0 directories, 2 files
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes