### PR TITLE
[DataStorage] API for String , Images (png, jpeg)

### DIFF
--- a/configs/datastorage/datastorage-device.yaml
+++ b/configs/datastorage/datastorage-device.yaml
@@ -31,3 +31,24 @@ deviceResources:
         { type: "Float64", readWrite: "RW" , mediaType : "text/plain" }
       units:
         { type: "String", readWrite: "R" }
+  - name: jpeg
+    description: "Jpeg image"
+    properties:
+      value:
+        { type: "Binary", readWrite: "RW" , mediaType : "image/jpeg" }
+      units:
+        { type: "String", readWrite: "R" }
+  - name: png
+    description: "png image"
+    properties:
+      value:
+        { type: "Binary", readWrite: "RW" , mediaType : "image/png" }
+      units:
+        { type: "String", readWrite: "R" }
+  - name: string
+    description: "String"
+    properties:
+      value:
+        { type: "String", readWrite: "RW" , mediaType : "text/plain"}
+      units:
+        { type: "String", readWrite: "R" }

--- a/internal/controller/storagemgr/storagedriver/storagehandler.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler.go
@@ -19,6 +19,7 @@ package storagedriver
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -196,6 +197,12 @@ func deviceHandler(writer http.ResponseWriter, request *http.Request) {
 	handler.processAsyncRequest(writer, request)
 }
 
+func convertToBase64(val []byte) string {
+	// Convert to Base 64
+	Base64Val := b64.StdEncoding.EncodeToString(val)
+	return Base64Val
+}
+
 func (handler StorageHandler) newCommandValue(resourceName string, reading interface{}, valueType models.ValueType) (*models.CommandValue, error) {
 	var result = &models.CommandValue{}
 	var errn error
@@ -214,7 +221,13 @@ func (handler StorageHandler) newCommandValue(resourceName string, reading inter
 		if !ok {
 			return nil, fmt.Errorf(castError, resourceName, "not []byte")
 		}
-		result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		if resourceName == "jpeg" || resourceName == "png" {
+			Base64Val := convertToBase64(val)
+			valueType = models.String
+			result, errn = models.NewCommandValue(resourceName, timestamp, Base64Val, valueType)
+		}else {
+			result, errn = models.NewCommandValue(resourceName, timestamp, val, valueType)
+		}
 
 	case models.Bool:
 		val, err := cast.ToBoolE(reading)


### PR DESCRIPTION
- Added Config to Store String type data.
- Modified the code to be able to store image data (jpeg/png)as Base64 strings.

Signed-off-by: Sunchit Sharma <sun.sharma@samsung.com>

# Description

-Use POST api like "IP:49986/api/v1/resource/datastorage/{string/png/jpeg}" to upload data
### String Example
curl --location --request POST 'http://localhost:49986/api/v1/resource/datastorage/string' \
--header 'Content-Type: text/plain' \
--data-raw 'Hello World'

### PNG Example
curl --location --request POST 'http://localhost:49986/api/v1/resource/datastorage/png' \
--header 'Content-Type: image/png' \
--data-binary '@image.png'

### JPEG Example
curl --location --request POST 'http://localhost:49986/api/v1/resource/datastorage/jpeg' \
--header 'Content-Type: image/jpeg' \
--data-binary '@image.jpg'

Fixes #286 

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Run edgex containers by docker-compose like below.
```
docker-compose -f deployments/datastorage/docker-compose.yml up -d
```
2. Copy DataStorage configuration files(configuration.toml and datastorage-device.yaml) to /var/edge-orchestration/datastorage/
3. Run edge-orchestration
4. Send some requests to upload data like below

```
curl --location --request POST 'http://localhost:49986/api/v1/resource/datastorage/string' \
--header 'Content-Type: text/plain' \
--data-raw 'Samsung'
```

```
curl --location --request POST 'http://localhost:49986/api/v1/resource/datastorage/png' \
--header 'Content-Type: image/png' \
--data-binary '@image.png'
```

5. Check the results from edgex-core-data via a web browser like below :
 http://localhost:48080/api/v1/event/device/datastorage/2

![Get](https://user-images.githubusercontent.com/63772873/117984987-f0e40700-b355-11eb-85dd-2fff5eff3e63.png)

As we can see, strings are normally stored and images can be converted back using a Base64 decoder or online tools. This was done to verify that proper retrieval is possible post storage.

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: v1.0.0

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
