### PR TITLE
Fix CWE-78, Command built from user-controlled sources

### DIFF
--- a/internal/controller/servicemgr/executor/nativeexecutor/nativeexecutor.go
+++ b/internal/controller/servicemgr/executor/nativeexecutor/nativeexecutor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/notification"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator"
 )
 
 var (
@@ -81,6 +82,13 @@ func (t NativeExecutor) setService() (cmd *exec.Cmd, pid int, err error) {
 		err = errors.New("error: empty parameter")
 		return
 	}
+
+	validator := commandvalidator.CommandValidator{}
+	if err = validator.CheckCommand(t.ServiceName, t.ParamStr); err != nil {
+		log.Println(err.Error())
+		return
+	}
+
 	cmd = exec.Command(t.ParamStr[0], t.ParamStr[1:]...)
 
 	// set "owner" account: need to execute user app

--- a/internal/controller/servicemgr/executor/nativeexecutor/nativeexecutor_test.go
+++ b/internal/controller/servicemgr/executor/nativeexecutor/nativeexecutor_test.go
@@ -20,6 +20,8 @@ package nativeexecutor
 import (
 	"testing"
 
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/types/configuremgrtypes"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor"
 	notificationMock "github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/notification/mocks"
 	clientApiMock "github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/client/mocks"
@@ -61,11 +63,14 @@ func TestExecute(t *testing.T) {
 	gomock.InOrder(
 		noti.EXPECT().InvokeNotification(gomock.Any(), gomock.Any(), gomock.Any()),
 	)
+	validator := commandvalidator.CommandValidator{}
+	info := configuremgrtypes.ServiceInfo{ServiceName: "ls", ExecutableFileName: "ls"}
+	err := validator.AddWhiteCommand(info)
 
-	s := executor.ServiceExecutionInfo{ServiceID: uint64(1), ServiceName: "ls_service", ParamStr: []string{"ls", "-ail"}, NotificationTargetURL: ""}
+	s := executor.ServiceExecutionInfo{ServiceID: uint64(1), ServiceName: "ls", ParamStr: []string{"ls", "-ail"}, NotificationTargetURL: ""}
 
 	tExecutor.SetNotiImpl(noti)
-	err := tExecutor.Execute(s)
+	err = tExecutor.Execute(s)
 
 	if err != nil {
 		t.Error()
@@ -79,11 +84,14 @@ func TestExecuteFailWithEmptyServiceCmd(t *testing.T) {
 	gomock.InOrder(
 		noti.EXPECT().InvokeNotification(gomock.Any(), gomock.Any(), gomock.Any()),
 	)
+	validator := commandvalidator.CommandValidator{}
+	info := configuremgrtypes.ServiceInfo{ServiceName: "ls", ExecutableFileName: "ls"}
+	err := validator.AddWhiteCommand(info)
 
-	s := executor.ServiceExecutionInfo{ServiceID: uint64(1), ServiceName: "ls_service", NotificationTargetURL: ""}
+	s := executor.ServiceExecutionInfo{ServiceID: uint64(1), ServiceName: "ls", NotificationTargetURL: ""}
 
 	tExecutor.SetNotiImpl(noti)
-	err := tExecutor.Execute(s)
+	err = tExecutor.Execute(s)
 
 	if err == nil {
 		t.Error()
@@ -100,11 +108,14 @@ func TestExecuteFailWithInvalidServiceName(t *testing.T) {
 	gomock.InOrder(
 		noti.EXPECT().InvokeNotification(gomock.Any(), gomock.Any(), gomock.Any()),
 	)
+	validator := commandvalidator.CommandValidator{}
+	info := configuremgrtypes.ServiceInfo{ServiceName: "ls", ExecutableFileName: "ls"}
+	err := validator.AddWhiteCommand(info)
 
 	s := executor.ServiceExecutionInfo{ServiceID: uint64(1), ServiceName: "InvalidService", ParamStr: []string{"invalid", "-ail"}, NotificationTargetURL: ""}
 
 	tExecutor.SetNotiImpl(noti)
-	err := tExecutor.Execute(s)
+	err = tExecutor.Execute(s)
 
 	if err == nil {
 		t.Error()
@@ -120,11 +131,14 @@ func TestExecuteFailWithInvalidServiceArgs(t *testing.T) {
 	gomock.InOrder(
 		noti.EXPECT().InvokeNotification(gomock.Any(), gomock.Any(), gomock.Any()),
 	)
+	validator := commandvalidator.CommandValidator{}
+	info := configuremgrtypes.ServiceInfo{ServiceName: "ls", ExecutableFileName: "ls"}
+	err := validator.AddWhiteCommand(info)
 
 	s := executor.ServiceExecutionInfo{ServiceID: uint64(1), ServiceName: "ls", ParamStr: []string{"ls", "InvalidArgs"}, NotificationTargetURL: ""}
 
 	tExecutor.SetNotiImpl(noti)
-	err := tExecutor.Execute(s)
+	err = tExecutor.Execute(s)
 
 	if err == nil {
 		t.Error()


### PR DESCRIPTION
- Checking the command and args before running a native application

Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Fix CWE-78, Command built from user-controlled sources

Fixes #298 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Run TC
```
$ go test -v ./internal/controller/servicemgr/executor/nativeexecutor
```

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes