### PR TITLE
Replacing the tls-psk with basic tls. Chain of trust is implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ examples/native/edge-orchestration
 internal/controller/discoverymgr/testDB/*
 internal/controller/storagemgr/storagedriver/tests.log
 
+# Certificates
+cert/
+
 # VS Code
 .vscode/
 

--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -128,6 +128,7 @@ Note that you can visit [Swagger Editor](https://editor.swagger.io/) to graphica
 `/var/edge-orchestration/data/cert/edge-orchestration.key` (Any cert file can be authentication key)
   - Edge Orchestration Docker image
     - Please see the above [How to build](#how-to-build) to know how to build Edge Orchestration Docker image
+  - If you use in secure mode, you must [deploy the key infrastructure](../../secure_manager.md#53-generation-key-infrastructure). 
 
 #### 1. Run Edge Orchestration container
 

--- a/internal/controller/discoverymgr/mnedc/servercontrol.go
+++ b/internal/controller/discoverymgr/mnedc/servercontrol.go
@@ -27,7 +27,7 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc/server"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route/tlspskserver"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route/tlsserver"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/tls"
 )
 
@@ -92,7 +92,7 @@ func startMNEDCBroadcastServer() {
 		http.HandleFunc("/register", handleClientInfo)
 		go http.ListenAndServe(":"+strconv.Itoa(broadcastServerPort), nil)
 	} else {
-		go tlspskserver.TLSPSKServer{}.ListenAndServe(":"+strconv.Itoa(broadcastServerPort), http.HandlerFunc(handleClientInfo))
+		go tlsserver.TLSServer{}.ListenAndServe(":"+strconv.Itoa(broadcastServerPort), http.HandlerFunc(handleClientInfo))
 	}
 }
 

--- a/internal/restinterface/route/route.go
+++ b/internal/restinterface/route/route.go
@@ -31,7 +31,7 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/externalhandler"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route/tlspskserver"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route/tlsserver"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/tls"
 )
 
@@ -109,7 +109,7 @@ func (r RestRouter) listenAndServe() {
 	switch r.IsSetCert {
 	case true:
 		log.Printf("ListenAndServeTLS_For_Inter")
-		go tlspskserver.TLSPSKServer{}.ListenAndServe(":"+strconv.Itoa(ConstInternalPort), r.routerInternal)
+		go tlsserver.TLSServer{}.ListenAndServe(":"+strconv.Itoa(ConstInternalPort), r.routerInternal)
 	default:
 		log.Printf("ListenAndServe_For_Inter")
 		go http.ListenAndServe(":"+strconv.Itoa(ConstInternalPort), r.routerInternal)

--- a/internal/restinterface/route/tlsserver/tlsserver.go
+++ b/internal/restinterface/route/tlsserver/tlsserver.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2019 Samsung Electronics All Rights Reserved.
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,38 +15,28 @@
  *
  *******************************************************************************/
 
-package tlshelper
+package tlsserver
 
 import (
+	"net/http"
+
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
-	"log"
-	"bufio"
-	"errors"
-	"fmt"
-	"net/http"
-	"strconv"
-	"strings"
 )
 
 var (
-	// config        *tls.Config
-	wellKnownPort map[string]string
+	log = logmgr.GetInstance()
 )
 
-type TLSHelper struct{}
-
-func init() {
-	wellKnownPort = map[string]string{
-		"http":  "80",
-		"https": "443",
-	}
-
+type TLSServerListener interface {
+	ListenAndServe(addr string, handler http.Handler)
 }
 
+type TLSServer struct{}
 
-func createClientConfig() (*tls.Config, error) {
+func createServerConfig() (*tls.Config, error) {
 	caCertPEM, err := ioutil.ReadFile("/var/edge-orchestration/data/cert/ca.crt")
 	if err != nil {
 		return nil, err
@@ -64,7 +54,8 @@ func createClientConfig() (*tls.Config, error) {
 	}
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		RootCAs:      roots,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    roots,
 		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
             tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
@@ -74,35 +65,19 @@ func createClientConfig() (*tls.Config, error) {
 }
 
 
-func (TLSHelper) Do(req *http.Request) (*http.Response, error) {
-	if _, err := strconv.Atoi(req.URL.Port()); err != nil {
-		return nil, fmt.Errorf("invalid URL port %q", req.URL.Port())
-	}
+func (TLSServer) ListenAndServe(addr string, handler http.Handler) {
 
-    config, err := createClientConfig()
+	config, err := createServerConfig()
 	if err != nil {
 		log.Fatal("config failed: ", err)
 	}
 
-	tlsconn, err := tls.Dial("tcp", req.URL.Host, config)
+	listener, err := tls.Listen("tcp", addr, config)
 	if err != nil {
-		return nil, err
+		log.Fatal("listen failed: ", err)
 	}
-	defer tlsconn.Close()
 
-	req.Write(tlsconn)
+	defer listener.Close()
 
-	br := bufio.NewReader(tlsconn)
-	resp, err := http.ReadResponse(br, req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != 200 {
-		f := strings.SplitN(resp.Status, " ", 2)
-		if len(f) < 2 {
-			return nil, errors.New("unknown status code")
-		}
-		return nil, errors.New(f[1])
-	}
-	return resp, nil
+	(&http.Server{Handler: handler}).Serve(listener)
 }

--- a/internal/restinterface/route/tlsserver/tlsserver_test.go
+++ b/internal/restinterface/route/tlsserver/tlsserver_test.go
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+
+package tlsserver

--- a/internal/restinterface/tls/tls.go
+++ b/internal/restinterface/tls/tls.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	certFilePath atomic.Value
-	handler      PSKHandler
+	handler	     Handler
 	log          = logmgr.GetInstance()
 )
 
@@ -48,6 +48,11 @@ func SetCertFilePath(path string) {
 
 func GetCertFilePath() string {
 	return certFilePath.Load().(string)
+}
+
+type Handler interface {
+	GetIdentity() string
+	GetKey(identity string) ([]byte, error)
 }
 
 type PSKHandler interface {
@@ -67,7 +72,7 @@ type HasCertificate struct {
 	IsSetCert bool
 }
 
-func SetPSKHandler(h PSKHandler) {
+func SetHandler(h Handler) {
 	handler = h
 }
 

--- a/tools/gen_ca_cert.sh
+++ b/tools/gen_ca_cert.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir -p ./cert
+
+# CA Root Certificate
+# Generate root certificate private key: ca.key
+openssl genrsa -out ./cert/ca.key 2048
+
+# Generate a self-signed root certificate: ca.crt
+openssl req -new -key ./cert/ca.key -x509 -days 3650 -out ./cert/ca.crt -subj /C=KR/ST=Seoul/O="Samsung Electronics"/CN="Home Edge CA Root"

--- a/tools/gen_hen_cert.sh
+++ b/tools/gen_hen_cert.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]
+then
+    echo "Generate Home Edge Node (HEN) Certificate"
+    echo "Usage:"
+    echo "-------------------------------------------------------------------------------"
+    echo "  $0 [IP]             : generate hen certificate for node with IP adrress"
+    echo "Example:"
+    echo "  $0 192.168.0.100    : generate hen certificate for node with 192.168.0.100"
+    echo "-------------------------------------------------------------------------------"
+    exit 1
+fi
+
+mkdir -p ./cert/$1
+
+# Home Edge Node (HEN) Certificate
+# Generate HEN Certificate private key : hen.key
+openssl genrsa -out ./cert/$1/hen.key 2048
+
+# Generate HEN Certificate request: hen.csr
+openssl req -new -nodes -key ./cert/$1/hen.key -out ./cert/$1/hen.csr -subj /C=KR/ST=Seoul/O="Samsung Electronics"/CN="Home Edge Node Certificate"
+
+# Signature HEN Certificate: hen.crt
+openssl x509 -req -extfile <(printf "subjectAltName=IP:$1") -days 365 -in ./cert/$1/hen.csr -CA ./cert/ca.crt -CAkey ./cert/ca.key -CAcreateserial -out ./cert/$1/hen.crt


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

The use of PSK for distributed systems is an unreliable mechanism from protection. This PR is the first step to replace the use of certificate mechanisms.
It should be noted that a chain of trust and use of sessional keys is implemented.

In future will be updated native and java part and refactore code to remove PSK package

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring
- [x] Documentation update
- [ ] This change requires a documentation update

# How Has This Been Tested?
See `docs/secure_manager.md` - 5. TLS part

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64, ARM
* Toolchain: Docker and Go recommended versions
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
