### PR TITLE
Set service to mdns TXT Records from the environment variable

### DIFF
--- a/internal/controller/discoverymgr/discovery.go
+++ b/internal/controller/discoverymgr/discovery.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net"
+	"os"
 	"reflect"
 	"sync"
 	"time"
@@ -239,9 +240,13 @@ func (d *DiscoveryImpl) ResetServiceName() {
 		return
 	}
 
+	servicEnv := getServiceFromEnv()
 	var serverTXT []string
 	serverTXT = append(serverTXT, confItem.ExecType)
 	serverTXT = append(serverTXT, confItem.Platform)
+	if len(servicEnv) > 0 {
+		serverTXT = append(serverTXT, servicEnv)
+	}
 
 	d.setNewServiceList(serverTXT)
 }
@@ -520,8 +525,12 @@ func setDeviceArgument(deviceUUID string, platform string, executionType string)
 	deviceID = "edge-orchestration-" + deviceUUID
 	hostName = "edge-" + deviceUUID
 
+	servicEnv := getServiceFromEnv()
 	Text = append(Text, platform)
 	Text = append(Text, executionType)
+	if len(servicEnv) > 0 {
+		Text = append(Text, servicEnv)
+	}
 	return
 }
 
@@ -850,6 +859,11 @@ func activeDiscovery() {
 // It Clears Map
 func resetServer(ips []net.IP) {
 	wrapperIns.ResetServer(ips)
+}
+
+// getServiceFromEnv returns the environment variable of service
+func getServiceFromEnv() string {
+	return os.Getenv("SERVICE")
 }
 
 // getMNEDCServerAddress fetches the IP and Port of the server


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

This PR is intended to set a service value to TXT records to advertise the service to other edge-orchestration.

Related #306 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
Run edge-orchestration with an environment variable.

```
$ docker run -it -d --privileged --network="host" --name edge-orchestration -e SERVICE=DataStorage -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
```

## RESULT
```
INFO[2021-06-07T11:25:45Z]discovery.go:577 func1 [deviceDetectionRoutine] edge-orchestration-19b4acfc-a094-4400-8ee9-50f8e6b91d31
INFO[2021-06-07T11:25:45Z]discovery.go:578 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker)
INFO[2021-06-07T11:25:45Z]discovery.go:579 func1 [deviceDetectionRoutine] netInfo     : IPv4([10.113.70.148]), RTT(0)
INFO[2021-06-07T11:25:45Z]discovery.go:580 func1 [deviceDetectionRoutine] serviceInfo : Services([DataStorage])
INFO[2021-06-07T11:25:45Z]discovery.go:581 func1
INFO[2021-06-07T11:25:58Z]discovery.go:577 func1 [deviceDetectionRoutine] edge-orchestration-1b302c57-c01d-42b6-afc6-abe47476feb9
INFO[2021-06-07T11:25:58Z]discovery.go:578 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker)
INFO[2021-06-07T11:25:58Z]discovery.go:579 func1 [deviceDetectionRoutine] netInfo     : IPv4([10.113.70.227]), RTT(0)
INFO[2021-06-07T11:25:58Z]discovery.go:580 func1 [deviceDetectionRoutine] serviceInfo : Services([])
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
