### PR TITLE
[DataStorage] Add a route for a reading that doesn't require device name

### DIFF
--- a/internal/controller/storagemgr/storage.go
+++ b/internal/controller/storagemgr/storage.go
@@ -54,7 +54,7 @@ var (
 
 func init() {
 	deviceID, _ := getDeviceID()
-	deviceName = dataStorageService + "-" + deviceID
+	deviceName = "edge-orchestration-" + deviceID
 	storageIns = &StorageImpl{
 		sd:     storagedriver.StorageDriver{},
 		status: 0,

--- a/internal/controller/storagemgr/storagedriver/storagehandler.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	dbhelper "github.com/lf-edge/edge-home-orchestration-go/internal/db/helper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper"
 	"io/ioutil"
 	"math"
@@ -40,9 +41,15 @@ import (
 const (
 	deviceNameKey     = "deviceName"
 	resourceNameKey   = "resourceName"
-	apiResourceRoute  = clients.ApiBase + "/resource/{" + deviceNameKey + "}/{" + resourceNameKey + "}"
 	handlerContextKey = "StorageHandler"
 	configPath        = "res/configuration.toml"
+
+	apiResourceRoute   = clients.ApiBase + "/resource/{" + deviceNameKey + "}/{" + resourceNameKey + "}"
+	apiWithoutResRoute = clients.ApiBase + "/resource/{" + resourceNameKey + "}"
+)
+
+var (
+	dbIns = dbhelper.GetInstance()
 )
 
 type StorageHandler struct {
@@ -67,6 +74,9 @@ func (handler StorageHandler) Start() error {
 	if err := handler.service.AddRoute(apiResourceRoute, handler.addContext(deviceHandler), http.MethodPost, http.MethodGet); err != nil {
 		return fmt.Errorf("unable to add required route: %s: %s", apiResourceRoute, err.Error())
 	}
+	if err := handler.service.AddRoute(apiWithoutResRoute, handler.addContext(deviceHandler), http.MethodPost, http.MethodGet); err != nil {
+		return fmt.Errorf("unable to add required route: %s: %s", apiWithoutResRoute, err.Error())
+	}
 
 	log.Info(fmt.Sprintf("Route %s added.", apiResourceRoute))
 
@@ -85,11 +95,20 @@ func (handler StorageHandler) addContext(next func(http.ResponseWriter, *http.Re
 func (handler StorageHandler) processAsyncGetRequest(writer http.ResponseWriter, request *http.Request) {
 	vars := mux.Vars(request)
 	deviceName := vars[deviceNameKey]
+	var err error
+	if deviceName == "" {
+		deviceName, err = dbIns.GetDeviceID()
+		if err != nil {
+			log.Error(fmt.Sprint("Fail to get deviceName"))
+			http.Error(writer, fmt.Sprintf("Device not found"), http.StatusNotFound)
+			return
+		}
+	}
 	resourceName := vars[resourceNameKey]
 
 	log.Debug(fmt.Sprintf("Received POST for Device=%s Resource=%s", deviceName, resourceName))
 
-	_, err := handler.service.GetDeviceByName(deviceName)
+	_, err = handler.service.GetDeviceByName(deviceName)
 	if err != nil {
 		log.Error(fmt.Sprintf("Incoming reading ignored. Device '%s' not found", deviceName))
 		http.Error(writer, fmt.Sprintf("Device not found"), http.StatusNotFound)
@@ -124,11 +143,19 @@ func (handler StorageHandler) processAsyncGetRequest(writer http.ResponseWriter,
 func (handler StorageHandler) processAsyncPostRequest(writer http.ResponseWriter, request *http.Request) {
 	vars := mux.Vars(request)
 	deviceName := vars[deviceNameKey]
+	var err error
+	if deviceName == "" {
+		deviceName, err = dbIns.GetDeviceID()
+		if err != nil {
+			log.Error(fmt.Sprint("Fail to get deviceName"))
+			http.Error(writer, fmt.Sprintf("Device not found"), http.StatusNotFound)
+		}
+	}
 	resourceName := vars[resourceNameKey]
 
 	log.Debug(fmt.Sprintf("Received POST for Device=%s Resource=%s", deviceName, resourceName))
 
-	_, err := handler.service.GetDeviceByName(deviceName)
+	_, err = handler.service.GetDeviceByName(deviceName)
 	if err != nil {
 		log.Error(fmt.Sprintf("Incoming reading ignored. Device '%s' not found", deviceName))
 		http.Error(writer, fmt.Sprintf("Device not found"), http.StatusNotFound)


### PR DESCRIPTION
- Use POST/GET api like "IP:49986/api/v1/resource/{Resource Key}"
- For example,
  - curl -X POST "localhost:49986/api/v1/resource/int" -H "accept: text/plain" -H "Content-Type: text/plain" -d 123
  - curl -X GET "localhost:49986/api/v1/resource/int"
- This PR automatically sets the device name to the device ID.

Signed-off-by: Taewan Kim <t25.kim@samsung.com>

Related #319

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
0. Remove configuration files in /var/edge-orchestration/datastorage
```
$ sudo rm -rf /var/edge-orchestration/datastorage/
```
1. Run edge-orchestration with DataStorage service and edgex containers like below.
```
$ cd deployments/datastorage/
$ docker-compose up -d
$ docker run -it -d --rm --privileged --network="host" --name edge-orchestration -e SERVICE=DataStorage -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
```
2. Upload a reading like below.
```
curl -X POST "localhost:49986/api/v1/resource/int" -H "accept: text/plain" -H "Content-Type: text/plain" -d 123
```
3. Download a reading like below.
```
curl -X GET "localhost:49986/api/v1/resource/int"
```

### RESULT
```
t25kim@t25kim:~/edge-home-orchestration-go$ curl -X POST "localhost:49986/api/v1/resource/int" -H "accept: text/plain" -H "Content-Type: text/plain" -d 123
t25kim@t25kim:~/edge-home-orchestration-go$ curl -X GET "localhost:49986/api/v1/resource/int"
[{"id":"94c717ff-ae13-41a0-9432-4b287e29e136","created":1626248773061,"origin":1626248773059540609,"device":"edge-orchestration-4d90eb1e-1b34-4c8d-99f2-9148e57bab72","name":"int","value":"123","valueType":"Int64"}]
```

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
