### PR TITLE
[MNEDC] Update mnedc/client TC

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,4 +1,3 @@
----
 name: Test Suite
 on: [push, pull_request]
 
@@ -27,4 +26,4 @@ jobs:
       - name: Run the Test Suite
         run: |
           make go-vendor
-          gocov test $(go list ./internal/... | grep -v mnedc/client | grep -v mock) -coverprofile=/dev/null
+          gocov test $(go list ./internal/... | grep -v mock) -coverprofile=/dev/null

--- a/docs/testing_policy.md
+++ b/docs/testing_policy.md
@@ -37,14 +37,12 @@ $ ./buils.sh test [PKG_NAME]
 ### 2.2 Using standard Go language facilities
 To start testing all packages:
 ```
-$ gocov test $(go list ./internal/... | grep -v mnedc/client | grep -v mock) -coverprofile=/dev/null
+$ gocov test $(go list ./internal/... | grep -v mock) -coverprofile=/dev/null
 ```
 To start testing a specific package:
 ```
 $ go test -v [PKG_NAME]
 ```
-
-> It should be noted that testing of the `internal/controller/discoverymgr/mnedc/client` package is temporarily not performed due to errors.
     
 ---
 


### PR DESCRIPTION
# Description

TC on 'mnedc/client' sometimes failed due to timing issue.
Fix it by waiting for the goroutine task to be done.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?
Run `mnedc/client` TC
 $ go test -cover ./internal/controller/discoverymgr/mnedc/client

### Result
```
ok      github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc/client     41.181s coverage: 72.0% of statements
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes