### PR TITLE
Removing all artifacts after cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ clean:
 	-rm -rf $(BUILD_VENDOR_DIR)
 	-rm -rf $(INTERFACE_OUT_DIR)
 	-rm -rf $(ANDROID_LIBRARY_OUT_DIR)
+	-rm -rf $(BASE_DIR)/bin/$(PKG_NAME)*
+	-rm -rf $(BASE_DIR)/coverage.out
+	@make -C examples/native clean
 
 ## check go style and static analysis
 lint:


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description
After executing `./build.sh clean` command, all artifacts must be deleted 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Example
```
$ ./build.sh container arm
```
result: `bin/edge-orchestration` and `bin/edge-orchestration.tar`
```
$. ./build.sh clean
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04, etc.)
* Hardware: x86-64, ARM
* Toolchain: Recommended Docker and Go versions
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
