### PR TITLE
Add configuration file for x86_64 native secure

### DIFF
--- a/configs/defconfigs/x86_64ns
+++ b/configs/defconfigs/x86_64ns
@@ -1,0 +1,14 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Edge-Home-Orchstration Configuration
+#
+CONFIG_CONFIGFILE="x86_64ns"
+CONFIG_X86_64=y
+# CONFIG_X86 is not set
+# CONFIG_ARM is not set
+# CONFIG_ARM64 is not set
+# CONFIG_CONTAINER is not set
+CONFIG_NATIVE=y
+# CONFIG_ANDROID is not set
+# CONFIG_MNEDC is not set
+CONFIG_SECURE_MODE=y


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Added configuration template for quick build of x86_64 native protected mode. 

Fixes #404 

## Type of change

Please delete options that are not relevant.

- [x] Code cleanup/refactoring

# How Has This Been Tested?

Described [here](https://github.com/lf-edge/edge-home-orchestration-go/blob/master/docs/platforms/x86_64_linux/x86_64_native.md#how-to-build)

**Test Configuration**:
* OS type & version: Ubuntu 18.04
* Hardware: x86-64
* Toolchain: Docker v17.6 and Go v1.16
* Edge Orchestration Release: v1.0.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
