### PR TITLE
[MNEDC]Resolving: SonarCloud defects for hardcoded IP

### DIFF
--- a/internal/controller/discoverymgr/mnedc/server/mocks/mocks_server.go
+++ b/internal/controller/discoverymgr/mnedc/server/mocks/mocks_server.go
@@ -227,3 +227,17 @@ func (mr *MockMNEDCServerMockRecorder) TunWriteRoutine() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TunWriteRoutine", reflect.TypeOf((*MockMNEDCServer)(nil).TunWriteRoutine))
 }
+
+// GetVirtualIP mocks base method
+func (m *MockMNEDCServer) GetVirtualIP() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVirtualIP")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetVirtualIP indicates an expected call of GetVirtualIP
+func (mr *MockMNEDCServerMockRecorder) GetVirtualIP() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualIP", reflect.TypeOf((*MockMNEDCServer)(nil).GetVirtualIP))
+}

--- a/internal/controller/discoverymgr/mnedc/servercontrol.go
+++ b/internal/controller/discoverymgr/mnedc/servercontrol.go
@@ -82,7 +82,7 @@ func (ServerImpl) StartMNEDCServer(deviceIDPath string) {
 	}
 
 	startMNEDCBroadcastServer()
-	mnedcServerIns.SetClientIP(deviceID, privateIP, mnedcServerVirtualIP)
+	mnedcServerIns.SetClientIP(deviceID, privateIP, mnedcServerIns.GetVirtualIP())
 
 	return
 }

--- a/internal/controller/discoverymgr/mnedc/servercontrol_test.go
+++ b/internal/controller/discoverymgr/mnedc/servercontrol_test.go
@@ -31,6 +31,7 @@ import (
 	ciphermock "github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/mocks"
 	helpermock "github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper/mocks"
 
+
 	"github.com/golang/mock/gomock"
 )
 
@@ -73,6 +74,7 @@ func TestStartMNEDCServer(t *testing.T) {
 		s := GetServerInstance()
 		mockMnedcServer.EXPECT().CreateServer(gomock.Any(), gomock.Any(), gomock.Any()).Return(&server.Server{}, nil)
 		mockMnedcServer.EXPECT().Run()
+		mockMnedcServer.EXPECT().GetVirtualIP().Return(clientDefaultVirtualIP)
 		mockNetwork.EXPECT().GetOutboundIP().Return(defaultOutboundIP, nil)
 		mockMnedcServer.EXPECT().SetClientIP(gomock.Any(), gomock.Any(), gomock.Any())
 		s.StartMNEDCServer(defaultDeviceIDFilePath)

--- a/internal/controller/discoverymgr/mnedc/types.go
+++ b/internal/controller/discoverymgr/mnedc/types.go
@@ -21,7 +21,6 @@ const (
 	logPrefix            = "[mnedcmgr]"
 	mnedcServerPort      = 3334
 	broadcastServerPort  = 3333
-	mnedcServerVirtualIP = "10.0.0.1"
 	internalPort         = 56002
 	maxAttempts          = 5
 )


### PR DESCRIPTION
Signed-off-by: Sunchit Sharma <sun.sharma@samsung.com>

# Description

1. To avoid hardcoding of MNEDC server IP :
   - Generated a random virtual IP for the server of the type 10.[RANDOM].[RANDOM].1
2. To avoid same Numbers being assigned on every run, Seed for the pseudo-random generator has been randomized according to current time
3. In case of a clash between the Actual(Private) IP and the Virtual IP a new random Virtual IP had been generated.
4. Fixed the Test cased and Generated new mocks as Function Signatures have changed

Fixes #273 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Two systems were set up : One in main NAT other in sub NAT
2. Main NAT system got a random virtual IP which was of the type 10.<RANDOM>.<RANDOM>.1
3. Sub NAT system got the same IP with 2 at the 4th place
4. Requests were sent from both system and they worked fine

#Logs

Main System

> INFO[2021-02-25T12:21:43Z]server.go:390  generateServerIP Virtual IP :    10.195.226.1
> INFO[2021-02-25T12:21:43Z]server.go:391  generateServerIP Private IP :    192.168.1.29

Sub System

> INFO[2021-02-25T12:22:47Z]networkhelper.go:129  [networkmgr] returning   10.195.226.2

Successively, in all runs different IPs were assigned.

```
Example
1. Describe the reproduction procedures freely.
2. Or list up the test description like :
  - [X] Unittest
  - [X] Execution of Container
  - [X] Execution on top of Native
```


**Test environment configuration:**
* Firmware version:  Ubuntu 16.04
* Hardware: x86-64
* Toolchain: Go 15.1
* Edge Orchestration Release:  Coconut

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
