### PR TITLE
Remove the CLI prompt symbol '$' from docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,14 +16,14 @@ help.
 
 #### 1. [Fork](http://help.github.com/fork-a-repo/) the Edge Orchestration repository on github and clone your fork to your development environment
 ```sh
-$ git clone https://github.com/YOUR-GITHUB-USERNAME/edge-home-orchestration-go.git
+git clone https://github.com/YOUR-GITHUB-USERNAME/edge-home-orchestration-go.git
 ```
 If you have trouble setting up GIT with GitHub in Linux, or are getting errors like "Permission Denied (publickey)", then you must [setup your GIT installation to work with GitHub](http://help.github.com/linux-set-up-git/)
 
 #### 2. Add the main Edge Orchestration repository as an additional git remote called "upstream"
 Change to the directory where you cloned Edge Orchestration, normally, "Edge Orchestration". Then enter the following command:
 ```sh
-$ git remote add upstream https://github.com/lf-edge/edge-home-orchestration-go
+git remote add upstream https://github.com/lf-edge/edge-home-orchestration-go
 ```
 
 #### 3. Make sure there is an issue created for the thing you are working on.
@@ -34,7 +34,7 @@ All new features and bug fixes should have an associated issue to provide a sing
 
 #### 4. Fetch the latest code from the main Edge Orchestration branch
 ```sh
-$ git fetch upstream
+git fetch upstream
 ```
 You should start at this point for every new contribution to make sure you are working on the latest code.
 
@@ -44,8 +44,8 @@ You should start at this point for every new contribution to make sure you are w
 
 Each separate bug fix or change should go in its own branch. Branch names should be descriptive and start with the number of the issue that your code relates to. If you aren't fixing any particular issue, just skip number. For example:
 ```sh
-$ git checkout upstream/<NAMED_RELEASE>
-$ git checkout -b 999-name-of-your-branch-goes-here
+git checkout upstream/<NAMED_RELEASE>
+git checkout -b 999-name-of-your-branch-goes-here
 ```
 Above, <NAMED_RELEASE> can be 'Alpha', 'Baobab', 'Coconut', etc. - see list of releases.
 
@@ -67,28 +67,28 @@ For very small fixes, e.g. typos and documentation changes, there is no need to 
 
 Before creating the Commit, format the source code using GOFMT. This can be done by following command:
 ```sh
-$ make fmt
+make fmt
 ```
 
 add the files/changes you want to commit to the staging area with
 ```sh
-$ git add path/to/my/file.go
+git add path/to/my/file.go
 ```
 
 Commit your changes with a descriptive commit message. Make sure to mention the ticket number with #XXX so github will automatically link your commit with the ticket:
 ```sh
-$ git commit -m "A brief description of this change which fixes #42 goes here" --signoff
+git commit -m "A brief description of this change which fixes #42 goes here" --signoff
 ```
 
 #### 9. Pull the latest Edge Orchestration code from upstream into your branch
 ```sh
-$ git pull upstream <NAMED_RELEASE>
+git pull upstream <NAMED_RELEASE>
 ```
 This ensures you have the latest code in your branch before you open your pull request. If there are any merge conflicts, you should fix them now and commit the changes again. This ensures that it's easy for the Edge Orchestration team to merge your changes with one click.
 
 #### 10. Having resolved any conflicts, push your code to github
 ```sh
-$ git push -u origin 999-name-of-your-branch-goes-here
+git push -u origin 999-name-of-your-branch-goes-here
 ```
 
 The `-u` parameter ensures that your branch will now automatically push and pull from the github branch. That means if you type `git push` the next time it will know where to push to.
@@ -106,7 +106,7 @@ Someone will review your code, and you might be asked to make some changes, if s
 
 After your code was either accepted or declined you can delete branches you've worked with from your local repository and `origin`.
 ```sh
-$ git checkout <NAMED_RELEASE>
-$ git branch -D 999-name-of-your-branch-goes-here
-$ git push origin --delete 999-name-of-your-branch-goes-here
+git checkout <NAMED_RELEASE>
+git branch -D 999-name-of-your-branch-goes-here
+git push origin --delete 999-name-of-your-branch-goes-here
 ```

--- a/docs/datastorage.md
+++ b/docs/datastorage.md
@@ -35,22 +35,24 @@ The following architecture assumes that data stored at data controller would be 
 
 - Placement the [`test/container/datastorage/`](../test/container/datastorage/) folder into `/var/edge-orchestration/apps/` in your **Home Edge** with Data Storage (**Device A**).
 ```sh
-$ sudo cp -rf test/container/datastorage/ /var/edge-orchestration/apps/
+sudo cp -rf test/container/datastorage/ /var/edge-orchestration/apps/
 ```
 
 ### 4.2 Run EdgeX Foundry containers
 - Run the Hanoi version of EdgeX Docker containers on your Linux machine (**Device A**) with respect to the guidance from [EdgeX Foundry Services](https://github.com/edgexfoundry/edgex-go#get-started), or the _simplest way_ that you can follow using follows;
 
 ```sh
-$ cd deployments/datastorage
-$ docker-compose up -d
+cd deployments/datastorage
+docker-compose up -d
 ```
 
 ### 4.3 Run Edge Orchestration
 - Run `edge-home-orchestration-go` with DataStorage on **Device A**, referring to "How to work" in [link](./platforms/x86_64_linux/x86_64_linux.md#how-to-work).
 - You can see the **Device A** has the `DataStorage` service as follows:
 ```
-$ docker logs -f edge-orchestration
+docker logs -f edge-orchestration
+```
+```
 INFO[2021-08-10T04:28:20Z]discovery.go:572 func1 [deviceDetectionRoutine] edge-orchestration-c1b23cc6-0767-400a-9cf0-36e1b3902da2
 INFO[2021-08-10T04:28:20Z]discovery.go:573 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker)
 INFO[2021-08-10T04:28:20Z]discovery.go:574 func1 [deviceDetectionRoutine] netInfo     : IPv4([10.113.70.227]), RTT(0)

--- a/docs/mnedc.md
+++ b/docs/mnedc.md
@@ -26,8 +26,8 @@ virtual IP to communicate with the peers will be able to send and receive the pa
 ### 4.1 Setting up the MNEDC Server
 Just run the following commands to run the MNEDC server on the device:
 ```
-$ make create_context CONFIGFILE=x86_64cms
-$ make
+make create_context CONFIGFILE=x86_64cms
+make
 ```
 Note that there should be only one device running the MNEDC Server in the network.
 
@@ -37,8 +37,6 @@ Steps to run the MNEDC Client:
 2. Copy this client-config.yaml file to /var/edge-orchestration/mnedc folder.
 3. Run the following commands:
 ```
-$ make create_context CONFIGFILE=x86_64cmc
-$ make
+make create_context CONFIGFILE=x86_64cmc
+make
 ```
-
-

--- a/docs/platforms/hikey960/hikey960.md
+++ b/docs/platforms/hikey960/hikey960.md
@@ -25,9 +25,9 @@ After starting Linux, you need to run the `nmtui` to configure the Wi-Fi.
 
 Docker installation:
 ```sh
-$ curl -sSL https://get.docker.com | sh
-$ sudo usermod -aG docker $USER
-$ newgrp docker
+curl -sSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
 ```
 Everything is now ready to deploy Edge-Orchestration
 
@@ -44,20 +44,16 @@ This section provides how to download and run pre-built Docker image without bui
 
 Prerequisites: install the qemu packages
 ```shell
-$ sudo apt-get install qemu binfmt-support qemu-user-static
+sudo apt-get install qemu binfmt-support qemu-user-static
 ```
 
 Run the `make create_context` and specify the configuration file name `arm64c` and `make` (in the case of building in protected mode, use add `arm64cs`), see examples below:
 ```
-$ make distclean
-$ make create_context CONFIGFILE=arm64c
-$ make
+make distclean ; make create_context CONFIGFILE=arm64c ; make
 ```
 or for protected mode:
 ```shell
-$ make distclean
-$ make create_context CONFIGFILE=arm64cs
-$ make
+make distclean; make create_context CONFIGFILE=arm64cs ; make
 ```
 
 > To change the configuration file, you must execute the command `make distclean`
@@ -66,7 +62,7 @@ The build result will be `edge-orchestration.tar` archive that can be found `bin
 
 Next, need to copy `edge-orchestration.tar` archive to the HiKey960 board and load the image using the command:
 ```shell
-$ docker load -i edge-orchestration.tar
+docker load -i edge-orchestration.tar
 ```
 The build is finished, how to run see [here](../x86_64_linux/x86_64_linux.md#How-to-work).
 

--- a/docs/platforms/orange_pi3/orange_pi3.md
+++ b/docs/platforms/orange_pi3/orange_pi3.md
@@ -31,20 +31,16 @@ There are two options for building a edge-orchestration container:
 
 Prerequisites: install the qemu packages
 ```shell
-$ sudo apt-get install qemu binfmt-support qemu-user-static
+sudo apt-get install qemu binfmt-support qemu-user-static
 ```
 
 Run the `make create_context` and specify the configuration file name `arm64c` and `make` (in the case of building in protected mode, use add `arm64cs`), see examples below:
 ```
-$ make distclean
-$ make create_context CONFIGFILE=arm64c
-$ make
+make distclean ; make create_context CONFIGFILE=arm64c ; make
 ```
 or for protected mode:
 ```shell
-$ make distclean
-$ make create_context CONFIGFILE=arm64cs
-$ make
+make distclean ; make create_context CONFIGFILE=arm64cs ; make
 ```
 
 > To change the configuration file, you must execute the command `make distclean`
@@ -53,7 +49,7 @@ The build result will be `edge-orchestration.tar` archive that can be found `bin
 
 Next, need to copy `edge-orchestration.tar` archive to the Paspberry Pi 3 board, install the docker container (see [here](../x86_64_linux/x86_64_linux.md#Build-Prerequisites) only docker part) and load the image using the command:
 ```shell
-$ docker load -i edge-orchestration.tar
+docker load -i edge-orchestration.tar
 ```
 The build is finished, how to run see [here](../x86_64_linux/x86_64_linux.md#how-to-work). If you find the issue with Curl Example then please reboot board and run Edge Orchestration container again.
 
@@ -62,11 +58,11 @@ The build is finished, how to run see [here](../x86_64_linux/x86_64_linux.md#how
 - docker
 
 ```sh
-$ sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
-$ sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-$ curl -sSL https://get.docker.com | sh
-$ sudo usermod -aG docker $USER
-$ newgrp docker
+sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+curl -sSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
 ```
 
 > For [execution of docker commands with non-root privileges](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) you need to add `$USER` to docker group.  
@@ -75,18 +71,18 @@ $ newgrp docker
 - go compiler (install a version not lower than 1.16.2, recommended v1.16.6))
 
 ```sh
-$ wget https://dl.google.com/go/go1.16.6.linux-arm64.tar.gz
-$ tar -C $HOME -xvf go1.16.6.linux-arm64.tar.gz
-$ export GOPATH=$HOME/go
-$ export PATH=$PATH:$GOPATH/bin
+wget https://dl.google.com/go/go1.16.6.linux-arm64.tar.gz
+tar -C $HOME -xvf go1.16.6.linux-arm64.tar.gz
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOPATH/bin
 ```
 
 - edge-orchestration source code
 
 ```sh
-$ git clone https://github.com/lf-edge/edge-home-orchestration-go.git
-
+git clone https://github.com/lf-edge/edge-home-orchestration-go.git
 ```
+
 The build is described [here](../x86_64_linux/x86_64_linux.md#how-to-build).
 
 The build is finished, how to run see [here](../x86_64_linux/x86_64_linux.md#how-to-work).

--- a/docs/platforms/raspberry_pi3/raspberry_pi3.md
+++ b/docs/platforms/raspberry_pi3/raspberry_pi3.md
@@ -31,20 +31,16 @@ There are two options for building a edge-orchestration container:
 
 Prerequisites: install the qemu packages
 ```shell
-$ sudo apt-get install qemu binfmt-support qemu-user-static
+sudo apt-get install qemu binfmt-support qemu-user-static
 ```
 
 Run the `make create_context` and specify the configuration file name `armc` and `make` (in the case of building in protected mode, use add `armcs`), see examples below:
 ```
-$ make distclean
-$ make create_context CONFIGFILE=armc
-$ make
+make distclean ; make create_context CONFIGFILE=armc ; make
 ```
 or for protected mode:
 ```shell
-$ make distclean
-$ make create_context CONFIGFILE=armcs
-$ make
+make distclean ; make create_context CONFIGFILE=armcs ; make
 ```
 
 > To change the configuration file, you must execute the command `make distclean`
@@ -53,7 +49,7 @@ The build result will be `edge-orchestration.tar` archive that can be found `bin
 
 Next, need to copy `edge-orchestration.tar` archive to the Raspberry Pi 3 board, install the docker container (see [here](../x86_64_linux/x86_64_linux.md#Build-Prerequisites) only docker part) and load the image using the command:
 ```shell
-$ docker load -i edge-orchestration.tar
+docker load -i edge-orchestration.tar
 ```
 The build is finished, how to run see [here](../x86_64_linux/x86_64_linux.md#how-to-work).
 
@@ -62,9 +58,9 @@ The build is finished, how to run see [here](../x86_64_linux/x86_64_linux.md#how
 - docker
 
 ```sh
-$ curl -sSL https://get.docker.com | sh
-$ sudo usermod -aG docker $USER
-$ newgrp docker
+curl -sSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
 ```
 
 > For [execution of docker commands with non-root privileges](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user) you need to add `$USER` to docker group.  
@@ -73,29 +69,25 @@ $ newgrp docker
 - go compiler (install a version not lower than 1.16.2, recommended v1.16.6)
 
 ```sh 
-$ wget https://dl.google.com/go/go1.16.6.linux-armv6l.tar.gz
-$ sudo tar -C /usr/local -xvf go1.16.6.linux-armv6l.tar.gz
-$ export GOPATH=$HOME/go
-$ export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
+wget https://dl.google.com/go/go1.16.6.linux-armv6l.tar.gz
+sudo tar -C /usr/local -xvf go1.16.6.linux-armv6l.tar.gz
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
 ```
 
 - edge-orchestration source code
 
 ```sh
-$ git clone https://github.com/lf-edge/edge-home-orchestration-go.git
+git clone https://github.com/lf-edge/edge-home-orchestration-go.git
 
 ```
 Run the `make create_context` and specify the configuration file name `armc` and `make` (in the case of building in protected mode, use add `armcs`), see examples below:
 ```
-$ make distclean
-$ make create_context CONFIGFILE=armc
-$ make
+make distclean ; make create_context CONFIGFILE=armc ; make
 ```
 or for protected mode:
 ```shell
-$ make distclean
-$ make create_context CONFIGFILE=armcs
-$ make
+make distclean ; make create_context CONFIGFILE=armcs ; make
 ```
 
 > To change the configuration file, you must execute the command `make distclean`

--- a/docs/platforms/raspberry_pi3_cluster/raspberry_pi3_cluster.md
+++ b/docs/platforms/raspberry_pi3_cluster/raspberry_pi3_cluster.md
@@ -59,7 +59,7 @@ We hope that you already have SSH setup to access all your Raspberry Pi 3s and s
 
 1. Install pssh on your PC
 ```
-$ sudo apt-get install pssh
+sudo apt-get install pssh
 ```
 2. Setting the ip addresses of your Raspberry Pi 3 boards.
 
@@ -77,7 +77,9 @@ Format that we use: `$ parallel-ssh -i -h hosts "<your command>"`
 
 Example:
 ```
-$ parallel-ssh -i -h hosts "date"
+parallel-ssh -i -h hosts "date"
+```
+```
 [1] 16:47:47 [SUCCESS] pi@192.168.0.111:22
 Fri 12 Feb 2021 04:47:48 PM EET
 [2] 16:47:47 [SUCCESS] pi@192.168.0.110:22
@@ -94,7 +96,7 @@ Fri 12 Feb 2021 04:47:48 PM EET
 #### [Fabric](http://www.fabfile.org/index.html) (w/o using RSA-keys)
 1. Install fabric on your PC
 ```
-$ sudo apt-get install fabric
+sudo apt-get install fabric
 ```
 
 2. Setting the ip addresses of your Raspberry Pi 3 boards.
@@ -124,7 +126,9 @@ Format that we use: `$ fab cmd:"<your command>"`
 
 Example:
 ```
-$ fab cmd:"date"
+fab cmd:"date"
+```
+```
 [pi@192.168.0.104] Executing task 'cmd'
 [pi@192.168.0.110] Executing task 'cmd'
 [pi@192.168.0.111] Executing task 'cmd'
@@ -190,12 +194,12 @@ done
 
 Next, need to copy `edge-orchestration.tar` archive to the Paspberry Pi 3 boards
 ```
-$ scp edge-orchestration.tar pi@192.168.0.104:.
+scp edge-orchestration.tar pi@192.168.0.104:.
 ```
 
 Install the docker container (see [here](../raspberry_pi3/raspberry_pi3.md#Build-Prerequisites) only docker part) and load the image using the command:
 ```shell
-$ parallel-ssh -i -h hosts "docker load -i edge-orchestration.tar"
+parallel-ssh -i -h hosts "docker load -i edge-orchestration.tar"
 ```
 
 How to run see [here](../x86_64_linux/x86_64_linux.md#how-to-work).

--- a/docs/platforms/x86_64_linux/x86_64_android.md
+++ b/docs/platforms/x86_64_linux/x86_64_android.md
@@ -6,21 +6,21 @@
 2. Wrapping `tools` directory inside `cmdline-tools`
 3. Go to `cmdline-tools/tools/bin` folder and execute following commands: 
 ```
-$ ./sdkmanager "platform-tools" "platforms;android-28"
-$ export ANDROID_SDK=<path to Android SDK directory>
-$ export ANDROID_HOME=<path to Android SDK directory>
-$ export PATH=$PATH:$ANDROID_SDK/cmdline-tools/tools:$ANDROID_SDK/platform-tools
+./sdkmanager "platform-tools" "platforms;android-28"
+export ANDROID_SDK=<path to Android SDK directory>
+export ANDROID_HOME=<path to Android SDK directory>
+export PATH=$PATH:$ANDROID_SDK/cmdline-tools/tools:$ANDROID_SDK/platform-tools
 ```
 - Android NDK
 1. Go to `cmdline-tools/tools/bin` folder and execute following commands:
 ```
-$ ./sdkmanager --list
+./sdkmanager --list
 ```
-Select NDK version from the list (recommended `ndk;21.3.6528147`)
+2. Select NDK version from the list (recommended `ndk;21.3.6528147`) and install it:
 ```
-$ ./sdkmanager --install "ndk;21.3.6528147"
-$ export ANDROID_NDK_HOME=<path to Android NDK directory> 
-$ export PATH=$PATH:$ANDROID_NDK_HOME
+./sdkmanager --install "ndk;21.3.6528147"
+export ANDROID_NDK_HOME=<path to Android NDK directory> 
+export PATH=$PATH:$ANDROID_NDK_HOME
 ```
 > `ndk;22.x` is temporarily not supported.
 
@@ -30,15 +30,11 @@ To build an java-object (`liborchestration.aar/liborchestration-sources.jar`), y
 
 Run the `make create_context` and specify the configuration file name `x86_64a` and `make` (in the case of building in protected mode, use add `x86_64as`), see examples below:
 ```
-$ make distclean
-$ make create_context CONFIGFILE=x86_64a
-$ make
+make distclean ; make create_context CONFIGFILE=x86_64a ; make
 ```
 or for protected mode:
 ```shell
-$ make distclean
-$ make create_context CONFIGFILE=x86_64as
-$ make
+make distclean ; make create_context CONFIGFILE=x86_64as ; make
 ```
 ```
 -----------------------------------

--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -13,11 +13,13 @@ Please download [edge-orchestration docker container](https://github.com/lf-edge
 
 #### 3. Load Docker image from tar file
 ```shell
-$ docker load -i edge-orchestration.tar
+docker load -i edge-orchestration.tar
 ```
 If it succeeds, you can see the Docker image as follows:
 ```shell
-$ docker images
+docker images
+```
+```
 REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
 edge-orchestration         coconut             502e3c07b01f        3 minutes ago       185MB
 ```
@@ -49,33 +51,29 @@ Please see the below [How to work](#how-to-work) to know how to run Edge Orchest
 > Recommendation: Do not install the `gocov` and `gocov-html` utilities from the `edge-home-orchestration-go` folder.
   - [gocov](https://pkg.go.dev/github.com/axw/gocov)
   ```
-  $ go get github.com/axw/gocov/gocov
+  go get github.com/axw/gocov/gocov
   ```
    - [gocov-html](https://github.com/matm/gocov-html#gocov-html-export)
   ```
-  $ go get github.com/matm/gocov-html
+  go get github.com/matm/gocov-html
   ```
   - [staticcheck](https://staticcheck.io)
   ```
-  $ go install honnef.co/go/tools/cmd/staticcheck@latest
+  go install honnef.co/go/tools/cmd/staticcheck@latest
   ```
 
 - extra linux utilities:
 ```
-$ sudo apt-get install tree jq
+sudo apt-get install tree jq
 ```
 
 For build of edge-orchestration project you should run the `make create_context` and specify the configuration file name for example: `x86_64c` and `make` (in the case of building in protected mode, use add `x86_64ns`), see examples below:
 ```
-$ make distclean
-$ make create_context CONFIGFILE=x86_64c
-$ make
+make distclean ; make create_context CONFIGFILE=x86_64c ; make
 ```
 or for protected mode:
 ```shell
-$ make distclean
-$ make create_context CONFIGFILE=x86_64cs
-$ make
+make distclean ; make create_context CONFIGFILE=x86_64cs ; make
 ```
 
 > To change the configuration file, you must execute the command `make distclean`
@@ -84,7 +82,7 @@ $ make
 
 After successfully build you can run edge-orchestration by execute next command:
 ```
-$ make run
+make run
 ```
 
 If it succeeds, you can see the container runs as follows:
@@ -99,14 +97,16 @@ CONTAINER ID        IMAGE                      COMMAND             CREATED      
 
 and the built image as follows:
 ```shell
-$ docker images
+docker images
+```
+```
 REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
 edge-orchestration         coconut             502e3c07b01f        3 seconds ago       185MB
 ```
 
 - All Build Options
 ```shell
-$ make help
+make help
 ```
 
 > If you build the edge-orchestration as c-object, then a more detailed description can be found [x86_64_native.md](x86_64_native.md)
@@ -137,7 +137,7 @@ Note that you can visit [Swagger Editor](https://editor.swagger.io/) to graphica
 #### 1. Run Edge Orchestration container
 
 ```shell
-$ docker run -it -d --privileged --network="host" --name edge-orchestration -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
+docker run -it -d --privileged --network="host" --name edge-orchestration -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
 ```
 - Environment Variables
 
@@ -146,26 +146,27 @@ $ docker run -it -d --privileged --network="host" --name edge-orchestration -v /
 
     [Secure](../../secure_manager.md) mode can be enabled by setting SECURE to `true`.
     ```shell
-    $ docker run -it -d --privileged --network="host" --name edge-orchestration -e SECURE=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
+    docker run -it -d --privileged --network="host" --name edge-orchestration -e SECURE=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
     ```
   - MNEDC
 
     [MNEDC](../../mnedc.md) mode can be enabled by setting MNEDC to `server` or `client`.
     ```shell
-    $ docker run -it -d --privileged --network="host" --name edge-orchestration -e MNEDC=server -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
+    docker run -it -d --privileged --network="host" --name edge-orchestration -e MNEDC=server -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
     ```
 
   - LOGLEVEL
 
-    You can set the log level(Debug, Info, Warn and others) by `LOGLEVEL`. (Default level is `Info`.)
+    You can set the log level (Debug, Info, Warn and others) by `LOGLEVEL` (Default level is `Info`).
     ```shell
-    $ docker run -it -d --privileged --network="host" --name edge-orchestration -e LOGLEVEL=Warn -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
+    docker run -it -d --privileged --network="host" --name edge-orchestration -e LOGLEVEL=Warn -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro edge-orchestration:coconut
 
 - Result
 
 ```shell
-$ docker logs -f edge-orchestration
-
+docker logs -f edge-orchestration
+```
+```
 2019/10/16 07:35:45 main_secured.go:89: [interface] OrchestrationInit
 2019/10/16 07:35:45 main_secured.go:90: >>> commitID  :  c3041ae
 2019/10/16 07:35:45 main_secured.go:91: >>> version   :  
@@ -214,17 +215,17 @@ RESTAPI
     ```
 - Curl Example:
     ```json
-  $ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+  curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
     ```
   ---
    If the `edge-orchestration` was assembled with `secure` option.
    You need to add a JSON Web Token into request header `Authorization: {token}` and a image digest (sha256) to the last parameter. `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`. More information about it you can find [here](../../secure_manager.md).
    ```
-   $ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+   curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
    ```  
    To add the `EDGE_ORCHESTRATION_TOKEN` variable to the environment execute the next command:
    ```
-   $ . tools/jwt_gen.sh HS256 Admin
+   . tools/jwt_gen.sh HS256 Admin
    ```
    To add your container hash to the container white list `/var/edge-orchestration/data/cwl/containerwhitelist.txt`, you need to add a hash line to the end file.  
    ```
@@ -235,8 +236,9 @@ RESTAPI
 - Result(Execution on itself)
   
   ```shell
-  $ docker logs -f edge-orchestration 
-
+  docker logs -f edge-orchestration 
+  ```
+  ```
   2019/06/07 05:41:03 externalhandler.go:75: [RestExternalInterface] APIV1RequestServicePost
   2019/06/07 05:41:03 orchestration_api.go:70: [RequestService] container_service: [docker run -v /var/run:/var/run:rw hello-world]
   2019/06/07 05:41:03 scoringmgr.go:131: [IN] getScoreLocalEnv
@@ -288,4 +290,3 @@ RESTAPI
    --io-maxbandwidth   (Windows only option)
    --io-maxiops        (Windows only option)
    ```
-

--- a/docs/platforms/x86_64_linux/x86_64_native.md
+++ b/docs/platforms/x86_64_linux/x86_64_native.md
@@ -7,15 +7,11 @@ To build an с-object (liborchestration.a), you must run commands depending on c
 
 Run the `make create_context` and specify the configuration file name `x86_64n` and `make` (in the case of building in protected mode, use add `x86_64ns`), see examples below:
 ```
-$ make distclean
-$ make create_context CONFIGFILE=x86_64n
-$ make
+make distclean ; make create_context CONFIGFILE=x86_64n ; make
 ```
 or for protected mode:
 ```shell
-$ make distclean
-$ make create_context CONFIGFILE=x86_64ns
-$ make
+make distclean ; make create_context CONFIGFILE=x86_64ns ; make
 ```
 ```
 ...
@@ -53,15 +49,17 @@ test
 
 1. Copy the folder with the service configuration file from `services` to `/var/edge-orchestration/apps` or use `copy_srvs.sh` to copy all service folders to `/var/edge-orchestration/apps`.
  ```
- $ cd test/native
- $ sudo ./copy_srvs.sh
+cd test/native
+sudo ./copy_srvs.sh
 ```
 > The structure of the [configuration file](../../../internal/controller/configuremgr/native/description/doc.go) and example can be found [ls_srv.conf](../../../test/native/ls_srv/ls_srv.conf).
 
 2. To build the native edge-orchestration, run the following commands:
 ```
-$ cd examples/native
-$ make
+cd examples/native
+make
+```
+```
 CC: main.c
 gcc -c -I../../bin/capi/output/inc/linux_x86-64 main.c -o main.o
 gcc   main.o -L../../bin/capi/output/lib/linux_x86-64 -pthread -lorchestration -o edge-orchestration
@@ -69,7 +67,9 @@ gcc   main.o -L../../bin/capi/output/lib/linux_x86-64 -pthread -lorchestration -
 ```
 3. Run native edge-orchestration
 ```
-$ sudo ./edge-orchestration 
+sudo ./edge-orchestration 
+```
+```
 2020/07/20 09:24:10 main.go:158: [interface] OrchestrationInit
 2020/07/20 09:24:10 main.go:159: >>> commitID  :  094ca91
 2020/07/20 09:24:10 main.go:160: >>> version   :  
@@ -161,7 +161,7 @@ REST API
     ```
 - Curl Example:
 ```json
-$ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceRequester\": \"curl\", \"ServiceName\": \"ls\", \"ServiceInfo\": [{ \"ExecutionType\": \"native\", \"ExecCmd\": [ \"ls\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"ServiceRequester\": \"curl\", \"ServiceName\": \"ls\", \"ServiceInfo\": [{ \"ExecutionType\": \"native\", \"ExecCmd\": [ \"ls\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
 ```
 Response:
 ```
@@ -201,11 +201,11 @@ You need to add a JSON Web Token into request header `Authorization: {token}`. M
 
 > To add the `EDGE_ORCHESTRATION_TOKEN` variable to the environment execute the next command:
 ```
-$ . tools/jwt_gen.sh HS256 Admin
+. tools/jwt_gen.sh HS256 Admin
 ```
 
 ```
-$ curl -X POST "127.0.0.1:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceRequester\": \"curl\", \"ServiceName\": \"ls\", \"ServiceInfo\": [{ \"ExecutionType\": \"native\", \"ExecCmd\": [ \"ls\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+curl -X POST "127.0.0.1:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceRequester\": \"curl\", \"ServiceName\": \"ls\", \"ServiceInfo\": [{ \"ExecutionType\": \"native\", \"ExecCmd\": [ \"ls\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
 ```
 Response:
 ```

--- a/docs/secure_manager.md
+++ b/docs/secure_manager.md
@@ -137,7 +137,7 @@ Example: _how to add hash by command line_
 ### 2.4 Usage Edge-Orchestration with Verifier
 To run **Edge Orchestration** container you need to add a digest (sha256) to the last parameter. For example:  `"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"`
 ```
-$ curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+curl -X POST "IP:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}], \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
 ```  
 If the `"fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"` hash is written to the `/var/edge-orchestration/data/cwl/containerwhitelist.txt` file, the container will be launched successfully.
 
@@ -184,24 +184,24 @@ node "Home Edge Node #1" {
 To create a JWT, you can use the script [tools/jwt_gen.sh](../tools/jwt_gen.sh) by running it as shown below:
 For `HMAC`
 ```shell
-$ . tools/jwt_gen.sh HS256 Admin
+. tools/jwt_gen.sh HS256 Admin
 ```
 or for `RSA256`
 ```shell
-$ . tools/jwt_gen.sh RS256 Admin
+. tools/jwt_gen.sh RS256 Admin
 ```
 
 The generated token is exported to the shell environment variable: `EDGE_ORCHESTRATION_TOKEN`.
 Enter the following command to display the token:
 ```shell
-$ echo $EDGE_ORCHESTRATION_TOKEN
+echo $EDGE_ORCHESTRATION_TOKEN
 ```
 
 > If you want to use the `RSA256` algorithm, you need to generate keys using the commands:
 ```
-$ cd /var/edge-orchestration/data/jwt
-$ openssl genrsa -out app_rsa.key keysize
-$ openssl rsa -in app_rsa.key -pubout > app_rsa.pub
+cd /var/edge-orchestration/data/jwt
+openssl genrsa -out app_rsa.key keysize
+openssl rsa -in app_rsa.key -pubout > app_rsa.pub
 ```
 
 ---
@@ -209,7 +209,7 @@ $ openssl rsa -in app_rsa.key -pubout > app_rsa.pub
 To use a JWT, you must include it in the header of the request: `Authorization: {token}`.
 Example below:
 ```shell
-$ curl -X POST "127.0.0.1:56001/api/v1/orchestration/securemgr" -H "accept: applicationnt-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"SecureMgr\": \"Verifier\", \"CmdType\": \"printAllHashCWL\", \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
+curl -X POST "127.0.0.1:56001/api/v1/orchestration/securemgr" -H "accept: applicationnt-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"SecureMgr\": \"Verifier\", \"CmdType\": \"printAllHashCWL\", \"StatusCallbackURI\": \"http://localhost:8888/api/v1/services/notification\"}"
 ```
 ---
 
@@ -258,17 +258,17 @@ p, member, /api/v1/orchestration/services, *
 To create a JWT, you can use the script [tools/jwt_gen.sh](../tools/jwt_gen.sh) by running it as shown below:
 common rules
 ```shell
-$ . tools/jwt_gen.sh [Algo] [User]
+. tools/jwt_gen.sh [Algo] [User]
 ```
 where: Algo {}; User {Admin, Member}.
 Examples:
 For `HMAC` and `Admin`
 ```shell
-$ . tools/jwt_gen.sh HS256 Admin
+. tools/jwt_gen.sh HS256 Admin
 ```
 or for `RSA256` and `Member`
 ```shell
-$ . tools/jwt_gen.sh RS256 Member
+. tools/jwt_gen.sh RS256 Member
 ```
 > It should be noted that the user's `name` and `role` are currently hardcoded in [authorizer.go](../internal/controller/securemgr/authorizer/authorizer.go),
  but this will change when the ability to register users in the system is added.  
@@ -313,7 +313,7 @@ There are two scripts:
 #### CA Root Certificate
 Generating a CA Root Certificate only needs to be done once for _Home Edge Network_ by running command:
 ```shell
-$ tools/gen_ca_cert.sh
+tools/gen_ca_cert.sh
 ```
 As a result, we get the private key `cert/ca.key` and self-signed root certificate `cert/ca.crt`. The certificate must be saved on all nodes in the `/var/edge-orchestration/data/cert/` folder.
 
@@ -322,7 +322,7 @@ Generate HEN Certificate private key : hen.key
 
 For each node, need to create a private key `hen.key` and a certificate `hen.crt`. To do this, need to start the script and specify the node IP address. 
 ```shell
-$ tools/gen_hen_cert.sh 192.168.0.100
+tools/gen_hen_cert.sh 192.168.0.100
 ```
 As a result, the key and certificate will be created in the `cert/<IP>/`. They must be copied into the `/var/edge-orchestration/data/cert/` folder on a node with the specified IP address
 

--- a/docs/testing_policy.md
+++ b/docs/testing_policy.md
@@ -29,23 +29,22 @@ There are two ways to test:
 ### 2.1 Using the makefile
 To start testing all packages:
 ```
-$ make test
+make test
 ```
 To start testing a specific package:
 ```
-$ make test [PKG_NAME]
+make test [PKG_NAME]
 ```
 
 ### 2.2 Using standard Go language facilities
 To start testing all packages:
 ```
-$ gocov test $(go list ./internal/... | grep -v mock) -coverprofile=/dev/null
+gocov test $(go list ./internal/... | grep -v mock) -coverprofile=/dev/null
 ```
 To start testing a specific package:
 ```
-$ go test -v [PKG_NAME]
+go test -v [PKG_NAME]
 ```
-
 
 ---
 
@@ -55,4 +54,3 @@ Code testing occurs remotely using a [github->Actions->workflow (Build)](https:/
 
 > [More information on github->actions](https://docs.github.com/en/actions) 
 ---
- 


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

I propose to remove the CLI prompt symbol `$` from examples of commands in our documentation. This will allow to use the copy button without additional string editing.
 
![изображение](https://user-images.githubusercontent.com/45031429/137857186-23f44e85-1ca7-4203-9637-8c42ed233a27.png)

## Type of change
- [x] Documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
