### PR TITLE
[MNEDC] Change of DB Clearing logic on Network Signal from Kernel

### DIFF
--- a/src/common/networkhelper/detector/detector_netlink.go
+++ b/src/common/networkhelper/detector/detector_netlink.go
@@ -84,5 +84,5 @@ func detectionHandler(detect netlink.AddrUpdate) bool {
 	}
 
 	log.Println(logPrefix, "[DetectionHandler]", "Disconnected : ", updatedAddr.LinkAddress.IP)
-	return false
+	return true
 }

--- a/src/common/networkhelper/detector/detector_netlink_test.go
+++ b/src/common/networkhelper/detector/detector_netlink_test.go
@@ -37,23 +37,23 @@ func TestAddrSubscribe(t *testing.T) {
 	retTrue := make(chan bool, 1)
 
 	t.Run("Success", func(t *testing.T) {
-		lambdaAddrSubscribe = func(ch chan<- netlink.AddrUpdate) error {
-			ch <- netlink.AddrUpdate{
-				NewAddr: true,
-				LinkAddress: net.IPNet{
-					IP: []byte{'1', '2', '3', '4'},
-				},
+		t.Run("Connected", func(t *testing.T) {
+			lambdaAddrSubscribe = func(ch chan<- netlink.AddrUpdate) error {
+				ch <- netlink.AddrUpdate{
+					NewAddr: true,
+					LinkAddress: net.IPNet{
+						IP: []byte{'1', '2', '3', '4'},
+					},
+				}
+				return nil
 			}
-			return nil
-		}
-		go GetInstance().AddrSubscribe(retTrue)
+			go GetInstance().AddrSubscribe(retTrue)
 
-		ret := <-retTrue
-		if !ret {
-			t.Error("unexpected result")
-		}
-	})
-	t.Run("Error", func(t *testing.T) {
+			ret := <-retTrue
+			if !ret {
+				t.Error("unexpected result")
+			}
+		})
 		t.Run("Disconnected", func(t *testing.T) {
 			lambdaAddrSubscribe = func(ch chan<- netlink.AddrUpdate) error {
 				ch <- netlink.AddrUpdate{
@@ -67,10 +67,12 @@ func TestAddrSubscribe(t *testing.T) {
 			go GetInstance().AddrSubscribe(retTrue)
 
 			ret := <-retTrue
-			if ret {
+			if !ret {
 				t.Error("unexpected result")
 			}
 		})
+	})
+	t.Run("Error", func(t *testing.T) {
 		t.Run("IPisEmpty", func(t *testing.T) {
 			lambdaAddrSubscribe = func(ch chan<- netlink.AddrUpdate) error {
 				ch <- netlink.AddrUpdate{

--- a/src/common/networkhelper/networkhelper.go
+++ b/src/common/networkhelper/networkhelper.go
@@ -212,10 +212,11 @@ func subAddrChange(isNewConnection chan bool) {
 	for {
 		select {
 		// @Note : If network status is changed, need to update network information
-		case ConnectionDetected := <-isNewConnection:
-			log.Println(logPrefix, ConnectionDetected)
-			getNetworkInformationFP()
-			netInfo.Notify(netInfo.GetIPs())
+		case connectionDetected := <-isNewConnection:
+			if connectionDetected == true {
+				getNetworkInformationFP()
+				netInfo.Notify(netInfo.GetIPs())
+			}
 		}
 	}
 	//apply detectorIns.Done when normal termination


### PR DESCRIPTION
Signed-off-by: Sunchit Sharma <sun.sharma@samsung.com>

- Reset DB regarding connected devices when new and del events regarding IPv4 address are up
- SetTUNIP() : Implemented by golang API that give the IP details instead of external ifconfig command
- detectionHandler() returns true when new and del events up

# Description

Connection failure post Network Reset due to multiple network interface events from kernel in a short time. This bug caused a total MNEDC connection break post reset after DBs got cleared. 

Fixes #271 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- A two system setup was taken, Where one system was in Main NAT and other system was in Sub NAT. 
- Main NAT system ran MNEDC Server
- Sub NAT system ran MNEDC Client
- Post this Multiple requests were sent from Sub to Main and Main to Sub and they worked successfully which was verifies from Request outputs and Score Logs

## Logs : While requesting service from Main to Sub

### Request
```
curl -X POST http://localhost:56001/api/v1/orchestration/services --data '{ "ServiceName": "hello-world", "ServiceInfo": [{ "ExecutionType": "container", "ExecCmd":[ "docker", "run", "-v", "/var/run:/var/run:rw", "hello-world"]}], "StatusCallbackURI": "http://localhost:8888/api/v1/services/notification","SelfSelection":"false","ServiceRequester":"curl"}'

{"Message":"ERROR_NONE","RemoteTargetInfo":{"ExecutionType":"container","Target":"10.0.0.2"},"ServiceName":"hello-world"}
```
### Main System Edge Orchestration Logs
```
INFO[2021-02-18T19:30:58Z]orchestrationapi.go:122 RequestService [RequestService] hello-world: [{container [docker run -v /var/run:/var/run:rw hello-world] map[]}] 

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:148 RequestService [RequestService] getCandidate                

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:150 RequestService [0] Id       : edge-orchestration-235d74e7-c62c-464c-8bd8-74443ef41e0c 

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:151 RequestService [0] ExecType : container                     

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:152 RequestService [0] Endpoint : [10.0.0.2]                    

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:153 RequestService                                              

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:150 RequestService [1] Id       : edge-orchestration-5c2e65bb-8ce8-40c8-bf48-248bf766ba9e 

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:151 RequestService [1] ExecType : container                     

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:152 RequestService [1] Endpoint : [192.168.1.29 10.0.0.1]       

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:153 RequestService                                              

INFO[2021-02-18T19:30:59Z]restclient.go:126 DoGetScoreRemoteDevice [restclient] DoGetScoreRemoteDevice : endpoint[10.0.0.2] 

INFO[2021-02-18T19:30:59Z]restclient.go:151 DoGetScoreRemoteDevice [restclient] respMsg From [10.0.0.2] : map[ScoreValue:10.72922950390001] 

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:331 func3 [orchestrationapi] deviceScore               

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:332 func3 candidate Id       : edge-orchestration-235d74e7-c62c-464c-8bd8-74443ef41e0c 

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:333 func3 candidate ExecType : container               

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:334 func3 candidate Endpoint : 10.0.0.2                

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:335 func3 candidate score    : 10.72922950390001       

INFO[2021-02-18T19:30:59Z]restclient.go:67 DoExecuteRemoteDevice [restclient] DoExecuteRemoteDevice : endpoint[10.0.0.2] 

INFO[2021-02-18T19:30:59Z]restclient.go:90 DoExecuteRemoteDevice [restclient] respMsg From [10.0.0.2] : map[Status:Started] 

INFO[2021-02-18T19:30:59Z]orchestrationapi.go:238 RequestService [orchestrationapi]  [{edge-orchestration-235d74e7-c62c-464c-8bd8-74443ef41e0c 10.0.0.2 10.72922950390001 map[] container}] 

INFO[2021-02-18T19:30:59Z]route.go:130 func1 From [[::1]:35426] POST /api/v1/orchestration/services APIV1RequestServicePost 963.373316ms 
```

## Logs : While requesting service from Main to Sub

### Request

```
curl -X POST "192.168.0.222:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d '{ "ServiceName": "hello-world", "ServiceInfo": [{ "ExecutionType": "container", "ExecCmd": [ "docker", "run", "-v", "/var/run:/var/run:rw", "hello-world"]}], "StatusCallbackURI": "http://localhost:8888/api/v1/services/notification", "SelfSelection" : "false"}'

{"Message":"ERROR_NONE","RemoteTargetInfo":{"ExecutionType":"container","Target":"10.0.0.1"},"ServiceName":"hello-world"}
```

### Sub System Edge Orchestration Logs

```
INFO[2021-02-18T19:37:07Z]orchestrationapi.go:122 RequestService [RequestService] hello-world: [{container [docker run -v /var/run:/var/run:rw hello-world] map[]}] 

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:148 RequestService [RequestService] getCandidate                

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:150 RequestService [0] Id       : edge-orchestration-235d74e7-c62c-464c-8bd8-74443ef41e0c 

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:151 RequestService [0] ExecType : container                     

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:152 RequestService [0] Endpoint : [192.168.0.222 10.0.0.2]      

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:153 RequestService                                              

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:150 RequestService [1] Id       : edge-orchestration-5c2e65bb-8ce8-40c8-bf48-248bf766ba9e 

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:151 RequestService [1] ExecType : container                     

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:152 RequestService [1] Endpoint : [10.0.0.1]                    

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:153 RequestService                                              

INFO[2021-02-18T19:37:07Z]restclient.go:126 DoGetScoreRemoteDevice [restclient] DoGetScoreRemoteDevice : endpoint[10.0.0.1] 

INFO[2021-02-18T19:37:07Z]restclient.go:151 DoGetScoreRemoteDevice [restclient] respMsg From [10.0.0.1] : map[ScoreValue:10.418973263495161] 

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:331 func3 [orchestrationapi] deviceScore               

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:332 func3 candidate Id       : edge-orchestration-5c2e65bb-8ce8-40c8-bf48-248bf766ba9e 

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:333 func3 candidate ExecType : container               

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:334 func3 candidate Endpoint : 10.0.0.1                

INFO[2021-02-18T19:37:07Z]orchestrationapi.go:335 func3 candidate score    : 10.418973263495161      

INFO[2021-02-18T19:37:07Z]restclient.go:67 DoExecuteRemoteDevice [restclient] DoExecuteRemoteDevice : endpoint[10.0.0.1] 

INFO[2021-02-18T19:37:09Z]restclient.go:90 DoExecuteRemoteDevice [restclient] respMsg From [10.0.0.1] : map[Status:Started] 

INFO[2021-02-18T19:37:09Z]orchestrationapi.go:238 RequestService [orchestrationapi]  [{edge-orchestration-5c2e65bb-8ce8-40c8-bf48-248bf766ba9e 10.0.0.1 10.418973263495161 map[] container}] 

INFO[2021-02-18T19:37:09Z]route.go:130 func1 From [192.168.0.222:53028] POST /api/v1/orchestration/services APIV1RequestServicePost 1.956543799s 
```

# Logic behind the fix

1. The problem was there because of multiple network interface events from kernel in a short time
2. Because of this during the disconnection the map would some times get cleared and thus IPs were lost resulting in faliure during GET/POST/Scoring
3. Thus, a system level command ifconfig was replaced by go packages that give the IP details neatly and avoid multiple events
4. New connections and Disconnections  were treated alike and network info was reset in both cases as in both cases it needs to be changed.
5. Other methods like timeouts, Retry Logics and IP Comparison in code was also tested for the fix but this fix looked neater and worked on the root cause thus this was raised.

```
Example
1. Describe the reproduction procedures freely.
2. Or list up the test description like :
  - [X] Unittest
  - [X] Execution of Container
  - [X] Execution on top of Native
```


**Test environment configuration:**
* Firmware version:  Ubuntu 16.04
* Hardware: x86-64
* Toolchain: Go 15.1
* Edge Orchestration Release:  Coconut

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
