### PR TITLE
[DataStorage] Add a route that doesn't require device name parameter for multiple readings

### DIFF
--- a/internal/controller/storagemgr/storagedriver/storagehandler.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler.go
@@ -45,9 +45,10 @@ const (
 	configPath        = "res/configuration.toml"
 	numberOfReadings  = "readingCount"
 
-	apiResourceRoute         = clients.ApiBase + "/device/{" + deviceNameKey + "}/resource/{" + resourceNameKey + "}"
-	apiResourceRouteMultiple = clients.ApiBase + "/device/{" + deviceNameKey + "}/resource/{" + resourceNameKey + "}/{" + numberOfReadings + "}"
-	apiWithoutResRoute       = clients.ApiBase + "/resource/{" + resourceNameKey + "}"
+	apiResourceRoute           = clients.ApiBase + "/device/{" + deviceNameKey + "}/resource/{" + resourceNameKey + "}"
+	apiResourceRouteMultiple   = clients.ApiBase + "/device/{" + deviceNameKey + "}/resource/{" + resourceNameKey + "}/{" + numberOfReadings + "}"
+	apiWithoutResRoute         = clients.ApiBase + "/resource/{" + resourceNameKey + "}"
+	apiWithoutResRouteMultiple = clients.ApiBase + "/resource/{" + resourceNameKey + "}/{" + numberOfReadings + "}"
 )
 
 var (
@@ -72,6 +73,7 @@ func NewStorageHandler(service *sdk.DeviceService, logger logger.LoggingClient, 
 	return &handler
 }
 
+// Start adds routes to DataStorage
 func (handler StorageHandler) Start() error {
 	if err := handler.service.AddRoute(apiResourceRoute, handler.addContext(deviceHandler), http.MethodPost, http.MethodGet); err != nil {
 		return fmt.Errorf("unable to add required route: %s: %s", apiResourceRoute, err.Error())
@@ -83,10 +85,9 @@ func (handler StorageHandler) Start() error {
 	if err := handler.service.AddRoute(apiResourceRouteMultiple, handler.addContext(deviceHandler), http.MethodGet); err != nil {
 		return fmt.Errorf("unable to add required route: %s: %s", apiResourceRouteMultiple, err.Error())
 	}
-
-	log.Info(fmt.Sprintf("Route %s added.", apiResourceRoute))
-	log.Info(fmt.Sprintf("Route %s added.", apiResourceRouteMultiple))
-
+	if err := handler.service.AddRoute(apiWithoutResRouteMultiple, handler.addContext(deviceHandler), http.MethodGet); err != nil {
+		return fmt.Errorf("unable to add required route: %s: %s", apiWithoutResRouteMultiple, err.Error())
+	}
 	return nil
 }
 
@@ -152,6 +153,7 @@ func (handler StorageHandler) processAsyncGetRequest(writer http.ResponseWriter,
 	handler.helper.Response(writer, resp, http.StatusOK)
 }
 
+// processGetAsyncRequest is used to handle Async POST Requests
 func (handler StorageHandler) processAsyncPostRequest(writer http.ResponseWriter, request *http.Request) {
 	vars := mux.Vars(request)
 	deviceName := vars[deviceNameKey]


### PR DESCRIPTION
- Use GET api like "IP:49986/api/v1/resource/{Resource Key}/{Reading Count}"

Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Readings from edgex would be fetched with this PR.

Related #319

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
0. Remove configuration files in /var/edge-orchestration/datastorage
```
$ sudo rm -rf /var/edge-orchestration/datastorage/
```
1. Run edge-orchestration with DataStorage service and edgex containers like below.
```
$ cd deployments/datastorage/
$ docker-compose up -d
$ docker run -it -d --rm --privileged --network="host" --name edge-orchestration -e SERVICE=DataStorage -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
```
2. Upload reading like below.
```
curl -X POST "localhost:49986/api/v1/resource/int" -H "accept: text/plain" -H "Content-Type: text/plain" -d 123
curl -X POST "localhost:49986/api/v1/resource/int" -H "accept: text/plain" -H "Content-Type: text/plain" -d 456
curl -X POST "localhost:49986/api/v1/resource/int" -H "accept: text/plain" -H "Content-Type: text/plain" -d 789
```
3. Download a reading like below.
```
curl -X GET "localhost:49986/api/v1/resource/int/5"
```

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

### RESULT
```
[{"id":"fff6bcf6-1173-432c-bfd7-1251d6ca00d1","created":1626939648581,"origin":1626939648581591841,"device":"edge-orchestration-c1b23cc6-0767-400a-9cf0-36e1b3902da2","name":"int","value":"789","valueType":"Int64"},{"id":"32ce1379-c0ff-4db3-a4e9-c7d8ad9206c5","created":1626939648576,"origin":1626939648574651216,"device":"edge-orchestration-c1b23cc6-0767-400a-9cf0-36e1b3902da2","name":"int","value":"456","valueType":"Int64"},{"id":"420c717e-d2d4-402b-a2fa-b7fc7f4de7cd","created":1626939648569,"origin":1626939648568198215,"device":"edge-orchestration-c1b23cc6-0767-400a-9cf0-36e1b3902da2","name":"int","value":"123","valueType":"Int64"}]
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
