### PR TITLE
[DataStorage] BugFix for Device not found in cache(Issue #312)

### DIFF
--- a/configs/datastorage/configuration.toml
+++ b/configs/datastorage/configuration.toml
@@ -2,7 +2,7 @@
 LogLevel = 'DEBUG'
 
 [Service]
-Host = 'localhost'
+Host = '172.17.0.1'
 Port = 49986
 ConnectRetries = 20
 Labels = []
@@ -22,13 +22,13 @@ FailWaitTime = 10
 [Clients]
   [Clients.Data]
   Protocol = "http"
-  Host = "localhost"
+  Host = "172.17.0.1"
   Port = 48080
   Timeout = 5000
 
   [Clients.Metadata]
   Protocol = "http"
-  Host = "localhost"
+  Host = "172.17.0.1"
   Port = 48081
   Timeout = 5000
 

--- a/docs/datastorage.md
+++ b/docs/datastorage.md
@@ -34,6 +34,8 @@ The following architecture assumes that data stored at data controller would be 
 ### 4.1 Configuration
 
 - Placement the [`test/container/datastorage/`](../test/container/datastorage/) folder into `/var/edge-orchestration/apps/` in your **Home Edge** with Data Storage (**Device A**).
+
+- For running service in dockers, replace the Host IP of metadata, coredata, service to docker0 IP. For example here it is 172.17.0.1
 ```sh
 $ sudo cp -rf test/container/datastorage/ /var/edge-orchestration/apps/
 ```


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description
**Bug:** The edge-orchestration can not find the device in the cache if edge-orchestration registers device configuration to edgex for the first time. It works after reboot.
**Reason:**
When running metadata, coredata in dockers, these services are unable to reach device service when device gets added. Hence callback is not invoked and so cache is not updated.
**Solution:**  Replace the HostIP of metadata, coredata and device service to docker0 IP in confuguration.toml file

Fixes #312 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Clear redis database
2. Run edge-orchestration with DataStorage configuration files
3. Call an API in terms of uploading Int value

curl -X POST "localhost:49986/api/v1/resource/datastorage/int" -H "accept: text/plain" -H "Content-Type: text/plain" -d 123

The value gets uploaded successfully.

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: 1.0.0

 # Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes