### PR TITLE
Add CODEOWNERS for automatic reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lf-edge/edge-home-orchestration-go-maintainers 


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

The members of @lf-edge/edge-home-orchestration-go-maintainers will be assigned to reviewers automatically.

## Type of change

- [x] CI system update

