### PR TITLE
[DataStorage]Replace getDeviceID functions in storage.go file with helper.go

### DIFF
--- a/internal/controller/storagemgr/storage.go
+++ b/internal/controller/storagemgr/storage.go
@@ -241,11 +241,3 @@ func saveYaml() (err error) {
 	}
 	return
 }
-
-func getDeviceID() (string, error) {
-	UUIDv4, err := ioutil.ReadFile(deviceIDFilePath)
-	if err != nil {
-		return "", err
-	}
-	return string(UUIDv4), nil
-}

--- a/internal/controller/storagemgr/storage.go
+++ b/internal/controller/storagemgr/storage.go
@@ -67,8 +67,6 @@ var (
 )
 
 func init() {
-	dbIns = dbhelper.GetInstance()
-	deviceName, _ = dbIns.GetDeviceID()
 	storageIns = &StorageImpl{
 		sd:     storagedriver.StorageDriver{},
 		status: 0,
@@ -104,6 +102,8 @@ func checkMetadataStatus() bool {
 
 // StartStorage starts a server in terms of DataStorage
 func (s *StorageImpl) StartStorage(host string) (err error) {
+	dbIns = dbhelper.GetInstance()
+	deviceName, _ = dbIns.GetDeviceID()
 	//Getting the Edge-Orchestration IP
 	ipv4, err = networkhelper.GetInstance().GetOutboundIP()
 	if err != nil {

--- a/internal/controller/storagemgr/storage.go
+++ b/internal/controller/storagemgr/storage.go
@@ -29,6 +29,7 @@ import (
 	networkhelper "github.com/lf-edge/edge-home-orchestration-go/internal/common/networkhelper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver"
+	dbhelper "github.com/lf-edge/edge-home-orchestration-go/internal/db/helper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper"
 )
 
@@ -60,13 +61,14 @@ var (
 	deviceName string
 	ipv4       string
 	storageIns *StorageImpl
+	dbIns      dbhelper.MultipleBucketQuery
 	helper     resthelper.RestHelper
 	log        = logmgr.GetInstance()
 )
 
 func init() {
-	deviceID, _ := getDeviceID()
-	deviceName = "edge-orchestration-" + deviceID
+	dbIns = dbhelper.GetInstance()
+	deviceName, _ = dbIns.GetDeviceID()
 	storageIns = &StorageImpl{
 		sd:     storagedriver.StorageDriver{},
 		status: 0,


### PR DESCRIPTION
Signed-off-by: Seughui98 <hithere1012@naver.com>

# Description

We have to replace getDeviceID in storage.go file with GetDevice function. 
So, I called GetDevice() in the helper.go file and changed it.

Fixes [#321](https://github.com/lf-edge/edge-home-orchestration-go/issues/321) (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Code cleanup/refactoring


# How Has This Been Tested?
I took the logs to test and here is the result.
```
INFO[2021-11-02T12:31:13Z]discovery.go:744 clearAllDeviceInfo [discoverymgr] Delete All Device Info        
INFO[2021-11-02T12:31:13Z]discovery.go:839 deleteDevice [discoverymgr] [deleteDevice] edge-orchestration-e61b3b31-9723-47fd-bd49-38aa865e057f 
INFO[2021-11-02T12:31:13Z]networkhelper.go:194 setAddrInfo [networkmgr] addr 10.0.2.15/24               
INFO[2021-11-02T12:31:13Z]discovery.go:398 setDeviceID [discoverymgr] UUID :  e61b3b31-9723-47fd-bd49-38aa865e057f 
INFO[2021-11-02T12:31:13Z]discovery.go:542 SetNetwotkArgument [discoverymgr] [10.0.2.15]                   
INFO[2021-11-02T12:31:13Z]discovery.go:573 func1 [deviceDetectionRoutine] edge-orchestration-e61b3b31-9723-47fd-bd49-38aa865e057f 
INFO[2021-11-02T12:31:13Z]discovery.go:574 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2021-11-02T12:31:13Z]discovery.go:575 func1 [deviceDetectionRoutine] netInfo     : IPv4([10.0.2.15]), RTT(0) 
INFO[2021-11-02T12:31:13Z]discovery.go:576 func1 [deviceDetectionRoutine] serviceInfo : Services([]) 
INFO[2021-11-02T12:31:13Z]discovery.go:577 func1                                              
INFO[2021-11-02T12:31:13Z]storage.go:107 StartStorage [storagemgr][deviceName]edge-orchestration-e61b3b31-9723-47fd-bd49-38aa865e057f 
INFO[2021-11-02T12:31:13Z]discovery.go:647 mdnsTXTSizeChecker [discoverymgr] [mdnsTXTSizeChecker] size ::  29  Bytes 
INFO[2021-11-02T12:31:13Z]configuremgr.go:149 Watch start watching for/var/edge-orchestration/apps 
INFO[2021-11-02T12:31:13Z]route.go:84 Add {APIV1Ping GET /api/v1/ping 0xbefe60}        
INFO[2021-11-02T12:31:13Z]route.go:84 Add {APIV1ServicemgrServicesPost POST /api/v1/servicemgr/services 0xbeff00} 
INFO[2021-11-02T12:31:13Z]route.go:84 Add {APIV1ServicemgrServicesNotificationServiceIDPost POST /api/v1/servicemgr/services/notification/{serviceid} 0xbeff80} 
```


**Test Configuration**:
* Firmware version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker 20.10.6 and Go 1.16.3
* Edge Orchestration Release: Coconut

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes