### PR TITLE
[Refactoring] Adaptation of the build system to use the go1.16.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.6'
+          go-version: '1.16.4'
 
       - name: Install Qemu
         if:  ${{ matrix.arch != 'x86_64c' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Golang
       uses: actions/setup-go@v1
       with:
-        go-version: '1.15.2'
+        go-version: '1.16.4'
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/lint-vet-gofmt-analysis.yml
+++ b/.github/workflows/lint-vet-gofmt-analysis.yml
@@ -11,10 +11,11 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.6'
+          go-version: '1.16.4'
 
       - name: Set env vars (golint)
         run: |
+          go mod tidy
           go get golang.org/x/lint/golint
           echo "$HOME/go/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.15.6'
+          go-version: '1.16.4'
 
       - name: Set env vars (gocov)
         run: |

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ test-go:
 	$(Q) firefox coverage.html &
 
 ## build clean
-clean:
+clean: go.sum
 	$(call print_header, "Build clean")
 	$(Q) $(GOCLEAN)
 	$(Q) -rm -rf $(BUILD_VENDOR_DIR)
@@ -255,6 +255,9 @@ endif
 
 create_context: .config
 
+go.sum:
+	$(Q) $(GOCMD) mod tidy
+
 run:
 	$(call print_header, "Run Docker container ")
 	docker run -it -d \
@@ -267,7 +270,7 @@ run:
                 $(DOCKER_IMAGE):$(CONTAINER_VERSION)
 	$(Q) docker container ls
 
-test:
+test: go.sum
 	$(call print_header, "Build test to calculate Coverage")
 	$(Q) -sudo systemctl stop ${SERVICE_FILE}
 	$(Q) -sudo systemctl status ${SERVICE_FILE}

--- a/go.mod
+++ b/go.mod
@@ -6,25 +6,22 @@ go 1.15
 replace github.com/edgexfoundry/device-sdk-go v1.4.0 => github.com/hahattan/device-sdk-go v1.4.1
 
 require (
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/casbin/casbin v1.9.1
 	github.com/containerd/containerd v1.4.1-0.20201117152358-0edc412565dc // indirect
-	github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7 // indirect
-	github.com/containerd/fifo v0.0.0-20201026212402-0724c46b320c // indirect
-	github.com/containerd/ttrpc v1.0.2 // indirect
-	github.com/containerd/typeurl v1.0.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docker/cli v0.0.0-20201024074417-fd3371eb7df1
 	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20201201034508-7d75c1d40d88+incompatible
 	github.com/docker/go-connections v0.4.0
-	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.4.0
 	github.com/edgexfoundry/device-sdk-go v1.4.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.115
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-ole/go-ole v1.2.5 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/mock v1.4.4
 	github.com/gomodule/redigo v1.8.3
 	github.com/gorilla/mux v1.8.0
@@ -32,15 +29,15 @@ require (
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/leemcloughlin/logfile v0.0.0-20201123203928-cff1c8a30a10
 	github.com/mattn/go-shellwords v1.0.10 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/opencontainers/runc v0.1.1 // indirect
-	github.com/opencontainers/selinux v1.8.0 // indirect
 	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/shirou/gopsutil v3.20.11+incompatible
 	github.com/sirupsen/logrus v1.7.0
+	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/pflag v1.0.3
@@ -50,7 +47,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20160323030313-93e72a773fad // indirect
 	go.etcd.io/bbolt v1.3.5
-	golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f // indirect
+	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 // indirect
 	google.golang.org/grpc v1.34.0 // indirect
 	gopkg.in/ini.v1 v1.62.0
 	gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Fixing the error during the execution of the `make clean` and `make distclean commands using the `go1.16.4` version. 

Fixes #331 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Install Go 1.16.4 version
2. Remove `go.sum` file
3. Execute make clean or make distclean commands

**Result:**
```
$ make clean  V=1
GO111MODULE=on go mod tidy

--------------------------------------
  Build clean
--------------------------------------
GO111MODULE=on go clean
rm -rf /home/virtual-pc/projects/edge-home-orchestration-go/vendor
rm -rf /home/virtual-pc/projects/edge-home-orchestration-go/bin/capi/output
rm -rf /home/virtual-pc/projects/edge-home-orchestration-go/bin/javaapi/output
rm -rf /home/virtual-pc/projects/edge-home-orchestration-go/bin/edge-orchestration*
rm -rf /home/virtual-pc/projects/edge-home-orchestration-go/coverage.out
make -C examples/native clean
make[1]: Entering directory '/home/virtual-pc/projects/edge-home-orchestration-go/examples/native'
make[1]: Leaving directory '/home/virtual-pc/projects/edge-home-orchestration-go/examples/native'

```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Toolchain: Go1.16.4 version
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
