### PR TITLE
Update the installation procedure of testing packages

### DIFF
--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -46,6 +46,7 @@ Please see the below [How to work](#how-to-work) to know how to run Edge Orchest
 `$ export PATH=$PATH:$GOPATH/bin`
 
 - extra Go utilities: (optional)
+> Recommendation: Do not install the `gocov` and `gocov-html` utilities from the `edge-home-orchestration-go` folder.
   - [gocov](https://pkg.go.dev/github.com/axw/gocov)
   ```
   $ go get github.com/axw/gocov/gocov

--- a/docs/testing_policy.md
+++ b/docs/testing_policy.md
@@ -23,7 +23,7 @@ The Edge Orchestration team strongly recommends adhering to the [Test-driven dev
 
 ## 2. How to start Test Suite (Local)
 
-> Make sure the `gocov` and `gocov-html` packages are installed [(How to install)](https://github.com/matm/gocov-html#installation)
+> Make sure the `gocov` and `gocov-html` packages are installed [(How to install)](https://github.com/matm/gocov-html#installation). Recommendation: Do not install these utilities from the `edge-home-orchestration-go` folder.
 
 There are two ways to test:
 ### 2.1 Using the makefile

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
-	github.com/axw/gocov v1.0.0 // indirect
 	github.com/casbin/casbin v1.9.1
 	github.com/containerd/containerd v1.4.1-0.20201117152358-0edc412565dc // indirect
 	github.com/docker/cli v0.0.0-20201024074417-fd3371eb7df1
@@ -29,7 +28,6 @@ require (
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/leemcloughlin/logfile v0.0.0-20201123203928-cff1c8a30a10
-	github.com/matm/gocov-html v0.0.0-20200509184451-71874e2e203b // indirect
 	github.com/mattn/go-shellwords v1.0.10 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Background:
When installing `gocov` and `gocov-html` packages with the `edge-home-orchestration-go ` folder, a description is added to the `go.mod` file. (go.mod is a tracked by the GitHub) The `go mod tidy` command makes check and optimize dependencies and since the packages are not included in the source code will be excluded from `go.mod`file. Therefore, `go.mod` file will always be marked as modified.

Update the installation procedure of `gocov` and `gocov-html`
 
## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
