### PR TITLE
[Refactoring] Add a variable storing cipher algorithm for ease of use

### DIFF
--- a/cmd/edge-orchestration/main.go
+++ b/cmd/edge-orchestration/main.go
@@ -109,19 +109,16 @@ func orchestrationInit() error {
 		isSecured = true
 	}
 
+	cipher := dummy.GetCipher(cipherKeyFilePath)
 	if isSecured {
 		verifier.Init(containerWhiteListPath)
 		authenticator.Init(passPhraseJWTPath)
 		authorizer.Init(rbacRulePath)
+		cipher = sha256.GetCipher(cipherKeyFilePath)
 	}
 
 	restIns := restclient.GetRestClient()
-
-	if isSecured {
-		restIns.SetCipher(dummy.GetCipher(cipherKeyFilePath))
-	} else {
-		restIns.SetCipher(sha256.GetCipher(cipherKeyFilePath))
-	}
+	restIns.SetCipher(cipher)
 
 	servicemgr.GetInstance().SetClient(restIns)
 	discoverymgr.GetInstance().SetClient(restIns)
@@ -160,11 +157,9 @@ func orchestrationInit() error {
 	ihandle.SetOrchestrationAPI(internalapi)
 
 	if isSecured {
-		ihandle.SetCipher(dummy.GetCipher(cipherKeyFilePath))
 		ihandle.SetCertificateFilePath(certificateFilePath)
-	} else {
-		ihandle.SetCipher(sha256.GetCipher(cipherKeyFilePath))
 	}
+	ihandle.SetCipher(cipher)
 	restEdgeRouter.Add(ihandle)
 
 	// external rest api
@@ -184,11 +179,9 @@ func orchestrationInit() error {
 
 	if len(mnedc) > 0 {
 		if strings.Compare(strings.ToLower(mnedc), "server") == 0 {
+			mnedcmgr.GetServerInstance().SetCipher(cipher)
 			if isSecured {
-				mnedcmgr.GetServerInstance().SetCipher(dummy.GetCipher(cipherKeyFilePath))
 				mnedcmgr.GetServerInstance().SetCertificateFilePath(certificateFilePath)
-			} else {
-				mnedcmgr.GetServerInstance().SetCipher(sha256.GetCipher(cipherKeyFilePath))
 			}
 			go discoverymgr.GetInstance().StartMNEDCServer(deviceIDFilePath)
 		} else if strings.Compare(strings.ToLower(mnedc), "client") == 0 {
@@ -199,11 +192,9 @@ func orchestrationInit() error {
 		}
 	} else {
 		if strings.Contains(buildTags, "mnedcserver") {
+			mnedcmgr.GetServerInstance().SetCipher(cipher)
 			if isSecured {
-				mnedcmgr.GetServerInstance().SetCipher(dummy.GetCipher(cipherKeyFilePath))
 				mnedcmgr.GetServerInstance().SetCertificateFilePath(certificateFilePath)
-			} else {
-				mnedcmgr.GetServerInstance().SetCipher(sha256.GetCipher(cipherKeyFilePath))
 			}
 			go discoverymgr.GetInstance().StartMNEDCServer(deviceIDFilePath)
 		} else if strings.Contains(buildTags, "mnedcclient") {


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

There are many function calls to set cipher algorithm in orchestrationInit().
Once it is set, the same algorithm will be used continuously to improve convenience and consistency.

Related #275 

## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?
Offload a hello-world container to other edge-orchestrator

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
