### PR TITLE
Use multi-stage build

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,6 +1,6 @@
 ---
 name: Build and Publish Containers
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,0 +1,30 @@
+---
+name: Build and Publish Containers
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [linux/amd64, linux/386, linux/arm64, linux/arm/v7]
+        os: [ubuntu-20.04, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.16.6'
+
+      - name: Install Qemu
+        if:  ${{ matrix.arch != 'x86_64c' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu binfmt-support qemu-user-static
+
+      - name: Build
+        run: |
+          make distclean
+          docker buildx build --tag lfedge/edge-home-orchestration-go:latest --platform=${{ matrix.arch }} --file configs/defdockerfiles/ubuntu_multistage .

--- a/Makefile
+++ b/Makefile
@@ -311,3 +311,9 @@ do_savedefconfig:
 	$(Q) cp -f .config configs/defconfigs/$(CONFIG_CONFIGFILE)
 
 savedefconfig: do_savedefconfig
+
+# Building binaries through multi-stage build
+buildx_binary:
+	$(call print_header, "Create Executable binary through buildx")
+	$(GOBUILD) -a $(GO_LDFLAGS) -o $(BIN_DIR)/$(BIN_FILE) $(CMD_SRC) || exit 1
+	$(Q) ls -al $(BIN_DIR)

--- a/configs/defdockerfiles/ubuntu_multistage
+++ b/configs/defdockerfiles/ubuntu_multistage
@@ -1,0 +1,51 @@
+# Docker image for "edge-orchestration"
+FROM --platform=$TARGETPLATFORM ubuntu:18.04 AS builder
+
+# environment variables
+ARG TARGETPLATFORM
+ENV GOVERSION=1.16.6
+ENV GOPATH=/usr/local/go
+ENV TARGET_DIR=/edge-orchestration
+
+# set the working directory
+WORKDIR $TARGET_DIR
+
+COPY . .
+
+# install required tools
+RUN apt update
+RUN apt install -y net-tools iproute2 wget build-essential git
+RUN script/install-golang.sh
+RUN make buildx_binary
+
+FROM ubuntu:18.04
+
+# environment variables
+ENV TARGET_DIR=/edge-orchestration
+ENV HTTP_PORT=56001
+ENV MDNS_PORT=5353
+ENV MNEDC_PORT=3334
+ENV MNEDC_BROADCAST_PORT=3333
+ENV ZEROCONF_PORT=42425
+ENV APP_BIN_DIR=bin
+ENV APP_NAME=edge-orchestration
+ENV APP_QEMU_DIR=$APP_BIN_DIR/qemu
+ENV BUILD_DIR=build
+
+# set the working directory
+WORKDIR $TARGET_DIR
+
+# copy files
+COPY --from=builder $TARGET_DIR/$APP_BIN_DIR/$APP_NAME $TARGET_DIR/
+COPY --from=builder $TARGET_DIR/$BUILD_DIR/package/run.sh $TARGET_DIR/
+RUN mkdir -p $TARGET_DIR/res/
+
+# install required tools
+RUN apt-get update
+RUN apt-get install -y net-tools iproute2
+
+# expose ports
+EXPOSE $HTTP_PORT $MDNS_PORT $ZEROCONF_PORT $MNEDC_PORT $MNEDC_BROADCAST_PORT
+
+# kick off the edge-orchestration container
+CMD ["sh", "run.sh"]

--- a/script/install-golang.sh
+++ b/script/install-golang.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo The platform is $TARGETPLATFORM.
+if [ $TARGETPLATFORM = "linux/amd64" ]; then
+    arch="amd64"
+elif [ $TARGETPLATFORM = "linux/386" ]; then
+    arch="386"
+elif [ $TARGETPLATFORM = "linux/arm64" ]; then
+    arch="arm64"
+elif [ $TARGETPLATFORM = "linux/arm/v7" ]; then
+    arch="armv6l"
+fi
+
+wget https://golang.org/dl/go$GOVERSION.linux-$arch.tar.gz && \
+tar -C /usr/local -xzf go$GOVERSION.linux-$arch.tar.gz && \
+ln -s $GOPATH/bin/go /usr/bin/


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

This PR uses multi-stage build with docker buildx plugin.  
It works properly over Docker engine 19.3 and Ubuntu 20.04.

Currently, multi-stage build code is to be used for automatic container image deployment to Docker Hub.
However, hopefully, multi-stage build code will be applied to Makfefile from v2.

Related #413 

## Type of change

- [x] CI system update

# How Has This Been Tested?
## Local PC
**x86_64**
```
docker buildx build --tag lfedge/edge-home-orchestration-go:latest --platform=linux/amd64 --file configs/defdockerfiles/ubuntu_multistage .
```
**arm**
```
docker buildx build --tag lfedge/edge-home-orchestration-go:latest --platform=linux/arm/v7 --file configs/defdockerfiles/ubuntu_multistage .
```

**Test Configuration**:
* OS type & version: Ubuntu 20.04 and latest
* Toolchain: Docker v20.10 and Go v1.16
* Edge Orchestration Release: v1.1.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes