### PR TITLE
[DataStorage] Fix golint warnings

### DIFF
--- a/internal/controller/storagemgr/config/toml.go
+++ b/internal/controller/storagemgr/config/toml.go
@@ -21,10 +21,12 @@ import (
 	toml "github.com/pelletier/go-toml"
 )
 
+// Writable contains the configuration for the DataStorage log.
 type Writable struct {
 	LogLevel string `toml:"LogLevel,omitempty"`
 }
 
+// Service contains the configuration for the DataStorage service.
 type Service struct {
 	Host                string   `toml:"Host"`
 	Port                int      `toml:"Port"`
@@ -36,6 +38,7 @@ type Service struct {
 	AsyncBufferSize     int      `toml:"AsyncBufferSize,omitempty"`
 }
 
+// Registry contains the configuration for the DataStorage in terms of the Registry server.
 type Registry struct {
 	Host          string `toml:"Host"`
 	Port          int    `toml:"Port"`
@@ -45,6 +48,7 @@ type Registry struct {
 	FailWaitTime  int    `toml:"FailWaitTime,omitempty"`
 }
 
+// Device contains the configuration for the DataStorage device.
 type Device struct {
 	DataTransform  bool   `toml:"DataTransform,omitempty"`
 	InitCmd        string `toml:"InitCmd"`
@@ -56,8 +60,10 @@ type Device struct {
 	ProfilesDir    string `toml:"ProfilesDir,omitempty"`
 }
 
+// ProtocolProperties is a map of device protocols.
 type ProtocolProperties map[string]string
 
+// DeviceProperties contains the configuration for a specific device.
 type DeviceProperties struct {
 	Name        string                        `toml:"Name"`
 	Profile     string                        `toml:"Profile"`
@@ -66,8 +72,10 @@ type DeviceProperties struct {
 	Protocols   map[string]ProtocolProperties `toml:"Protocols,omitempty"`
 }
 
+// DeviceList is a list of the DevicesPropertieses.
 type DeviceList []DeviceProperties
 
+// Client contains other service information for DataStroage.
 type Client struct {
 	Host     string `toml:"Host"`
 	Port     int    `toml:"Port"`
@@ -75,8 +83,10 @@ type Client struct {
 	Timeout  int    `toml:"Timeout,omitempty"`
 }
 
+// Clients is a map of Clients.
 type Clients map[string]Client
 
+// Toml contains the struct for building the DataStorage configuration file.
 type Toml struct {
 	Writable
 	Service
@@ -90,10 +100,12 @@ var (
 	tomlInfo Toml
 )
 
+// SetWritable configures the Writable information.
 func SetWritable(level string) {
 	tomlInfo.Writable = Writable{LogLevel: level}
 }
 
+// SetService configures the Service information.
 func SetService(host string, port int, label []string) {
 	tomlInfo.Service = Service{
 		Host:                host,
@@ -106,6 +118,7 @@ func SetService(host string, port int, label []string) {
 		AsyncBufferSize:     16}
 }
 
+// SetRegistry configures the Registry information.
 func SetRegistry(host string, port int) {
 	tomlInfo.Registry = Registry{
 		Host:          host,
@@ -116,6 +129,7 @@ func SetRegistry(host string, port int) {
 		FailWaitTime:  10}
 }
 
+// SetDevice configures the Device's common information.
 func SetDevice(dataTransform bool, initCmd string, initCmdArgs string, maxCmdOps int,
 	maxCmdValueLen int, removeCmd string, removeCmdArgs string, profilesDir string) {
 	tomlInfo.Device = Device{
@@ -129,6 +143,7 @@ func SetDevice(dataTransform bool, initCmd string, initCmdArgs string, maxCmdOps
 		ProfilesDir:    profilesDir}
 }
 
+// SetDeviceList configures the specific Device information
 func SetDeviceList(name string, profile string, description string, label []string) {
 	tomlInfo.DeviceList = DeviceList{DeviceProperties{
 		Name:        name,
@@ -138,6 +153,7 @@ func SetDeviceList(name string, profile string, description string, label []stri
 		Protocols:   map[string]ProtocolProperties{"other": {}}}}
 }
 
+// SetClients configures the service information in terms of Data and Metadata.
 func SetClients(host string, protocol string, timeout int) {
 	tomlInfo.Clients = Clients{
 		"Data": Client{Host: host,
@@ -150,6 +166,7 @@ func SetClients(host string, protocol string, timeout int) {
 			Timeout:  timeout}}
 }
 
+// TomlMarshal returns bytes for DataStorage configuration.
 func TomlMarshal() (b []byte, err error) {
 	return toml.Marshal(tomlInfo)
 }

--- a/internal/controller/storagemgr/config/yaml.go
+++ b/internal/controller/storagemgr/config/yaml.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// Yaml contains the struct for building the DataStorage Device Resources configuration.
 type Yaml struct {
 	Name            string           `yaml:"name"`
 	Manufacturer    string           `yaml:"manufacturer"`
@@ -30,17 +31,22 @@ type Yaml struct {
 	DeviceResources []DeviceResource `yaml:"deviceResources,omitempty"`
 }
 
+// DeviceResource contains the resource information.
 type DeviceResource struct {
 	Name        string   `yaml:"name"`
 	Description string   `yaml:"description,omitempty"`
 	Properties  Property `yaml:"properties"`
 }
 
+// Property has the value and units properties.
 type Property struct {
 	Value PropertyDetail `yaml:"value,flow"`
 	Units PropertyDetail `yaml:"units,flow"`
 }
 
+// PropertyDetail contains the specific property(Value and Units) information.
+// Type : bool, int8 - int64, uint8 - uint64, float32, float64, string, binary types are supported.
+// ReadWrite : R, RW, or W
 type PropertyDetail struct {
 	Type      string `yaml:"type"`
 	ReadWrite string `yaml:"readWrite"`
@@ -51,6 +57,7 @@ var (
 	yamlInfo Yaml
 )
 
+// SetYaml configures the device resource information.
 func SetYaml(name, manufac, model, desc string, labels []string, resources []DeviceResource) {
 	yamlInfo = Yaml{
 		Name:            name,
@@ -61,6 +68,7 @@ func SetYaml(name, manufac, model, desc string, labels []string, resources []Dev
 		DeviceResources: resources}
 }
 
+// YamlMarshal returns bytes for DataStorage device resource configuration.
 func YamlMarshal() (b []byte, err error) {
 	return yaml.Marshal(yamlInfo)
 }

--- a/internal/controller/storagemgr/config/yaml_test.go
+++ b/internal/controller/storagemgr/config/yaml_test.go
@@ -27,7 +27,7 @@ var (
 	testModel        = "Home Edge"
 	testLabel        = []string{"rest", "json", "numeric", "float", "int"}
 	testDescription  = "REST Device"
-	testPropertyJson = Property{
+	testPropertyJSON = Property{
 		Value: PropertyDetail{
 			Type:      "String",
 			ReadWrite: "RW",
@@ -79,7 +79,7 @@ var (
 		{
 			Name:        "json",
 			Description: "json",
-			Properties:  testPropertyJson},
+			Properties:  testPropertyJSON},
 		{
 			Name:       "int",
 			Properties: testPropertyInt},

--- a/internal/controller/storagemgr/storage.go
+++ b/internal/controller/storagemgr/storage.go
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  *******************************************************************************/
+
 package storagemgr
 
 import (
@@ -33,12 +34,14 @@ const (
 	deviceIDFilePath      = "/var/edge-orchestration/device/orchestration_deviceID.txt"
 )
 
+// Storage is the interface for starting DataStorage.
 type Storage interface {
 	GetStatus() int
 	StartStorage(host string) error
 	BuildConfiguration(host string) error
 }
 
+// StorageImpl has DataStorage's driver and status data.
 // status = 0 : No action
 // status = 1 : Completed to build configuration files
 // status = 2 : Running DataStorage
@@ -130,7 +133,7 @@ func saveYaml() (err error) {
 	model := "Home Edge"
 	label := []string{"rest", "json", "int", "float", "jpeg", "png", "string"}
 	description := "REST Device"
-	propertyJson := config.Property{
+	propertyJSON := config.Property{
 		Value: config.PropertyDetail{
 			Type:      "String",
 			ReadWrite: "RW",
@@ -181,7 +184,7 @@ func saveYaml() (err error) {
 	resource := []config.DeviceResource{
 		{
 			Name:       "json",
-			Properties: propertyJson},
+			Properties: propertyJSON},
 		{
 			Name:       "int",
 			Properties: propertyInt},

--- a/internal/controller/storagemgr/storagedriver/storagedriver.go
+++ b/internal/controller/storagemgr/storagedriver/storagedriver.go
@@ -29,6 +29,7 @@ import (
 
 const logPrefix = "[storagedriver]"
 
+// StorageDriver has a logger and a channel for the device service.
 type StorageDriver struct {
 	logger      logger.LoggingClient
 	asyncValues chan<- *dsModels.AsyncValues
@@ -38,7 +39,7 @@ var (
 	log = logmgr.GetInstance()
 )
 
-// Initialize performs protocol-specific initialization for the device
+// Initialize performs protocol-specific initialization for the device service.
 func (driver *StorageDriver) Initialize(logger logger.LoggingClient, asyncValues chan<- *dsModels.AsyncValues, deviceCh chan<- []dsModels.DiscoveredDevice) error {
 	log.Println(logPrefix, "Device service intialize started")
 	driver.logger = logger
@@ -65,6 +66,7 @@ func (driver *StorageDriver) Stop(force bool) error {
 	return nil
 }
 
+// AddDevice is a callback function that is invoked
 // when a new Device associated with this Device Service is added
 func (driver *StorageDriver) AddDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error {
 
@@ -73,6 +75,7 @@ func (driver *StorageDriver) AddDevice(deviceName string, protocols map[string]c
 	return nil
 }
 
+// UpdateDevice is a callback function that is invoked
 // when a Device associated with this Device Service is updated
 func (driver *StorageDriver) UpdateDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error {
 
@@ -80,6 +83,7 @@ func (driver *StorageDriver) UpdateDevice(deviceName string, protocols map[strin
 	return nil
 }
 
+// RemoveDevice is a callback function that is invoked
 // when a Device associated with this Device Service is removed
 func (driver *StorageDriver) RemoveDevice(deviceName string, protocols map[string]contract.ProtocolProperties) error {
 

--- a/internal/controller/storagemgr/storagedriver/storagehandler.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler.go
@@ -38,12 +38,14 @@ import (
 	"github.com/pelletier/go-toml"
 )
 
+type ctxKey string
+
 const (
-	deviceNameKey     = "deviceName"
-	resourceNameKey   = "resourceName"
-	handlerContextKey = "StorageHandler"
-	configPath        = "res/configuration.toml"
-	numberOfReadings  = "readingCount"
+	deviceNameKey            = "deviceName"
+	resourceNameKey          = "resourceName"
+	handlerContextKey ctxKey = "StorageHandler"
+	configPath               = "res/configuration.toml"
+	numberOfReadings         = "readingCount"
 
 	apiResourceRoute           = clients.ApiBase + "/device/{" + deviceNameKey + "}/resource/{" + resourceNameKey + "}"
 	apiResourceRouteMultiple   = clients.ApiBase + "/device/{" + deviceNameKey + "}/resource/{" + resourceNameKey + "}/{" + numberOfReadings + "}"
@@ -55,6 +57,7 @@ var (
 	dbIns = dbhelper.GetInstance()
 )
 
+// StorageHandler provides necessary struct for running DataStorage.
 type StorageHandler struct {
 	service     *sdk.DeviceService
 	logger      logger.LoggingClient
@@ -62,6 +65,7 @@ type StorageHandler struct {
 	helper      resthelper.RestHelper
 }
 
+// NewStorageHandler creates and returns a handler for DataStorage.
 func NewStorageHandler(service *sdk.DeviceService, logger logger.LoggingClient, asyncValues chan<- *models.AsyncValues) *StorageHandler {
 	handler := StorageHandler{
 		service:     service,
@@ -143,8 +147,8 @@ func (handler StorageHandler) processAsyncGetRequest(writer http.ResponseWriter,
 
 	readingAPI := "/api/v1/reading/name/" + resourceName + "/device/" + deviceName + "/" + readingCount
 
-	requestUrl := handler.helper.MakeTargetURL(serverIP, readingPort, readingAPI)
-	resp, _, err := handler.helper.DoGet(requestUrl)
+	requestURL := handler.helper.MakeTargetURL(serverIP, readingPort, readingAPI)
+	resp, _, err := handler.helper.DoGet(requestURL)
 	if err != nil {
 		http.Error(writer, "Resource not found", http.StatusNotFound)
 		return


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description
With #354, this PR fixes the golint warnings as follows.
```
internal/controller/storagemgr/storage.go:1:1: package comment should be of the form "Package storagemgr ..."
internal/controller/storagemgr/storage.go:36:6: exported type Storage should have comment or be unexported
internal/controller/storagemgr/storage.go:42:1: comment on exported type StorageImpl should be of the form "StorageImpl ..." (with optional leading article)
internal/controller/storagemgr/storage.go:133:2: var propertyJson should be propertyJSON
internal/controller/storagemgr/config/toml.go:24:6: exported type Writable should have comment or be unexported
internal/controller/storagemgr/config/toml.go:28:6: exported type Service should have comment or be unexported
internal/controller/storagemgr/config/toml.go:39:6: exported type Registry should have comment or be unexported
internal/controller/storagemgr/config/toml.go:48:6: exported type Device should have comment or be unexported
internal/controller/storagemgr/config/toml.go:59:6: exported type ProtocolProperties should have comment or be unexported
internal/controller/storagemgr/config/toml.go:61:6: exported type DeviceProperties should have comment or be unexported
internal/controller/storagemgr/config/toml.go:69:6: exported type DeviceList should have comment or be unexported
internal/controller/storagemgr/config/toml.go:71:6: exported type Client should have comment or be unexported
internal/controller/storagemgr/config/toml.go:78:6: exported type Clients should have comment or be unexported
internal/controller/storagemgr/config/toml.go:80:6: exported type Toml should have comment or be unexported
internal/controller/storagemgr/config/toml.go:93:1: exported function SetWritable should have comment or be unexported
internal/controller/storagemgr/config/toml.go:97:1: exported function SetService should have comment or be unexported
internal/controller/storagemgr/config/toml.go:109:1: exported function SetRegistry should have comment or be unexported
internal/controller/storagemgr/config/toml.go:119:1: exported function SetDevice should have comment or be unexported
internal/controller/storagemgr/config/toml.go:132:1: exported function SetDeviceList should have comment or be unexported
internal/controller/storagemgr/config/toml.go:141:1: exported function SetClients should have comment or be unexported
internal/controller/storagemgr/config/toml.go:153:1: exported function TomlMarshal should have comment or be unexported
internal/controller/storagemgr/config/yaml.go:24:6: exported type Yaml should have comment or be unexported
internal/controller/storagemgr/config/yaml.go:33:6: exported type DeviceResource should have comment or be unexported
internal/controller/storagemgr/config/yaml.go:39:6: exported type Property should have comment or be unexported
internal/controller/storagemgr/config/yaml.go:44:6: exported type PropertyDetail should have comment or be unexported
internal/controller/storagemgr/config/yaml.go:54:1: exported function SetYaml should have comment or be unexported
internal/controller/storagemgr/config/yaml.go:64:1: exported function YamlMarshal should have comment or be unexported
internal/controller/storagemgr/config/yaml_test.go:30:2: var testPropertyJson should be testPropertyJSON
internal/controller/storagemgr/error/errorconstants.go:23:2: exported const DSInitializeError should have comment (or a comment on this block) or be unexported
internal/controller/storagemgr/storagedriver/storagedriver.go:32:6: exported type StorageDriver should have comment or be unexported
internal/controller/storagemgr/storagedriver/storagedriver.go:68:1: comment on exported method StorageDriver.AddDevice should be of the form "AddDevice ..."
internal/controller/storagemgr/storagedriver/storagedriver.go:76:1: comment on exported method StorageDriver.UpdateDevice should be of the form "UpdateDevice ..."
internal/controller/storagemgr/storagedriver/storagedriver.go:83:1: comment on exported method StorageDriver.RemoveDevice should be of the form "RemoveDevice ..."
internal/controller/storagemgr/storagedriver/storagehandler.go:58:6: exported type StorageHandler should have comment or be unexported
internal/controller/storagemgr/storagedriver/storagehandler.go:65:1: exported function NewStorageHandler should have comment or be unexported
internal/controller/storagemgr/storagedriver/storagehandler.go:97:10: should not use basic type string as key in context.WithValue
internal/controller/storagemgr/storagedriver/storagehandler.go:146:2: var requestUrl should be requestURL
```
Related to #353 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup/refactoring

# How Has This Been Tested?
$ golint ./internal/controller/storagemgr/...

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: v1.0.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
