### PR TITLE
[IMPORTANT] Add support all platform for build on github->actions->workflow

### DIFF
--- a/.github/workflows/edge-home-orchestration-go.yml
+++ b/.github/workflows/edge-home-orchestration-go.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch: [x86, x86_64, arm, arm64]
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
@@ -17,16 +18,28 @@ jobs:
         with:
           go-version: '1.15.6'
 
-      - name: Set env vars
+      - name: Set env vars (gocov)
+        if:  ${{ matrix.arch == 'x86_64' }}    
         run: |
           go get github.com/axw/gocov/gocov
           echo "$HOME/go/bin" >> $GITHUB_PATH
           sudo mkdir -p /var/edge-orchestration/mnedc
           echo -e '192.168.0.125\n3334' | sudo tee /var/edge-orchestration/mnedc/client.config
+      - name: Install Qemu
+        if:  ${{ matrix.arch != 'x86_64' }}    
+        run: |        
+          sudo apt-get update
+          sudo apt-get install -y qemu binfmt-support qemu-user-static
+  
       - name: Build the project
-        run: ./build.sh
+        if:  ${{ matrix.arch == 'x86_64' }}    
+        run: ./build.sh 
+
+      - name: Build the container
+        run: ./build.sh container ${{ matrix.arch }}
 
       - name: Run the Test Suite
+        if:  ${{ matrix.arch == 'x86_64' }}
         run: |
           docker stop edge-orchestration || true
           gocov test $(go list ./src/... | grep -v mnedc/client | grep -v mock) -coverprofile=/dev/null


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

**This is a very important commit as it allows you to test the build system of different architectures on different versions of Ubuntu and run Test Suite for `pull_request` and `push`.**

> It should be noted that failure of either does not stop testing on others. And at the same time, in any case, it is possible to merge the code into the `master` branch, but it is desirable that all `Actions` are successful.

| action\arch                      | x86_64 | x86 | arm64 | arm | 
|---------------------------|--------|------|--------|-----|
| ./build.sh                         |     x      |        |            |        |
| ./build.sh container [arch]|     x      |   x    |    x      |    x   |
| Test Suite                        |      x     |        |            |         |
| ./build.sh lint (TBD)          |            |        |            |         |
| ./build.sh object (TBD)     |            |        |            |         |


## Type of change

- [x] New feature 

# How Has This Been Tested?

**Test Configuration**:

Result you can see in Action tab
![изображение](https://user-images.githubusercontent.com/45031429/106187083-d1add900-61ad-11eb-90ec-e056bd5d30c1.png)


* Firmware version: Ubuntu 16.04, 18.04, 20.04
* Hardware: All platforms
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
