### PR TITLE
Update Go compiler version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.6'
 
       - name: Install Qemu
         if:  ${{ matrix.arch != 'x86_64c' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Golang
       uses: actions/setup-go@v1
       with:
-        go-version: '1.16.4'
+        go-version: '1.16.6'
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/lint-vet-gofmt-staticcheck-analysis.yml
+++ b/.github/workflows/lint-vet-gofmt-staticcheck-analysis.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.6'
 
       - name: Set env vars (golint)
         run: |

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.4'
+          go-version: '1.16.6'
 
       - name: Set env vars (gocov)
         run: |

--- a/docs/platforms/orange_pi3/orange_pi3.md
+++ b/docs/platforms/orange_pi3/orange_pi3.md
@@ -72,11 +72,11 @@ $ newgrp docker
 > For [execution of docker commands with non-root privileges](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) you need to add `$USER` to docker group.  
 `$ sudo usermod -aG docker $USER`
 
-- go compiler (install a version not lower than 1.12.5)
+- go compiler (install a version not lower than 1.16.2, recommended v1.16.6))
 
 ```sh
-$ wget https://dl.google.com/go/go1.16.2.linux-arm64.tar.gz
-$ tar -C $HOME -xvf go1.16.2.linux-arm64.tar.gz
+$ wget https://dl.google.com/go/go1.16.6.linux-arm64.tar.gz
+$ tar -C $HOME -xvf go1.16.6.linux-arm64.tar.gz
 $ export GOPATH=$HOME/go
 $ export PATH=$PATH:$GOPATH/bin
 ```

--- a/docs/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/docs/platforms/raspberry_pi3/raspberry_pi3.md
@@ -70,11 +70,11 @@ $ newgrp docker
 > For [execution of docker commands with non-root privileges](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) you need to add `$USER` to docker group.  
 `$ sudo usermod -aG docker $USER`
 
-- go compiler (install a version not lower than 1.12.5, recommended v1.14.x)
+- go compiler (install a version not lower than 1.16.2, recommended v1.16.6)
 
 ```sh 
-$ wget https://dl.google.com/go/go1.14.5.linux-armv6l.tar.gz
-$ sudo tar -C /usr/local -xvf go1.14.5.linux-armv6l.tar.gz
+$ wget https://dl.google.com/go/go1.16.6.linux-armv6l.tar.gz
+$ sudo tar -C /usr/local -xvf go1.16.6.linux-armv6l.tar.gz
 $ export GOPATH=$HOME/go
 $ export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
 ```

--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -38,7 +38,7 @@ Please see the below [How to work](#how-to-work) to know how to run Edge Orchest
 `$ sudo usermod -aG docker $USER`
 
 - go compiler
-    - Version: 1.15 (or above)
+    - Version: 1.16.6 (or above)
     - [How to install](https://golang.org/dl/)
 
 > To build Edge Orchestrator from Go sources, you need to set GOPATH environment variable:  


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Due to the need to interact with edgex 2.0.0, a requirement has arisen to use the new version of the Go1.16 compiler

Fixes #325 

## Type of change

- [x] Documentation update

# How Has This Been Tested?

Install stable go version (v1.16.6) and build project or see result `Actions -> build` for  this PR

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64, ARM)
* Toolchain: Docker and Go 1.16.6 versions
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
