### PR TITLE
Change an env in TC in order to avoid a hard-coded credential issue

### DIFF
--- a/src/controller/servicemgr/executor/containerexecutor/containerexecutor_test.go
+++ b/src/controller/servicemgr/executor/containerexecutor/containerexecutor_test.go
@@ -432,11 +432,11 @@ func TestSuccessConvertConfigWithEntryPoint(t *testing.T) {
 
 func TestSuccessConvertConfigEnvOption(t *testing.T) {
 	t.Run("Env", func(t *testing.T) {
-		validStr := []string{"docker", "run", "--env", "MYSQL_ROOT_PASSWORD=password", imageName}
+		validStr := []string{"docker", "run", "--env", "ENV_TEST=env", imageName}
 		container, _, _ := convertConfig(validStr)
 		envs := container.Env
 		for _, env := range envs {
-			if strings.Contains(env, "MYSQL_ROOT_PASSWORD") != true {
+			if strings.Contains(env, "ENV_TEST") != true {
 				t.Fail()
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

SonarCloud detects a [security issue](https://sonarcloud.io/project/security_hotspots?id=lf-edge_edge-home-orchestration-go&hotspots=AXdpfOm7vQYo9bTgUVlP).
This PR changes a key of `env`  from `PASSWORD` to `ENV_TEST` to resolve the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
$ go test -cover ./src/controller/servicemgr/executor/containerexecutor/

### Result of TC
```
t25kim@t25kim:~/work/edge-home-orchestration-go$ go test -cover ./src/controller/servicemgr/executor/containerexecutor/
ok      github.com/lf-edge/edge-home-orchestration-go/src/controller/servicemgr/executor/containerexecutor      0.015s  coverage: 86.1% of statements
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
