### PR TITLE
Add sonarcloud configuration file

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,16 @@
+
+# Path to sources
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/vendor/**,**/third_party/**
+#sonar.inclusions=
+
+# Path to tests
+sonar.tests=.
+sonar.test.exclusions=**/vendor/**,**/third_party/**
+sonar.test.inclusions=**/*_test.go
+
+# Source encoding
+#sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+#sonar.cpd.exclusions=


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@gmail.com>

# Description

A file is added to configure the SonarCloud analyzer.
I would like to note that the use of this configuration file is not intended for automatic testing and may disable it. 
_If you import a project that already contains a sonar-project.properties file, SonarCloud will deem the project ineligible for automatic analysis. You can still force automatic analysis if you choose_ from official documentation.
**Hence this change is for testing purposes and can be reverted!**

Other configuration properties can be added as needed.   

Fixes #254 

## Type of change

- [x] CI update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
