### PR TITLE
Assign the tag version automatically while building container images at github workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          build-args: TARGETVERSION=v${{ steps.meta.outputs.version }}
           platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/configs/defdockerfiles/ubuntu_multistage
+++ b/configs/defdockerfiles/ubuntu_multistage
@@ -16,7 +16,8 @@ COPY . .
 RUN apt update
 RUN apt install -y wget build-essential git
 RUN script/install-golang.sh
-RUN make buildx_binary
+ARG TARGETVERSION
+RUN make buildx_binary VERSION=$TARGETVERSION
 
 FROM ubuntu:18.04
 


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

This PR is intended to assign the pushed tag version to the container image.

## Type of change

- [x] CI system update

# How Has This Been Tested?
Push a tag (eg, v1.1.2) to the master branch.

**Image for part of the workflow logs**
![image](https://user-images.githubusercontent.com/5847128/143951482-a3e574ff-95c0-4f00-a921-d6cd531878a0.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
