### PR TITLE
Replacing the use of the apt with the apt-get in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ COPY $APP_QEMU_DIR/ /usr/bin/
 RUN mkdir -p $TARGET_DIR/res/
 
 # install required tools
-RUN apt update
-RUN apt install -y net-tools iproute2
+RUN apt-get update
+RUN apt-get install -y net-tools iproute2
 
 # expose ports
 EXPOSE $HTTP_PORT $MDNS_PORT $ZEROCONF_PORT $MNEDC_PORT $MNEDC_BROADCAST_PORT


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@gmail.com>

# Description

During the build of the container, the messages appears:
```
...
Step 16/20 : RUN apt update
 ---> Running in 4c7137e4e486

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```
and 
```
Step 17/20 : RUN apt install -y net-tools iproute2
 ---> Running in 0b020507349a

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```
Replacing the use of the `apt` with the `apt-get` fixes this. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
$ ./build.sh
```
There will be no warning messages. 

**Test Configuration**:
* Firmware version: 18.04
* Hardware: x86-64
* Toolchain: Docker and Go recommended versions
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
