### PR TITLE
Fix Android archive build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,9 @@ endef
 build-object-java:
 	$(Q) mkdir -p $(ANDROID_LIBRARY_OUT_DIR)
 	$(Q) rm -rf $(BUILD_VENDOR_DIR)
+	$(Q) go get golang.org/x/mobile@v0.0.0-20201217150744-e6ae53a27f4f
 	$(GOMOBILE) bind $(GO_MOBILE_LDFLAGS) -o $(ANDROID_LIBRARY_OUT_DIR)/$(ANDROID_LIBRARY_FILE) -target=$(ANDROID_TARGET) -androidapi=23 $(ANDROID_SRC_DIR) || exit 1
+	$(Q) go mod tidy
 	$(Q) ls -al $(ANDROID_LIBRARY_OUT_DIR)
 
 ## edge-orchestration container build


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

In connection with the approaching release, I checked the success of the build of all configurations. The library build for Android was failing. The error occurs due to the optimization of packages by `go mod tidy` (Since all dependencies are analyzed from the `main` package. To build a library under the android, `main` packet is lacking. And therefore the `golang.org/x/mobile` package is deleted during optimization).  It should also be noted that the last version of `golang.org/x/mobile` is not working for our project. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
How to build see [x86_64_android.md](https://github.com/lf-edge/edge-home-orchestration-go/blob/master/docs/platforms/x86_64_linux/x86_64_android.md)

**Test Configuration**:
* Firmware version: Ubuntu 18.04
* Hardware: x86-64
* Toolchain: Docker and Go recommended
* Edge Orchestration Release: v1.0.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
