### PR TITLE
Exclude mocks folder from SonarCloud analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,13 +1,13 @@
 
 # Path to sources
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/vendor/**,**/third_party/**
+sonar.exclusions=**/*_test.go,**/vendor/**,**/third_party/**,**/mocks/**
 #sonar.inclusions=
 
 # Path to tests
 sonar.tests=.
 sonar.test.exclusions=**/vendor/**,**/third_party/**
-sonar.test.inclusions=**/*_test.go
+sonar.test.inclusions=**/mocks/**,**/*_test.go
 
 # Source encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@gmail.com>

# Description

At the request of @t25kim, I excluded the `mocks` folder from SonarCloud analysis.
But I want to note that in any case, we need to fight for the cleanness of the code in tests. 

## Type of change

- [x] SonarCloud configuration

# How Has This Been Tested?

See [result](https://sonarcloud.io/dashboard?id=lf-edge_edge-home-orchestration-go)
