### PR TITLE
Update android build documentation

### DIFF
--- a/doc/platforms/x86_64_linux/x86_64_android.md
+++ b/doc/platforms/x86_64_linux/x86_64_android.md
@@ -14,10 +14,15 @@ $ export PATH=$PATH:$ANDROID_SDK/cmdline-tools/tools:$ANDROID_SDK/platform-tools
 - Android NDK
 1. Go to `cmdline-tools/tools/bin` folder and execute following commands:
 ```
-$ ./sdkmanager --install ndk-bundle
+$ ./sdkmanager --list
+```
+Select NDK version from the list (recommended `ndk;21.3.6528147`)
+```
+$ ./sdkmanager --install "ndk;21.3.6528147"
 $ export ANDROID_NDK_HOME=<path to Android NDK directory> 
 $ export PATH=$PATH:$ANDROID_NDK_HOME
 ```
+> `ndk;22.x` is temporarily not supported.
 
 ## How to build
 The general preparation steps are described [here](x86_64_linux.md).


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Due to the temporary inoperability of the NDK 22, the documentation for building of the android platform has been updated. 
This PR is first part to PR #249. 

## Type of change

- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
