### PR TITLE
Configure automatically based on HW platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BASE_DIR := ${shell pwd | sed -e 's/ /\\ /g'}
+CUR_HW_PLATFORM := $(shell uname -m)
 
 # Control build verbosity
 #  V=1,2: Enable echo of commands
@@ -56,11 +57,11 @@ BIN_FILE	:= $(PKG_NAME)
 
 # Go Library for C-archive
 LIBRARY_NAME		:= liborchestration
-HEADER_FILE			:= orchestration.h
+HEADER_FILE		:= orchestration.h
 LIBRARY_FILE		:= liborchestration.a
 CUR_HEADER_FILE 	:= $(LIBRARY_NAME).h
 CUR_LIBRARY_FILE 	:= $(LIBRARY_NAME).a
-OBJ_SRC_DIR			:= $(CMD_DIR)/edge-orchestration/capi
+OBJ_SRC_DIR		:= $(CMD_DIR)/edge-orchestration/capi
 INTERFACE_OUT_DIR	:= $(BIN_DIR)/capi/output
 
 ifeq ($(CONFIG_ARM),y)
@@ -251,7 +252,29 @@ else ifeq ($(CONFIG_ANDROID),y)
 endif
 
 .config:
+ifndef CONFIGFILE
+ifeq ($(CUR_HW_PLATFORM),x86_64)
+	$(Q) echo "Configure based on "x86_64c
+	$(Q) cp configs/defconfigs/x86_64c .config
+else ifeq ($(CUR_HW_PLATFORM),i386)
+	$(Q) echo "Configure based on "x86c
+	$(Q) cp configs/defconfigs/x86c .config
+else ifeq ($(CUR_HW_PLATFORM),i686)
+	$(Q) echo "Configure based on "x86c
+	$(Q) cp configs/defconfigs/x86c .config
+else ifeq ($(CUR_HW_PLATFORM),aarch64)
+	$(Q) echo "Configure based on "arm64c
+	$(Q) cp configs/defconfigs/arm64c .config
+else ifeq ($(CUR_HW_PLATFORM),armv7l)
+	$(Q) echo "Configure based on "armc
+	$(Q) cp configs/defconfigs/armc .config
+else
+	$(Q) echo "Please create configuration with make create_context CONFIGFILE="
+endif
+else
+	$(Q) echo "Configure based on "$(CONFIGFILE)
 	$(Q) cp configs/defconfigs/$(CONFIGFILE) .config
+endif
 
 create_context: .config
 

--- a/docs/platforms/hikey960/hikey960.md
+++ b/docs/platforms/hikey960/hikey960.md
@@ -53,6 +53,8 @@ $ make distclean
 $ make create_context CONFIGFILE=arm64c
 $ make
 ```
+> If you don't specify CONFIGFILE, it will configure automatically as `arm64c`.
+
 or for protected mode:
 ```shell
 $ make distclean

--- a/docs/platforms/orange_pi3/orange_pi3.md
+++ b/docs/platforms/orange_pi3/orange_pi3.md
@@ -40,6 +40,8 @@ $ make distclean
 $ make create_context CONFIGFILE=arm64c
 $ make
 ```
+> If you don't specify CONFIGFILE, it will configure automatically as `arm64c`.
+
 or for protected mode:
 ```shell
 $ make distclean

--- a/docs/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/docs/platforms/raspberry_pi3/raspberry_pi3.md
@@ -40,6 +40,8 @@ $ make distclean
 $ make create_context CONFIGFILE=armc
 $ make
 ```
+> If you don't specify CONFIGFILE, it will configure automatically as `armc`.
+
 or for protected mode:
 ```shell
 $ make distclean

--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -56,6 +56,8 @@ $ make distclean
 $ make create_context CONFIGFILE=x86_64c
 $ make
 ```
+> If you don't specify CONFIGFILE, it will configure automatically as `x86_64c`.
+
 or for protected mode:
 ```shell
 $ make distclean


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

For user convenience, when `make create_context` is executed, 
the .config file is created automatically according to the HW platform and CONFIG_CONTAINER=y. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# How Has This Been Tested?
Run `make create_context`

**Test Configuration**:
* Firmware version: Ubuntu 20.04, Raspberry Pi OS
* Hardware: x86-64, ARM
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
