### PR TITLE
Add support alpine as base docker image of edge-orchestration

### DIFF
--- a/configs/defconfigs/armc_alpine
+++ b/configs/defconfigs/armc_alpine
@@ -1,0 +1,15 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Edge-Home-Orchstration Configuration
+#
+CONFIG_CONFIGFILE="armc_alpine"
+CONFIG_DOCKERFILE="alpine"
+# CONFIG_X86_64 is not set
+# CONFIG_X86 is not set
+CONFIG_ARM=y
+# CONFIG_ARM64 is not set
+CONFIG_CONTAINER=y
+# CONFIG_NATIVE is not set
+# CONFIG_ANDROID is not set
+# CONFIG_MNEDC is not set
+# CONFIG_SECURE_MODE is not set

--- a/configs/defconfigs/x86_64c_alpine
+++ b/configs/defconfigs/x86_64c_alpine
@@ -1,0 +1,15 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Edge-Home-Orchstration Configuration
+#
+CONFIG_CONFIGFILE="x86_64c_alpine"
+CONFIG_DOCKERFILE="alpine"
+CONFIG_X86_64=y
+# CONFIG_X86 is not set
+# CONFIG_ARM is not set
+# CONFIG_ARM64 is not set
+CONFIG_CONTAINER=y
+# CONFIG_NATIVE is not set
+# CONFIG_ANDROID is not set
+# CONFIG_MNEDC is not set
+# CONFIG_SECURE_MODE is not set

--- a/configs/defdockerfiles/alpine
+++ b/configs/defdockerfiles/alpine
@@ -1,0 +1,49 @@
+# Docker image for "edge-orchestration"
+### alpine:3.12
+ARG PLATFORM
+FROM $PLATFORM/alpine:3.12
+
+# environment variables
+ENV TARGET_DIR=/edge-orchestration
+ENV HTTP_PORT=56001
+ENV MDNS_PORT=5353
+ENV MNEDC_PORT=3334
+ENV MNEDC_BROADCAST_PORT=3333
+ENV ZEROCONF_PORT=42425
+ENV APP_BIN_DIR=bin
+ENV APP_NAME=edge-orchestration
+ENV APP_QEMU_DIR=$APP_BIN_DIR/qemu
+ENV BUILD_DIR=build
+
+# copy files
+COPY $APP_BIN_DIR/$APP_NAME $BUILD_DIR/package/run.sh $TARGET_DIR/
+COPY $APP_QEMU_DIR/ /usr/bin/
+RUN mkdir -p $TARGET_DIR/res/
+
+# install required tools
+RUN apk update
+RUN apk search net-tools
+RUN apk add net-tools
+RUN apk search iproute2
+RUN apk add iproute2
+
+RUN apk --no-cache add wget ca-certificates libstdc++
+ARG APK_GLIBC_VERSION=2.29-r0
+ARG APK_GLIBC_FILE="glibc-${APK_GLIBC_VERSION}.apk"
+ARG APK_GLIBC_BIN_FILE="glibc-bin-${APK_GLIBC_VERSION}.apk"
+ARG APK_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${APK_GLIBC_VERSION}"
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+    && wget "${APK_GLIBC_BASE_URL}/${APK_GLIBC_FILE}"       \
+    && apk --no-cache add "${APK_GLIBC_FILE}"               \
+    && wget "${APK_GLIBC_BASE_URL}/${APK_GLIBC_BIN_FILE}"   \
+    && apk --no-cache add "${APK_GLIBC_BIN_FILE}"           \
+    && rm glibc-*
+
+# expose ports
+EXPOSE $HTTP_PORT $MDNS_PORT $ZEROCONF_PORT $MNEDC_PORT $MNEDC_BROADCAST_PORT
+
+# set the working directory
+WORKDIR $TARGET_DIR
+
+# kick off the edge-orchestration container
+CMD ["ash", "run.sh"]

--- a/configs/defdockerfiles/ubuntu
+++ b/configs/defdockerfiles/ubuntu
@@ -1,7 +1,5 @@
 # Docker image for "edge-orchestration"
-# TODO - need to reduce base image of edge-orchestration
-### ubuntu:16.04 image size is 119MB
-### alpine:3.6 image size is 4MB
+### ubuntu:16.04
 ARG PLATFORM
 FROM $PLATFORM/ubuntu:16.04
 


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

Co-authored-by: Vitalii55 <vitaliyt75@gmail.com.com>

# Description

In collaboration with Vitalii55, we have prepared support for the Alpine as a basic image for the edge-orchestration. The size of the image is up to 55Mb 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

For x86_64
```
$ make distclean
$ make create_context CONFIGFILE=x86_64c_alpine
$ make 
```
or for arm
```
$ make distclean
$ make create_context CONFIGFILE=armc_alpine
$ make 
```

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64, ARM
* Toolchain: Docker and Go recommended versions
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
