### PR TITLE
[DataStorage] Refactor functions and update test code

### DIFF
--- a/internal/controller/storagemgr/storagedriver/storagehandler.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler.go
@@ -206,9 +206,9 @@ func (handler StorageHandler) processAsyncPostRequest(writer http.ResponseWriter
 	readingType := models.ParseValueType(deviceResource.Properties.Value.Type)
 
 	if readingType == models.Binary {
-		reading, err = handler.readBodyAsBinary(writer, request)
+		reading, err = handler.readBodyAsBinary(request)
 	} else {
-		reading, err = handler.readBodyAsString(writer, request)
+		reading, err = handler.readBodyAsString(request)
 	}
 
 	if err != nil {
@@ -236,7 +236,7 @@ func (handler StorageHandler) processAsyncPostRequest(writer http.ResponseWriter
 	handler.asyncValues <- asyncValues
 }
 
-func (handler StorageHandler) readBodyAsString(writer http.ResponseWriter, request *http.Request) (string, error) {
+func (handler StorageHandler) readBodyAsString(request *http.Request) (string, error) {
 	if request.Body == nil {
 		return "", fmt.Errorf("no request body provided")
 	}
@@ -254,7 +254,7 @@ func (handler StorageHandler) readBodyAsString(writer http.ResponseWriter, reque
 	return string(body), nil
 }
 
-func (handler StorageHandler) readBodyAsBinary(writer http.ResponseWriter, request *http.Request) ([]byte, error) {
+func (handler StorageHandler) readBodyAsBinary(request *http.Request) ([]byte, error) {
 	if request.Body == nil {
 		return nil, fmt.Errorf("no request body provided")
 	}

--- a/internal/controller/storagemgr/storagedriver/storagehandler_test.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,11 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/pkg/models"
 	sdk "github.com/edgexfoundry/device-sdk-go/pkg/service"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+const (
+	unexpectedSuccess = "unexpected success"
+	unexpectedFail    = "unexpected fail"
 )
 
 var handler *StorageHandler
@@ -40,15 +46,6 @@ func TestMain(m *testing.M) {
 
 	handler = NewStorageHandler(service, logger, asyncValues)
 	os.Exit(m.Run())
-}
-
-func TestReadasBinary(t *testing.T) {
-
-	req := httptest.NewRequest(http.MethodPost, "http://0.0.0.0:12345", nil)
-
-	handler.readBodyAsString(nil, req)
-
-	handler.readBodyAsBinary(nil, req)
 }
 
 func TestNewCommandValue(t *testing.T) {
@@ -201,4 +198,48 @@ func TestStorageDriver(t *testing.T) {
 	sd.HandleWriteCommands("TestDeviuce", nil, nil, nil)
 	sd.RemoveDevice("TestingDevice", nil)
 	sd.Stop(true)
+}
+
+func TestReadBodyAsString(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://0.0.0.0:12345", strings.NewReader("test"))
+		_, err := handler.readBodyAsString(req)
+		if err != nil {
+			t.Error(unexpectedFail)
+		}
+	})
+	t.Run("Fail", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://0.0.0.0:12345", nil)
+		_, err := handler.readBodyAsString(req)
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+		req.Body = nil
+		_, err = handler.readBodyAsString(req)
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+	})
+}
+
+func TestReadBodyAsBinary(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://0.0.0.0:12345", strings.NewReader("test"))
+		_, err := handler.readBodyAsBinary(req)
+		if err != nil {
+			t.Error(unexpectedFail)
+		}
+	})
+	t.Run("Fail", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "http://0.0.0.0:12345", nil)
+		_, err := handler.readBodyAsBinary(req)
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+		req.Body = nil
+		_, err = handler.readBodyAsBinary(req)
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+	})
 }


### PR DESCRIPTION
- The unused parameter is removed from readBodyAsString() and readBodyAsBinary().
- Test cases for readBodyAsString() and readBodyAsBinary() are implemented.

Signed-off-by: Taewan Kim <t25.kim@samsung.com>

## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?
Run unit testing for storagedriver package.
$ make test ./internal/controller/storagemgr/storagedriver/

Result : 51.00% ( before 49.40% )
```
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     checkValueInRange                       100.00% (13/13)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     checkUintValueRange                     100.00% (12/12)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     checkIntValueRange                      100.00% (10/10)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     checkFloatValueRange                    100.00% (7/7)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.AddDevice                 100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     NewStorageHandler                       100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.Stop                      100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.HandleWriteCommands       100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.RemoveDevice              100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.HandleReadCommands        100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.UpdateDevice              100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.readBodyAsString         88.89% (8/9)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.readBodyAsBinary         88.89% (8/9)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.newCommandValue          88.06% (59/67)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.processAsyncPostRequest  0.00% (0/47)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.processAsyncGetRequest   0.00% (0/35)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.Start                    0.00% (0/9)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     deviceHandler                           0.00% (0/8)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.Initialize                0.00% (0/4)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     getServerIP                             0.00% (0/4)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     convertToBase64                         0.00% (0/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     @96:26                                  0.00% (0/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.addContext               0.00% (0/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver                       --------------------------------------  51.00% (127/249)

Total Coverage: 51.00% (127/249)
```
**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: v1.0.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
