### PR TITLE
Add GetLogLevel() to Logmgr

### DIFF
--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -155,6 +155,12 @@ $ docker run -it -d --privileged --network="host" --name edge-orchestration -v /
     $ docker run -it -d --privileged --network="host" --name edge-orchestration -e MNEDC=server -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
     ```
 
+  - LOGLEVEL
+
+    You can set the log level(Debug, Info, Warn and others) by `LOGLEVEL`. (Default level is `Info`.)
+    ```shell
+    $ docker run -it -d --privileged --network="host" --name edge-orchestration -e LOGLEVEL=Warn -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
+
 - Result
 
 ```shell

--- a/internal/common/logmgr/logmgr.go
+++ b/internal/common/logmgr/logmgr.go
@@ -48,7 +48,7 @@ func init() {
 			return function, filenline
 		},
 	}
-	logIns.Level = logrus.InfoLevel
+	logIns.Level = GetLogLevel()
 	logIns.Out = os.Stdout
 }
 
@@ -78,4 +78,14 @@ func InitLogfile(logFilePath string) {
 // GetInstance returns an instance of the logmgr
 func GetInstance() *logrus.Logger {
 	return logIns
+}
+
+// GetLogLevel returns the logging level
+func GetLogLevel() logrus.Level {
+	level, err := logrus.ParseLevel(os.Getenv("LOGLEVEL"))
+	if err != nil {
+		logIns.Warn(err.Error())
+		level = logrus.InfoLevel
+	}
+	return level
 }

--- a/internal/common/logmgr/logmgr_test.go
+++ b/internal/common/logmgr/logmgr_test.go
@@ -19,6 +19,7 @@ package logmgr
 
 import (
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"os"
 	"testing"
 )
@@ -41,6 +42,13 @@ func TestInit(t *testing.T) {
 	err := os.Remove(TestFile)
 	if err != nil {
 		t.Error(err.Error())
+	}
+}
+
+func TestGetLogLevel(t *testing.T) {
+	level := GetLogLevel()
+	if level != logrus.InfoLevel {
+		t.Error("unexpected level")
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description
This PR is for changing the logging level.
Logs are printed with the value applied to the `LOGLEVEL` environment variable. 
If the logging level is not set or incorrect, the `Info` level is set by default. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Run Edge Orchestration with Warn logging level.
```
$ docker run -it -d --privileged --network="host" --name edge-orchestration -e LOGLEVEL=warn  -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
```

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
