### PR TITLE
[WIP] Insert the current version of the edge-orchestration relative to the …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup Golang
         uses: actions/setup-go@v1

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 endif
 
 BUILD_DATE=${shell date +%Y%m%d.%H%M}
-VERSION=v1.1.0
+VERSION=${shell git describe --tags ${shell git rev-list --tags --max-count=1}}
 CONTAINER_VERSION="latest"
 DOCKER_IMAGE="lfedge/edge-home-orchestration-go"
 


### PR DESCRIPTION
…last git tag

Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description
To get rid of manual changing of the version in the source code and automation of the load new container to Docker Hub. The version will be read from GIT.

## Type of change

- [x] Code cleanup/refactoring
- [x] CI system update

# How Has This Been Tested?
```
make 
```
Check version:

```
GOARM= GOARCH=amd64 GO111MODULE=on go build -a -ldflags '-extldflags "-static" -X main.version=v1.1.0 -X main.commitID=a5a7527 -X main.buildTime=20211125.1214' -o /home/virtual-pc/projects/edge-home-orchestration-go/bin/edge-orchestration /home/virtual-pc/projects/edge-home-orchestration-go/cmd/edge-orchestration/main.go || exit 1
```

**Test Configuration**:
* OS type & version: Ubuntu 18.04
* Hardware: x86-64
* Toolchain: Docker v17.6 and Go v1.16
* Edge Orchestration Release: v1.1.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
