### PR TITLE
[DataStorage] Add unit test for Base64

### DIFF
--- a/internal/controller/storagemgr/storagedriver/storagehandler_test.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler_test.go
@@ -243,3 +243,12 @@ func TestReadBodyAsBinary(t *testing.T) {
 		}
 	})
 }
+
+func TestConvertToBase64(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		b64 := convertToBase64([]byte("test"))
+		if b64 != "dGVzdA==" {
+			t.Error(unexpectedFail)
+		}
+	})
+}


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Unit Test Coverage for DataStorage storagedriver : 51.84% > 52.65%

## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?
$ make test ./internal/controller/storagemgr/storagedriver/

## Result
```
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     checkValueInRange                       100.00% (13/13)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     checkUintValueRange                     100.00% (12/12)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     checkIntValueRange                      100.00% (10/10)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     checkFloatValueRange                    100.00% (7/7)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.Stop                      100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.AddDevice                 100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     NewStorageHandler                       100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     convertToBase64                         100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.RemoveDevice              100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.UpdateDevice              100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.HandleWriteCommands       100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.HandleReadCommands        100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.readBodyAsString         88.89% (8/9)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.readBodyAsBinary         88.89% (8/9)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.newCommandValue          88.06% (59/67)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.processAsyncPostRequest  0.00% (0/47)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.processAsyncGetRequest   0.00% (0/35)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.Start                    0.00% (0/9)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     deviceHandler                           0.00% (0/8)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagedriver.go      StorageDriver.Initialize                0.00% (0/4)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     @100:26                                 0.00% (0/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver/storagehandler.go     StorageHandler.addContext               0.00% (0/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver                       --------------------------------------  52.65% (129/245)

Total Coverage: 52.65% (129/245)
```

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
