### PR TITLE
[DataStorage] Device Not found in Cache Issue

### DIFF
--- a/configs/datastorage/configuration.toml
+++ b/configs/datastorage/configuration.toml
@@ -2,7 +2,7 @@
 LogLevel = 'DEBUG'
 
 [Service]
-Host = 'localhost'
+Host = '172.17.0.1'
 Port = 49986
 ConnectRetries = 20
 Labels = []
@@ -12,7 +12,7 @@ EnableAsyncReadings = true
 AsyncBufferSize = 16
 
 [Registry]
-Host = 'localhost'
+Host = '172.17.0.1'
 Port = 8500
 Type = "consul"
 CheckInterval = "10s"
@@ -22,19 +22,19 @@ FailWaitTime = 10
 [Clients]
   [Clients.Data]
   Protocol = "http"
-  Host = "localhost"
+  Host = '172.17.0.1'
   Port = 48080
   Timeout = 5000
 
   [Clients.Metadata]
   Protocol = "http"
-  Host = "localhost"
+  Host = '172.17.0.1'
   Port = 48081
   Timeout = 5000
 
   [Clients.Logging]
   Protocol = "http"
-  Host = "localhost"
+  Host = '172.17.0.1'
   Port = 48061
 
 [Device]


### PR DESCRIPTION
Signed-off-by: Nitu Sajjanlal Gupta <nitu.gupta@samsung.com>

# Description
**Bug:** The edge-orchestration can not find the device in the cache if edge-orchestration registers device configuration to edgex for the first time. It works after reboot.

**Solution:** The configuration toml file is generated automatically, so the ip of edge-orchestration resolves the issue and callbacks are recieved.


Fixes #312 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Clear redis database
2. Run the docker-compose up -d from deployments/datatsorage
3. Run edge-orchestration with datastorage service
4. Call an API in terms of uploading Int value

curl -X POST "{ip of edge-orchestration}:49986/api/v1/resource/int" -H "accept: text/plain" -H "Content-Type: text/plain" -d 123
For example: 
curl -X POST "107.108.70.126:49986/api/v1/resource/int" -H "accept: text/plain" -H "Content-Type: text/plain" -d 123
The value gets uploaded successfully. which is verified with GET command

**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Edge Orchestration Release: 1.0.0

 # Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes