### PR TITLE
Update Ubuntu (16.04->18.04) as the basic image of edge-orchestration…

### DIFF
--- a/configs/defdockerfiles/ubuntu
+++ b/configs/defdockerfiles/ubuntu
@@ -1,7 +1,7 @@
 # Docker image for "edge-orchestration"
-### ubuntu:16.04
+### ubuntu:18.04
 ARG PLATFORM
-FROM $PLATFORM/ubuntu:16.04
+FROM $PLATFORM/ubuntu:18.04
 
 # environment variables
 ENV TARGET_DIR=/edge-orchestration


### PR DESCRIPTION
… container

Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

In connection with the use of Ubuntu 18.04 image for automatic build and push to the Docker Hub and also the Ububntu 18.04 image of a smaller size you can see it below:
```
virtual-pc@virtualpc-VirtualBox:~/projects/edge-home-orchestration-go$ docker images 
REPOSITORY                                     TAG            IMAGE ID       CREATED         SIZE
lfedge/edge-home-orchestration-go              latest         4bfb0330da21   19 seconds ago   134MB
lfedge/edge-home-orchestration-go              latest         e27c21ba8673   43 hours ago    198MB
amd64/ubuntu                                   18.04          5a214d77f5d7   7 weeks ago     63.1MB
amd64/ubuntu                                   16.04          b6f507652425   2 months ago    135MB
``` 

## Type of change

- [x] Code cleanup/refactoring

**Test Configuration**:
* OS type & version: Ubuntu 18.04)
* Hardware: x86-64, arm
* Toolchain: Docker v19.6 and Go v1.16)
* Edge Orchestration Release: v1.1.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
