### PR TITLE
Fix Runtime Error in terms of DataStorage in Native

### DIFF
--- a/cmd/edge-orchestration/capi/main.go
+++ b/cmd/edge-orchestration/capi/main.go
@@ -82,6 +82,7 @@ import (
 	"unsafe"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
 
 	configuremgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/configuremgr/native"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr"
@@ -177,6 +178,7 @@ func OrchestrationInit() C.int {
 	builder := orchestrationapi.OrchestrationBuilder{}
 	builder.SetWatcher(configuremgr.GetInstance(configPath))
 	builder.SetDiscovery(discoverymgr.GetInstance())
+	builder.SetStorage(storagemgr.GetInstance())
 	builder.SetVerifierConf(verifier.GetInstance())
 	builder.SetScoring(scoringmgr.GetInstance())
 	builder.SetService(servicemgr.GetInstance())


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Due to missing datastorage code during OrchestrationInit() caused a runtime error.
## Error Log
```
t25kim@t25kim:~/work/edge-home-orchestration-go/examples/native$ sudo ./edge-orchestration
INFO[2021-03-29T08:03:41+09:00]main.go:147 OrchestrationInit [interface] OrchestrationInit
INFO[2021-03-29T08:03:41+09:00]main.go:148 OrchestrationInit >>> commitID  :  16a2edf
INFO[2021-03-29T08:03:41+09:00]main.go:149 OrchestrationInit >>> version   :
INFO[2021-03-29T08:03:41+09:00]main.go:150 OrchestrationInit >>> buildTime :  20210329.0802
INFO[2021-03-29T08:03:41+09:00]main.go:151 OrchestrationInit >>> buildTags :
FATA[2021-03-29T08:03:41+09:00]main.go:187 OrchestrationInit [interface] Orchestaration initalize fail
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. [Build HomeEdge for Native](https://github.com/lf-edge/edge-home-orchestration-go/blob/master/docs/platforms/x86_64_linux/x86_64_native.md#how-to-build)
2. [Run HomeEdge on top of Native](https://github.com/lf-edge/edge-home-orchestration-go/blob/master/docs/platforms/x86_64_linux/x86_64_native.md#example-of-using-c-object-liborchestrationc)
```

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
