### PR TITLE
[Refactoring] Build Script in terms of TC

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,64 +6,6 @@ export BUILD_TAGS=""
 DOCKER_IMAGE="edge-orchestration"
 BINARY_FILE="edge-orchestration"
 
-PKG_LIST=(
-        "common/errormsg"
-        "common/errors"
-        "common/logmgr"
-        "common/networkhelper"
-        "common/networkhelper/detector"
-        "common/resourceutil"
-        "common/resourceutil/cpu"
-        "common/resourceutil/native"
-        "common/resourceutil/types/servicemgrtypes"
-        "common/sigmgr"
-        "common/types/configuremgrtypes"
-        "common/types/servicemgrtypes"
-        "controller/configuremgr"
-        "controller/configuremgr/container"
-        "controller/configuremgr/native"
-        "controller/discoverymgr"
-        "controller/discoverymgr/wrapper"
-        "controller/scoringmgr"
-        "controller/securemgr/verifier"
-        "controller/securemgr/authenticator"
-        "controller/securemgr/authorizer"
-        "controller/servicemgr"
-        "controller/servicemgr/executor"
-        "controller/servicemgr/executor/androidexecutor"
-        "controller/servicemgr/executor/containerexecutor"
-        "controller/servicemgr/executor/nativeexecutor"
-        "controller/servicemgr/notification"
-        "controller/discoverymgr/mnedc"
-        "controller/discoverymgr/mnedc/client"
-        "controller/discoverymgr/mnedc/connectionutil"
-        "controller/discoverymgr/mnedc/server"
-        "controller/discoverymgr/mnedc/tunmgr"
-        "controller/storagemgr"
-        "controller/storagemgr/storagedriver"
-        "db/bolt/common"
-        "db/bolt/configuration"
-        "db/bolt/network"
-        "db/bolt/resource"
-        "db/bolt/service"
-        "db/bolt/system"
-        "db/bolt/wrapper"
-        "db/helper"
-        "interfaces/capi"
-        "interfaces/javaapi"
-        "orchestrationapi"
-        "restinterface"
-        "restinterface/cipher"
-        "restinterface/cipher/dummy"
-        "restinterface/cipher/sha256"
-        "restinterface/client"
-        "restinterface/client/restclient"
-        "restinterface/externalhandler"
-        "restinterface/internalhandler"
-        "restinterface/resthelper"
-        "restinterface/route"
-)
-
 export CONTAINER_VERSION="coconut"
 export BUILD_DATE=$(date +%Y%m%d.%H%M)
 
@@ -180,29 +122,14 @@ function build_test() {
     stop_docker_container
 
     if [[ $1 == "" ]]; then
-        echo ""
-        echo "---------------------------"
-        echo " build test for ALL pkgs"
-        echo "---------------------------"
-        make test-go TEST_PKG_DIRS=./internal/...
+	DIRS=./internal/...
     else
-        idx=0
-        for pkg in "${PKG_LIST[@]}"; do
-            if [[ "$pkg" == *"$1"* ]]; then
-                break
-            fi
-            idx=$((idx+1))
-        done
-        if [ $idx -ge ${#PKG_LIST[@]} ]; then
-            echo ""
-            echo " ERROR!!! There is no package for $1"
-        else
-            echo "---------------------------------------"
-            echo " build test for ${PKG_LIST[$idx]}"
-            echo "---------------------------------------"
-            make test-go TEST_PKG_DIRS=./internal/${PKG_LIST[$idx]}
-        fi
+	DIRS=$1
     fi
+    echo "---------------------------------------"
+    echo " build test for $DIRS"
+    echo "---------------------------------------"
+    make test-go TEST_PKG_DIRS=$DIRS
 }
 
 function lint_src_code() {
@@ -510,7 +437,7 @@ case "$1" in
     *)
         echo "build script"
         echo "Usage:"
-        echo "-------------------------------------------------------------------------------------------------------------------------------------------"
+        echo "---------------------------------------------------------------------------------------------------------------------------------------------------"
         echo "  $0                         : build edge-orchestration by default Docker container"
         echo "  $0 secure                  : build edge-orchestration by default Docker container with secure option"
         echo "  $0 container [Arch]        : build Docker container Arch:{x86, x86_64, arm, arm64}"
@@ -522,8 +449,8 @@ case "$1" in
         echo "  $0 mnedcclient             : build edge-orchestration by default container with MNEDC client running option"
         echo "  $0 mnedcclient secure      : build edge-orchestration by default container with MNEDC client running option in secure mode"
         echo "  $0 clean                   : build clean"
-        echo "  $0 test [PKG_NAME]         : run unittests (optional for PKG_NAME)"
-        echo "-------------------------------------------------------------------------------------------------------------------------------------------"
+        echo "  $0 test [PKG_PATH]         : run unittests (optional for PKG_PATH which is a relative path such as './internal/common/commandvalidator')"
+        echo "---------------------------------------------------------------------------------------------------------------------------------------------------"
         exit 0
         ;;
 esac

--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -78,7 +78,7 @@ edge-orchestration         coconut             502e3c07b01f        3 seconds ago
 ```shell
 build script
 Usage:
--------------------------------------------------------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------------------------------------------------------
   ./build.sh                         : build edge-orchestration by default Docker container
   ./build.sh secure                  : build edge-orchestration by default Docker container with secure option
   ./build.sh container [Arch]        : build Docker container Arch:{x86, x86_64, arm, arm64}
@@ -86,8 +86,8 @@ Usage:
   ./build.sh object [Arch]           : build object (c-object, java-object), Arch:{x86, x86_64, arm, arm64} (default:all)
   ./build.sh object secure [Arch]    : build object (c-object, java-object) with secure option, Arch:{x86, x86_64, arm, arm64} (default:all)
   ./build.sh clean                   : build clean
-  ./build.sh test [PKG_NAME]         : run unittests (optional for PKG_NAME)
--------------------------------------------------------------------------------------------------------------------------------------------
+  ./build.sh test [PKG_PATH]         : run unittests (optional for PKG_PATH which is a relative path such as './internal/common/commandvalidator')
+---------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 > If you build the edge-orchestration as c-object, then a more detailed description can be found [x86_64_native.md](x86_64_native.md)
 


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Refactor `build.sh` file in terms of TC in order to reduce LOC
- Remove PKG_LIST
- Use relative path to run TC
Fixes #278 

## Type of change

- [x] Code cleanup/refactoring
- [x] This change requires a documentation update

# How Has This Been Tested?
Run TC with `./build.sh` file.
- $ ./build.sh test
- $ ./build.sh test ./internal/common/commandvalidator/

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes