### PR TITLE
[DataStorage] Use Official device SDK 1.4.0 and remove redirection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/lf-edge/edge-home-orchestration-go
 
 go 1.16
 
-// Temporary measure to avoid crash in Hanoi release of EdgeX, Will be removed post Ireland release.
-replace github.com/edgexfoundry/device-sdk-go v1.4.0 => github.com/hahattan/device-sdk-go v1.4.1
-
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect

--- a/internal/controller/storagemgr/config/toml.go
+++ b/internal/controller/storagemgr/config/toml.go
@@ -179,3 +179,12 @@ func GetServerIP(ConfigPath string) (string, int, error) {
 	}
 	return config.Get("Clients.Data.Host").(string), (int)(config.Get("Clients.Data.Port").(int64)), nil
 }
+
+// GetMetadataServerIP is used to obtain the IP and port number of Metadata
+func GetMetadataServerIP(ConfigPath string) (string, int, error) {
+	config, err := toml.LoadFile(ConfigPath)
+	if err != nil {
+		return "", 0, err
+	}
+	return config.Get("Clients.Metadata.Host").(string), (int)(config.Get("Clients.Metadata.Port").(int64)), nil
+}


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description

Edge Orchestration uses edgexfoundry/device-sdk-go from github.com/hahattan/device-sdk-go v1.4.1, not the official repository, So the official repository used and checked for metadata running to avoid the locks issue in Hanoi release of EdgeX

Fixes #231 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Edge-orchestration checks for Metadata IP address from configuration.toml file
2. It pings to the url to check if metadata is running
3. If the metadata is running, the datastorage is started else Error log is printed and datastorage is not started
4. Build the code and run
5. Stop the metadata and check. Error log is printed as expected 
6. Start metadata and rerun edge-orchestration. Device service started and POST/GET APIs working as expected

**Test Configuration**:
* OS type & version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (1.0.0)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
