### PR TITLE
[DataStorage] Change DataStorage configuration path to relative

### DIFF
--- a/internal/controller/storagemgr/storage.go
+++ b/internal/controller/storagemgr/storage.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	dataStorageService = "datastorage"
-	dataStorageFilePath = "/var/edge-orchestration" + "/datastorage/configuration.toml"
+	dataStorageConfPath = "res/configuration.toml"
 )
 
 type Storage interface{
@@ -46,7 +46,7 @@ func GetInstance() Storage {
 	return storageIns
 }
 func (StorageImpl) StartStorage() error {
-	if _, err := os.Stat(dataStorageFilePath); err == nil {
+	if _, err := os.Stat(dataStorageConfPath); err == nil {
 		sd := storagedriver.StorageDriver{}
 		go startup.Bootstrap(dataStorageService, device.Version, &sd)
 		return nil


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

When edge-orchestration is executed in native with DataStorage mode on, 
the "could not load configuration file" error occurs if the conf file is not in the ./res folder. 

## Problem
```
t25kim@t25kim:~/work/edge-home-orchestration-go/examples/native$ sudo ./edge-orchestration
INFO[2021-04-16T15:10:47+09:00]main.go:148 OrchestrationInit [interface] OrchestrationInit
INFO[2021-04-16T15:10:47+09:00]main.go:149 OrchestrationInit >>> commitID  :  37f3e98
INFO[2021-04-16T15:10:47+09:00]main.go:150 OrchestrationInit >>> version   :
INFO[2021-04-16T15:10:47+09:00]main.go:151 OrchestrationInit >>> buildTime :  20210406.1425
INFO[2021-04-16T15:10:47+09:00]main.go:152 OrchestrationInit >>> buildTags :
INFO[2021-04-16T15:10:47+09:00]discovery.go:730 clearAllDeviceInfo [discoverymgr] Delete All Device Info
INFO[2021-04-16T15:10:47+09:00]discovery.go:825 deleteDevice [discoverymgr] [deleteDevice] edge-orchestration-1b302c57-c01d-42b6-afc6-abe47476feb9
INFO[2021-04-16T15:10:47+09:00]networkhelper.go:194 setAddrInfo [networkmgr] addr 10.113.70.227/24
INFO[2021-04-16T15:10:47+09:00]discovery.go:396 setDeviceID [discoverymgr] UUID :  1b302c57-c01d-42b6-afc6-abe47476feb9
INFO[2021-04-16T15:10:47+09:00]discovery.go:537 SetNetwotkArgument [discoverymgr] [10.113.70.227]
INFO[2021-04-16T15:10:47+09:00]discovery.go:568 func1 [deviceDetectionRoutine] edge-orchestration-1b302c57-c01d-42b6-afc6-abe47476feb9
INFO[2021-04-16T15:10:47+09:00]discovery.go:569 func1 [deviceDetectionRoutine] confInfo    : ExecType(native), Platform(linux)
INFO[2021-04-16T15:10:47+09:00]discovery.go:570 func1 [deviceDetectionRoutine] netInfo     : IPv4([10.113.70.227]), RTT(0)
INFO[2021-04-16T15:10:47+09:00]discovery.go:571 func1 [deviceDetectionRoutine] serviceInfo : Services([])
INFO[2021-04-16T15:10:47+09:00]discovery.go:572 func1
INFO[2021-04-16T15:10:47+09:00]native.go:179 getdirname [configuremgr] confPath : /var/edge-orchestration/apps/ls_srv/ls_srv.conf
INFO[2021-04-16T15:10:47+09:00]native.go:147 getServiceInfo [configuremgr] ServiceName: ls
INFO[2021-04-16T15:10:47+09:00]native.go:148 getServiceInfo [configuremgr] ExecutableFileName: ls
level=ERROR ts=2021-04-16T06:10:47.152126853Z app=datastorage source=bootstrap.go:45 msg="could not load configuration file (./res/configuration.toml): open ./res/configuration.toml: no such file or directory"
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Put DataStorage conf files in /var/edge-orchestration/datastorage/ folders.
Run edge-orchestration in Native. 
$ sudo ./edge-orchestration

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes