### PR TITLE
[DataStorage] Initial code to create the configuration.toml file while edge-orchestration is running

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opencontainers/selinux v1.8.0 // indirect
+	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/raff/tls-ext v0.0.1
 	github.com/raff/tls-psk v0.0.0

--- a/internal/controller/storagemgr/config/toml.go
+++ b/internal/controller/storagemgr/config/toml.go
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+
+package config
+
+import (
+	toml "github.com/pelletier/go-toml"
+)
+
+type Writable struct {
+	LogLevel	string `toml:"LogLevel,omitempty"`
+}
+
+type Service struct {
+	Host			string		`toml:"Host"`
+	Port			int		`toml:"Port"`
+	ConnectionRetries	int		`toml:"ConnectionRetries,omitempty"`
+	Labels			[]string	`toml:"Labels"`
+	OpenMsg			string		`toml:"OpenMsg,omitempty"`
+	Timeout			int		`toml:"Timeout,omitempty"`
+	EnableAsyncReadings	bool		`toml:"EnableAsyncReadings,omitempty"`
+	AsyncBufferSize		int		`toml:"AsyncBufferSize,omitempty"`
+}
+
+type Registry struct {
+	Host		string	`toml:"Host"`
+	Port		int	`toml:"Port"`
+	Type		string	`toml:"Type"`
+	CheckInterval	string	`toml:"CheckInterval,omitempty"`
+	FailLimit	int	`toml:"FailLimit,omitempty"`
+	FailWaitTime	int	`toml:"FailWaitTime,omitempty"`
+}
+
+type Device struct {
+	DataTransform	bool	`toml:"DataTransform,omitempty"`
+	InitCmd		string	`toml:"InitCmd"`
+	InitCmdArgs	string	`toml:"InitCmdArgs"`
+	MaxCmdOps	int	`toml:"MaxCmdOps,omitempty"`
+	MaxCmdValueLen	int	`toml:"MaxCmdValueLen,omitempty"`
+	RemoveCmd	string	`toml:"RemoveCmd"`
+	RemoveCmdArgs	string	`toml:"RemoveCmdArgs"`
+	ProfilesDir	string	`toml:"ProfilesDir,omitempty"`
+}
+
+type ProtocolProperties map[string]string
+
+type DeviceProperties struct {
+	Name		string				`toml:"Name"`
+	Profile		string				`toml:"Profile"`
+	Description	string				`toml:"Description,omitempty"`
+	Labels		[]string			`toml:"Labels,omitempty"`
+	Protocols	map[string]ProtocolProperties	`toml:"Protocols,omitempty"`
+}
+
+type DeviceList	[]DeviceProperties
+
+type Client struct {
+	Host            string  `toml:"Host"`
+	Port            int     `toml:"Port"`
+	Protocol	string	`toml:"Protocol"`
+	Timeout		int	`toml:"Timeout,omitempty"`
+}
+
+type Clients map[string]Client
+
+type Toml struct {
+	Writable
+	Service
+	Registry
+	Device
+	DeviceList
+	Clients
+}
+
+var (
+	tomlInfo	Toml
+)
+
+func SetWritable(level string) {
+	tomlInfo.Writable = Writable{LogLevel: level}
+}
+
+func SetService(port int, label []string) {
+	tomlInfo.Service = Service{
+		Host: "127.0.0.1",
+		Port: port,
+		ConnectionRetries: 20,
+		Labels: label,
+		OpenMsg: "REST device started",
+		Timeout: 5000,
+		EnableAsyncReadings: true,
+		AsyncBufferSize: 16}
+}
+
+func SetRegistry(host string, port int) {
+	tomlInfo.Registry = Registry{
+		Host: host,
+		Port: port,
+		Type: "consul",
+		CheckInterval: "10s",
+		FailLimit: 3,
+		FailWaitTime: 10}
+}
+
+func SetDevice(dataTransform bool, initCmd string, initCmdArgs string, maxCmdOps int,
+		maxCmdValueLen int, removeCmd string, removeCmdArgs string, profilesDir string) {
+	tomlInfo.Device = Device{
+		DataTransform: dataTransform,
+		InitCmd: initCmd,
+		InitCmdArgs: initCmdArgs,
+		MaxCmdOps: maxCmdOps,
+		MaxCmdValueLen: maxCmdValueLen,
+		RemoveCmd: removeCmd,
+		RemoveCmdArgs: removeCmdArgs,
+		ProfilesDir: profilesDir}
+}
+
+func SetDeviceList(name string, profile string, description string, label []string) {
+	tomlInfo.DeviceList = DeviceList{DeviceProperties{
+		Name: name,
+		Profile: profile,
+		Description: description,
+		Labels: label,
+		Protocols: map[string]ProtocolProperties{ "other":{} }}}
+}
+
+func SetClients(host string, protocol string, timeout int) {
+	tomlInfo.Clients = Clients{
+				"Data":Client{Host:host,
+						Port:48080,
+						Protocol:protocol,
+						Timeout:timeout},
+				"Metadata":Client{Host:host,
+						Port:48081,
+						Protocol:protocol,
+						Timeout:timeout}}
+}
+
+func Marshal() (b []byte, err error) {
+	return toml.Marshal(tomlInfo)
+}

--- a/internal/controller/storagemgr/config/toml_test.go
+++ b/internal/controller/storagemgr/config/toml_test.go
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright 2021 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+
+package config
+
+import (
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
+	"testing"
+)
+
+var (
+	log = logmgr.GetInstance()
+)
+
+func TestToml(t *testing.T) {
+	SetWritable("DEBUG")
+	SetService(49986, nil)
+	SetRegistry("127.0.0.1", 8500)
+	SetDevice(true, "", "", 128, 256, "", "", "./res")
+	SetDeviceList("datastorage", "datastorage", "RESTful Device", []string{"rest", "json"})
+	SetClients("127.0.0.1","http",5000)
+
+	b, err := Marshal()
+	if err != nil {
+		t.Fatal("Unexpected Error")
+	}
+	log.Println(string(b))
+}


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

This PR is the initial code of TOML for creating and modifying DataStorage's configuration.toml file and its attributes (such as device name, host and others) dynamically. 

Related to #302 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Run TC and compare the result log to the [configs/datastorage/configuration.toml](https://github.com/lf-edge/edge-home-orchestration-go/blob/master/configs/datastorage/configuration.toml) file. 
$ go test -v ./internal/controller/storagemgr/config/

### RESULT
```
=== RUN   TestToml
INFO[2021-05-26T15:51:37+09:00]toml_test.go:41 TestToml
[Clients]

  [Clients.Data]
    Host = "127.0.0.1"
    Port = 48080
    Protocol = "http"
    Timeout = 5000

  [Clients.Metadata]
    Host = "127.0.0.1"
    Port = 48081
    Protocol = "http"
    Timeout = 5000

[Device]
  DataTransform = true
  InitCmd = ""
  InitCmdArgs = ""
  MaxCmdOps = 128
  MaxCmdValueLen = 256
  ProfilesDir = "./res"
  RemoveCmd = ""
  RemoveCmdArgs = ""

[[DeviceList]]
  Description = "RESTful Device"
  Labels = ["rest","json"]
  Name = "datastorage"
  Profile = "datastorage"

  [DeviceList.Protocols]

    [DeviceList.Protocols.other]

[Registry]
  CheckInterval = "10s"
  FailLimit = 3
  FailWaitTime = 10
  Host = "127.0.0.1"
  Port = 8500
  Type = "consul"

[Service]
  AsyncBufferSize = 16
  ConnectionRetries = 20
  EnableAsyncReadings = true
  Host = "127.0.0.1"
  Labels = []
  OpenMsg = "REST device started"
  Port = 49986
  Timeout = 5000

[Writable]
  LogLevel = "DEBUG"
--- PASS: TestToml (0.00s)
PASS
ok      github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config     0.001s
```

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
