### PR TITLE
[Refactoring] Export the getServerIP function

### DIFF
--- a/internal/controller/storagemgr/config/toml.go
+++ b/internal/controller/storagemgr/config/toml.go
@@ -153,3 +153,12 @@ func SetClients(host string, protocol string, timeout int) {
 func TomlMarshal() (b []byte, err error) {
 	return toml.Marshal(tomlInfo)
 }
+
+// GetServerIP is used to obtain server IP from the configuration.toml file
+func GetServerIP(ConfigPath string) (string, int, error) {
+	config, err := toml.LoadFile(ConfigPath)
+	if err != nil {
+		return "", 0, err
+	}
+	return config.Get("Clients.Data.Host").(string), (int)(config.Get("Clients.Data.Port").(int64)), nil
+}

--- a/internal/controller/storagemgr/storagedriver/storagehandler.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config"
 	dbhelper "github.com/lf-edge/edge-home-orchestration-go/internal/db/helper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper"
 	"io/ioutil"
@@ -35,7 +36,6 @@ import (
 	sdk "github.com/edgexfoundry/device-sdk-go/pkg/service"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/pelletier/go-toml"
 )
 
 const (
@@ -134,7 +134,7 @@ func (handler StorageHandler) processAsyncGetRequest(writer http.ResponseWriter,
 		return
 	}
 
-	serverIP, readingPort, err := getServerIP(configPath)
+	serverIP, readingPort, err := config.GetServerIP(configPath)
 
 	if err != nil {
 		http.Error(writer, fmt.Sprintf("Configuration File Not Found"), http.StatusNotFound)
@@ -498,12 +498,4 @@ func checkFloatValueRange(valueType models.ValueType, val float64) bool {
 		}
 	}
 	return isValid
-}
-
-func getServerIP(ConfigPath string) (string, int, error) {
-	config, err := toml.LoadFile(ConfigPath)
-	if err != nil {
-		return "", 0, err
-	}
-	return config.Get("Clients.Data.Host").(string), (int)(config.Get("Clients.Data.Port").(int64)), nil
 }


### PR DESCRIPTION
The getServerIP function is moved to toml file in storagemgr/config to improve usability.

Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description

This function is exported to toml.go to improve its usability. This function is used to obtain the server IP using the config path to create request URL

Fixes #321

## Type of change
- [X] Code cleanup/refactoring

# How Has This Been Tested?
1. The code was build and edge-orchestration container was run after starting the EdgeX containers
2. The changes were tested using GET and POST API calls using dummy data
  
**Test Configuration**:
* Firmware version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (1.0.0)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
