### PR TITLE
[DataStorage] Connect to the device which is DataStorage service running

### DIFF
--- a/internal/controller/storagemgr/mocks/mocks_storage.go
+++ b/internal/controller/storagemgr/mocks/mocks_storage.go
@@ -48,6 +48,18 @@ func (_m *MockStorage) EXPECT() *MockStorageMockRecorder {
 	return _m.recorder
 }
 
+// GetStatus mocks base method
+func (_m *MockStorage) GetStatus() int {
+	ret := _m.ctrl.Call(_m, "GetStatus")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetStatus indicates an expected call of GetStatus
+func (_mr *MockStorageMockRecorder) GetStatus() *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "GetStatus", reflect.TypeOf((*MockStorage)(nil).GetStatus))
+}
+
 // StartStorage mocks base method
 func (_m *MockStorage) StartStorage(host string) error {
 	ret := _m.ctrl.Call(_m, "StartStorage", host)

--- a/internal/controller/storagemgr/storage.go
+++ b/internal/controller/storagemgr/storage.go
@@ -34,6 +34,7 @@ const (
 )
 
 type Storage interface {
+	GetStatus() int
 	StartStorage(host string) error
 	BuildConfiguration(host string) error
 }
@@ -63,6 +64,11 @@ func init() {
 // GetInstance returns the instance of DataStorage
 func GetInstance() Storage {
 	return storageIns
+}
+
+// GetStatus returns the status value in StorageImpl
+func (s *StorageImpl) GetStatus() int {
+	return s.status
 }
 
 // StartStorage starts a server in terms of DataStorage


### PR DESCRIPTION
- Even if the configuration files are not in the /var/edge-orchestration/datastorage/ folder,
  it will be attached to other device automatically if the device's mdnsTXT contains DataStorage during device discovery.

Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

This PR is intended to connect between devices automatically in terms of DataStorage.
Close #306 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
This test requires 2 devices.

1. Run edge-orchestration with DataStorage service and edgex containers on Device A like below.
```
$ cd deployments/datastorage/
$ docker-compose up -d
$ docker run -it -d --rm --privileged --network="host" --name edge-orchestration -e SERVICE=DataStorage -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
```
2. Build edge-orchestration on Device B.
```
$ ./build.sh
```
3. Check the device profile from edgex with a web browser
 ex) http://localhost:48081/api/v1/deviceprofile

### RESULT
![image](https://user-images.githubusercontent.com/5847128/122324628-14592d80-cf64-11eb-8a49-b74e6391be73.png)

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
