### PR TITLE
Add the help, when the create_context command was not entered with al…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ define stop_docker_container
 endef
 
 ##
-all:
+all: check_context
 	make clean
 	$(call go-vendor)
 ifeq ($(CONFIG_CONTAINER),y)
@@ -251,9 +251,20 @@ else ifeq ($(CONFIG_ANDROID),y)
 endif
 
 .config:
+ifeq ($(CONFIGFILE),)
+	$(Q) echo "" ; echo "CONFIGFILE not been specified:"
+	$(Q) echo "  make create_context CONFIGFILE=<configfile>" ; echo "" ; exit 1
+endif
 	$(Q) cp configs/defconfigs/$(CONFIGFILE) .config
 
 create_context: .config
+
+check_context:
+	$(Q) if [ ! -e ${BASE_DIR}/.config ]; then \
+		echo "" ; echo "Edge-Orchestration has not been configured:" ; \
+		echo "  make create_context CONFIGFILE=<configfile>" ; echo "" ; \
+		exit 1 ; \
+	fi
 
 run:
 	$(call print_header, "Run Docker container ")

--- a/docs/platforms/hikey960/hikey960.md
+++ b/docs/platforms/hikey960/hikey960.md
@@ -59,7 +59,10 @@ $ make distclean
 $ make create_context CONFIGFILE=arm64cs
 $ make
 ```
-the build result will be `edge-orchestration.tar` archive that can be found `bin/edge-orchestration.tar`
+
+> To change the configuration file, you must execute the command `make distclean`
+
+The build result will be `edge-orchestration.tar` archive that can be found `bin/edge-orchestration.tar`
 
 Next, need to copy `edge-orchestration.tar` archive to the HiKey960 board and load the image using the command:
 ```shell

--- a/docs/platforms/orange_pi3/orange_pi3.md
+++ b/docs/platforms/orange_pi3/orange_pi3.md
@@ -46,7 +46,10 @@ $ make distclean
 $ make create_context CONFIGFILE=arm64cs
 $ make
 ```
-the build result will be `edge-orchestration.tar` archive that can be found `bin/edge-orchestration.tar`
+
+> To change the configuration file, you must execute the command `make distclean`
+
+The build result will be `edge-orchestration.tar` archive that can be found `bin/edge-orchestration.tar`
 
 Next, need to copy `edge-orchestration.tar` archive to the Paspberry Pi 3 board, install the docker container (see [here](../x86_64_linux/x86_64_linux.md#Build-Prerequisites) only docker part) and load the image using the command:
 ```shell

--- a/docs/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/docs/platforms/raspberry_pi3/raspberry_pi3.md
@@ -46,7 +46,10 @@ $ make distclean
 $ make create_context CONFIGFILE=armcs
 $ make
 ```
-the build result will be `edge-orchestration.tar` archive that can be found `bin/edge-orchestration.tar`
+
+> To change the configuration file, you must execute the command `make distclean`
+
+The build result will be `edge-orchestration.tar` archive that can be found `bin/edge-orchestration.tar`
 
 Next, need to copy `edge-orchestration.tar` archive to the Raspberry Pi 3 board, install the docker container (see [here](../x86_64_linux/x86_64_linux.md#Build-Prerequisites) only docker part) and load the image using the command:
 ```shell

--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -62,6 +62,9 @@ $ make distclean
 $ make create_context CONFIGFILE=x86_64cs
 $ make
 ```
+
+> To change the configuration file, you must execute the command `make distclean`
+
 > To easy change the configuration, you can use the kconfig-frontends. For Ubuntu 20.04 you can execute next command `sudo apt-get install kconfig-frontends`.
 
 After successfully build you can run edge-orchestration by execute next command:


### PR DESCRIPTION
…l the parameters

Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description
An entered prompt if the context is not exixst or create_context command was entered without CONFIGFILE

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

1) Absent `.config`
```
$ make distclean
$ make 
Edge-Orchestration has not been configured:
  make create_context CONFIGFILE=<configfile>

Makefile:263: recipe for target 'check_context' failed
make: *** [check_context] Error 1
```
2) Enter create_context without CONFIGFILE
```
$ make create_context

CONFIGFILE not been specified:
  make create_context CONFIGFILE=<configfile>

Makefile:255: recipe for target '.config' failed
make: *** [.config] Error 1

```
**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
