### PR TITLE
Add Service Application Execution with Application DB

### DIFF
--- a/internal/controller/servicemgr/executor/containerexecutor/containerexecutor.go
+++ b/internal/controller/servicemgr/executor/containerexecutor/containerexecutor.go
@@ -155,8 +155,8 @@ func convertConfig(paramStr []string) (
 }
 
 func addRequestEnv(s executor.ServiceExecutionInfo) executor.ServiceExecutionInfo {
-	s.ParamStr = append(s.ParamStr[:4], s.ParamStr[2:]...)
-	s.ParamStr[2] = "-e"
-	s.ParamStr[3] = "REQUEST=" + s.NotificationTargetURL
+	s.ParamStr = append(s.ParamStr, s.ParamStr[len(s.ParamStr)-2:]...)
+	s.ParamStr[len(s.ParamStr)-3] = "-e"
+	s.ParamStr[len(s.ParamStr)-2] = "REQUEST=" + s.NotificationTargetURL
 	return s
 }

--- a/internal/db/helper/helper.go
+++ b/internal/db/helper/helper.go
@@ -29,7 +29,7 @@ func init() {
 // MultipleBucketQuery provides interfaces for the helper
 type MultipleBucketQuery interface {
 	GetDeviceID() (string, error)
-	GetDeviceInfoWithService(serviceName string, executionTypes []string) ([]ExecutionCandidate, error)
+	GetDeviceInfoWithService(serviceName string, executionTypes []string, installed bool) ([]ExecutionCandidate, error)
 }
 
 // ExecutionCandidate structure
@@ -57,7 +57,7 @@ func (multipleBucketQuery) GetDeviceID() (string, error) {
 	return id.Value, err
 }
 
-func (multipleBucketQuery) GetDeviceInfoWithService(serviceName string, executionTypes []string) ([]ExecutionCandidate, error) {
+func (multipleBucketQuery) GetDeviceInfoWithService(serviceName string, executionTypes []string, installed bool) ([]ExecutionCandidate, error) {
 	ret := make([]ExecutionCandidate, 0)
 
 	confItems, err := confQuery.GetList()
@@ -71,7 +71,7 @@ func (multipleBucketQuery) GetDeviceInfoWithService(serviceName string, executio
 			continue
 		}
 
-		if confItem.ExecType == "container" {
+		if confItem.ExecType == "container" && !installed {
 			endpoints, err := getEndpoints(confItem.ID)
 			if err != nil {
 				continue

--- a/internal/db/helper/helper_test.go
+++ b/internal/db/helper/helper_test.go
@@ -103,7 +103,7 @@ func TestGetDeviceInfoWithService(t *testing.T) {
 			}, nil),
 		)
 
-		ret, err := GetInstance().GetDeviceInfoWithService("testService1", []string{"native", "container"})
+		ret, err := GetInstance().GetDeviceInfoWithService("testService1", []string{"native", "container"}, false)
 		if err != nil {
 			t.Error("unexpected error")
 		} else if len(ret) != 2 {
@@ -129,7 +129,7 @@ func TestGetDeviceInfoWithService(t *testing.T) {
 		t.Run("confQueryGetList", func(t *testing.T) {
 			mockConf.EXPECT().GetList().Return(nil, errors.New(""))
 
-			ret, err := GetInstance().GetDeviceInfoWithService("", nil)
+			ret, err := GetInstance().GetDeviceInfoWithService("", nil, false)
 			if err == nil {
 				t.Error("unexpected success")
 			} else if ret != nil {
@@ -145,7 +145,7 @@ func TestGetDeviceInfoWithService(t *testing.T) {
 				},
 			}, nil)
 
-			ret, err := GetInstance().GetDeviceInfoWithService("", []string{"container"})
+			ret, err := GetInstance().GetDeviceInfoWithService("", []string{"container"}, false)
 			if err == nil {
 				t.Error("unexpected success")
 			} else if ret != nil {
@@ -164,7 +164,7 @@ func TestGetDeviceInfoWithService(t *testing.T) {
 				mockNet.EXPECT().Get(gomock.Eq("test")).Return(network.Info{}, errors.New("")),
 			)
 
-			ret, err := GetInstance().GetDeviceInfoWithService("", []string{"container"})
+			ret, err := GetInstance().GetDeviceInfoWithService("", []string{"container"}, false)
 			if err == nil {
 				t.Error("unexpected success")
 			} else if ret != nil {
@@ -183,7 +183,7 @@ func TestGetDeviceInfoWithService(t *testing.T) {
 				mockService.EXPECT().Get(gomock.Eq("test")).Return(service.Info{}, errors.New("")),
 			)
 
-			ret, err := GetInstance().GetDeviceInfoWithService("", []string{"native"})
+			ret, err := GetInstance().GetDeviceInfoWithService("", []string{"native"}, false)
 			if err == nil {
 				t.Error("unexpected success")
 			} else if ret != nil {
@@ -208,7 +208,7 @@ func TestGetDeviceInfoWithService(t *testing.T) {
 				}, nil),
 			)
 
-			ret, err := GetInstance().GetDeviceInfoWithService("", []string{"native"})
+			ret, err := GetInstance().GetDeviceInfoWithService("", []string{"native"}, false)
 			if err == nil {
 				t.Error("unexpected success")
 			} else if ret != nil {
@@ -234,7 +234,7 @@ func TestGetDeviceInfoWithService(t *testing.T) {
 				mockNet.EXPECT().Get(gomock.Eq("test")).Return(network.Info{}, errors.New("")),
 			)
 
-			ret, err := GetInstance().GetDeviceInfoWithService("testService1", []string{"native"})
+			ret, err := GetInstance().GetDeviceInfoWithService("testService1", []string{"native"}, false)
 			if err == nil {
 				t.Error("unexpected success")
 			} else if ret != nil {

--- a/internal/db/helper/mocks/mock_helper.go
+++ b/internal/db/helper/mocks/mock_helper.go
@@ -67,16 +67,16 @@ func (mr *MockMultipleBucketQueryMockRecorder) GetDeviceID() *gomock.Call {
 }
 
 // GetDeviceInfoWithService mocks base method.
-func (m *MockMultipleBucketQuery) GetDeviceInfoWithService(serviceName string, executionTypes []string) ([]helper.ExecutionCandidate, error) {
+func (m *MockMultipleBucketQuery) GetDeviceInfoWithService(serviceName string, executionTypes []string, installed bool) ([]helper.ExecutionCandidate, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceInfoWithService", serviceName, executionTypes)
+	ret := m.ctrl.Call(m, "GetDeviceInfoWithService", serviceName, executionTypes, installed)
 	ret0, _ := ret[0].([]helper.ExecutionCandidate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDeviceInfoWithService indicates an expected call of GetDeviceInfoWithService.
-func (mr *MockMultipleBucketQueryMockRecorder) GetDeviceInfoWithService(serviceName, executionTypes interface{}) *gomock.Call {
+func (mr *MockMultipleBucketQueryMockRecorder) GetDeviceInfoWithService(serviceName, executionTypes, installed interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceInfoWithService", reflect.TypeOf((*MockMultipleBucketQuery)(nil).GetDeviceInfoWithService), serviceName, executionTypes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceInfoWithService", reflect.TypeOf((*MockMultipleBucketQuery)(nil).GetDeviceInfoWithService), serviceName, executionTypes, installed)
 }

--- a/internal/orchestrationapi/orchestrationapi.go
+++ b/internal/orchestrationapi/orchestrationapi.go
@@ -147,12 +147,16 @@ func (orcheEngine *orcheImpl) RequestService(serviceInfo ReqeustService) Respons
 
 	executionTypes := make([]string, 0)
 	var scoringType string
+	installed := true
 	for _, info := range serviceInfo.ServiceInfo {
 		executionTypes = append(executionTypes, info.ExecutionType)
 		scoringType, _ = info.ExeOption["scoringType"].(string)
+		if len(info.ExeCmd) > 0 {
+			installed = false
+		}
 	}
 
-	candidates, err := orcheEngine.getCandidate(serviceInfo.ServiceName, executionTypes)
+	candidates, err := orcheEngine.getCandidate(serviceInfo.ServiceName, executionTypes, installed)
 
 	log.Printf("[RequestService] getCandidate")
 	for index, candidate := range candidates {
@@ -266,8 +270,8 @@ func getExecCmds(execType string, requestServiceInfos []RequestServiceInfo) ([]s
 	return nil, errors.New("not found")
 }
 
-func (orcheEngine orcheImpl) getCandidate(appName string, execType []string) (deviceList []dbhelper.ExecutionCandidate, err error) {
-	return helper.GetDeviceInfoWithService(appName, execType)
+func (orcheEngine orcheImpl) getCandidate(appName string, execType []string, installed bool) (deviceList []dbhelper.ExecutionCandidate, err error) {
+	return helper.GetDeviceInfoWithService(appName, execType, installed)
 }
 
 func (orcheEngine orcheImpl) gatherDevicesScore(candidates []dbhelper.ExecutionCandidate, selfSelection bool) (deviceScores []deviceInfo) {

--- a/internal/orchestrationapi/orchestrationapi_test.go
+++ b/internal/orchestrationapi/orchestrationapi_test.go
@@ -83,7 +83,7 @@ func TestRequestService(t *testing.T) {
 		gomock.InOrder(
 			mockService.EXPECT().SetLocalServiceExecutor(mockExecutor),
 			mockDiscovery.EXPECT().SetRestResource(),
-			mockDBHelper.EXPECT().GetDeviceInfoWithService(gomock.Eq(appName), gomock.Any()).Return(candidateInfos, nil),
+			mockDBHelper.EXPECT().GetDeviceInfoWithService(gomock.Eq(appName), gomock.Any(), gomock.Any()).Return(candidateInfos, nil),
 			mockSystemDBExecutor.EXPECT().Get("id").Return(sysInfo, nil),
 			mockNetwork.EXPECT().GetIPs().Return([]string{""}, nil),
 			mockClient.EXPECT().DoGetScoreRemoteDevice(gomock.Any(), gomock.Any()).Return(scores[0], nil),
@@ -127,7 +127,7 @@ func TestRequestService(t *testing.T) {
 			gomock.InOrder(
 				mockService.EXPECT().SetLocalServiceExecutor(mockExecutor),
 				mockDiscovery.EXPECT().SetRestResource(),
-				mockDBHelper.EXPECT().GetDeviceInfoWithService(gomock.Eq(appName), gomock.Any()).Return(nil, errors.New("-3")),
+				mockDBHelper.EXPECT().GetDeviceInfoWithService(gomock.Eq(appName), gomock.Any(), gomock.Any()).Return(nil, errors.New("-3")),
 			)
 			o := getOcheIns(ctrl)
 			if o == nil {

--- a/internal/restinterface/externalhandler/externalhandler.go
+++ b/internal/restinterface/externalhandler/externalhandler.go
@@ -204,15 +204,11 @@ func (h *Handler) APIV1RequestServicePost(w http.ResponseWriter, r *http.Request
 		serviceInfos.ServiceInfo[idx].ExecutionType = exeType
 
 		exeCmd, ok := tmp["ExecCmd"].([]interface{})
-		if !ok {
-			responseMsg = orchestrationapi.InvalidParameter
-			responseName = name
-			goto SEND_RESP
-		}
-
-		serviceInfos.ServiceInfo[idx].ExeCmd = make([]string, len(exeCmd))
-		for idy, cmd := range exeCmd {
-			serviceInfos.ServiceInfo[idx].ExeCmd[idy] = cmd.(string)
+		if ok {
+			serviceInfos.ServiceInfo[idx].ExeCmd = make([]string, len(exeCmd))
+			for idy, cmd := range exeCmd {
+				serviceInfos.ServiceInfo[idx].ExeCmd[idy] = cmd.(string)
+			}
 		}
 
 		exeOption, ok := tmp["ExecOption"].(interface{})

--- a/internal/restinterface/externalhandler/externalhandler_test.go
+++ b/internal/restinterface/externalhandler/externalhandler_test.go
@@ -255,30 +255,6 @@ func TestAPIV1RequestServicePost(t *testing.T) {
 
 				handler.APIV1RequestServicePost(w, r)
 			})
-			t.Run("ExecCmd", func(t *testing.T) {
-				handler.SetCipher(mockCipher)
-				handler.SetOrchestrationAPI(mockOrchestration)
-				handler.setHelper(mockHelper)
-				handler.netHelper = mockNetHelper
-
-				_, appCommand := getReqeustArgs()
-				tmp := appCommand["ServiceInfo"].([]interface{})
-				serviceInfo := tmp[0].(map[string]interface{})
-				delete(serviceInfo, "ExecCmd")
-
-				gomock.InOrder(
-					mockNetHelper.EXPECT().GetIPs().Return([]string{addr}, nil),
-					mockCipher.EXPECT().DecryptByteToJSON(gomock.Any()).Return(appCommand, nil),
-					mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Do(func(resp map[string]interface{}) {
-						if resp["Message"] != orchestrationapi.InvalidParameter {
-							t.Error("unexpected response")
-						}
-					}).Return(nil, nil),
-					mockHelper.EXPECT().Response(gomock.Any(), gomock.Any(), gomock.Eq(http.StatusOK)),
-				)
-
-				handler.APIV1RequestServicePost(w, r)
-			})
 		})
 	})
 


### PR DESCRIPTION
- If there is no ExecCmd information in the request,
  the service app would be executed based on the Application DB

Signed-off-by: Taewan Kim <t25.kim@samsung.com>

Fixes #376 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
1. Pull docker image
```
$ docker pull hello-world
```
2. Put the configuration file in /var/edge-orchestration/apps/hello-world/hello-world.conf
**hello-world.conf**
```
[Version]
ConfVersion=v0.1                    ; Version of Configuration file

[ServiceInfo]
ServiceName=hello-world             ; Name of distributed service
ExecType=container
ExecCmd=docker run -v /var/run:/var/run:rw hello-world
```
3. Run Edge Orchestration
```
$ make run
```
4. See the running hello-world service with `docker logs`
```
$ docker logs -f edge-orchestration
...
INFO[2021-09-13T01:05:50Z]discovery.go:573 func1 [deviceDetectionRoutine] edge-orchestration-c1b23cc6-0767-400a-9cf0-36e1b3902da2
INFO[2021-09-13T01:05:50Z]discovery.go:574 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker)
INFO[2021-09-13T01:05:50Z]discovery.go:575 func1 [deviceDetectionRoutine] netInfo     : IPv4([10.113.70.227]), RTT(0)
INFO[2021-09-13T01:05:50Z]discovery.go:576 func1 [deviceDetectionRoutine] serviceInfo : Services([hello-world])
```
5. Request the hello-world service without ExecCmd information
```
$ curl -X POST "localhost:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\"}]}"
```

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
