### PR TITLE
fix lint warnings

### DIFF
--- a/internal/controller/securemgr/authenticator/authenticator.go
+++ b/internal/controller/securemgr/authenticator/authenticator.go
@@ -34,8 +34,8 @@ import (
 	jwt "github.com/golang-jwt/jwt/v4"
 )
 
-// AuthenticatorImpl structure
-type AuthenticatorImpl struct{}
+// AuthenticationImpl structure
+type AuthenticationImpl struct{}
 
 const (
 	passPhraseJWTFileName = "passPhraseJWT.txt"
@@ -45,7 +45,7 @@ const (
 var (
 	logPrefix             = "[securemgr: authenticator]"
 	log                   = logmgr.GetInstance()
-	authenticatorIns      *AuthenticatorImpl
+	authenticatorIns      *AuthenticationImpl
 	passphrase            = []byte{}
 	passPhraseJWTFilePath = ""
 	initialized           = false
@@ -54,7 +54,7 @@ var (
 )
 
 func init() {
-	authenticatorIns = new(AuthenticatorImpl)
+	authenticatorIns = new(AuthenticationImpl)
 }
 
 var alphabet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/internal/controller/securemgr/authorizer/authorizer.go
+++ b/internal/controller/securemgr/authorizer/authorizer.go
@@ -29,8 +29,8 @@ import (
 	"github.com/casbin/casbin"
 )
 
-// AuthorizerImpl structure
-type AuthorizerImpl struct{}
+// AuthorizationImpl structure
+type AuthorizationImpl struct{}
 
 const (
 	rbacPolicyFileName = "policy.csv"
@@ -52,14 +52,14 @@ var (
 	log                   = logmgr.GetInstance()
 	rbacPolicyFilePath    = ""
 	rbacAuthModelFilePath = ""
-	authorizerIns         *AuthorizerImpl
+	authorizerIns         *AuthorizationImpl
 	initialized           = false
 	users                 Users
 	enf                   *casbin.Enforcer
 )
 
 func init() {
-	authorizerIns = new(AuthorizerImpl)
+	authorizerIns = new(AuthorizationImpl)
 }
 
 // User structure describes user properties

--- a/internal/controller/securemgr/verifier/verifier.go
+++ b/internal/controller/securemgr/verifier/verifier.go
@@ -37,14 +37,14 @@ const (
 	NotAllowedCommand = "NOT_ALLOWED_COMMAND"
 )
 
-// VerifierImpl structure
-type VerifierImpl struct{}
+// VerificationImpl structure
+type VerificationImpl struct{}
 
 var (
 	containerWhiteList []string
 	logPrefix          = "[securemgr: verifier]"
 	log                = logmgr.GetInstance()
-	verifierIns        *VerifierImpl
+	verifierIns        *VerificationImpl
 	initialized        = false
 	cwlFilePath        = ""
 )
@@ -74,7 +74,7 @@ type VerifierConf interface {
 }
 
 func init() {
-	verifierIns = new(VerifierImpl)
+	verifierIns = new(VerificationImpl)
 }
 
 // initContainerWhiteList fills the containerWhiteList by reading the information
@@ -99,8 +99,8 @@ func initContainerWhiteList() error {
 	return err
 }
 
-// GetInstance gives the VerifierImpl singletone instance
-func GetInstance() *VerifierImpl {
+// GetInstance gives the VerificationImpl singletone instance
+func GetInstance() *VerificationImpl {
 	return verifierIns
 }
 
@@ -136,7 +136,7 @@ func Init(cwlPath string) {
 }
 
 // ContainerIsInWhiteList checks if the containerName is in containerWhiteList
-func (VerifierImpl) ContainerIsInWhiteList(containerName string) error {
+func (VerificationImpl) ContainerIsInWhiteList(containerName string) error {
 	if !initialized {
 		return nil
 	}
@@ -239,7 +239,7 @@ func printAllHashFromContainerWhiteList() {
 }
 
 // RequestVerifierConf is Verifier configuration request handler
-func (verifier *VerifierImpl) RequestVerifierConf(containerInfo RequestVerifierConf) ResponseVerifierConf {
+func (verifier *VerificationImpl) RequestVerifierConf(containerInfo RequestVerifierConf) ResponseVerifierConf {
 	log.Printf("%s command type: %s\n", logPrefix, containerInfo.CmdType)
 	switch containerInfo.CmdType {
 	case "addHashCWL":

--- a/internal/restinterface/route/tlsserver/tlsserver.go
+++ b/internal/restinterface/route/tlsserver/tlsserver.go
@@ -30,10 +30,12 @@ var (
 	log = logmgr.GetInstance()
 )
 
-type TLSServerListener interface {
+// TLSListenerServer provides insterface for tlsserver
+type TLSListenerServer interface {
 	ListenAndServe(addr string, handler http.Handler)
 }
 
+// TLSServer structure
 type TLSServer struct{}
 
 func createServerConfig() (*tls.Config, error) {
@@ -64,6 +66,7 @@ func createServerConfig() (*tls.Config, error) {
 	}, nil
 }
 
+// ListenAndServe listens HTTPS connection and calls Serve with handler to handle requests on incoming connections.
 func (TLSServer) ListenAndServe(addr string, handler http.Handler) {
 
 	config, err := createServerConfig()


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

PR fixes the golint warnings, except one: _type name will be used as verifier.VerifierConf by other packages, and that stutters; consider calling this Conf_. Replacing this name can lead to confusion, in addition, the `staticcheck` does not take into account this as a warning

Related to #353 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup/refactoring

# How Has This Been Tested?
```
$ golint ./internal/restinterface/route/tlsserver/...
$ golint ./internal/controller/securemgr/...
```
**Test Configuration**:
* Firmware version: Ubuntu 18.04, etc.)
* Hardware: x86-64
* Edge Orchestration Release: v1.0.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
