### PR TITLE
Update deprecated client.NewEnvClient function

### DIFF
--- a/internal/controller/servicemgr/executor/containerexecutor/ce_docker.go
+++ b/internal/controller/servicemgr/executor/containerexecutor/ce_docker.go
@@ -51,7 +51,7 @@ type CEDocker struct {
 }
 
 func newCEDocker() (ceDocker *CEDocker) {
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err == nil {
 		ceDocker = &CEDocker{context.Background(), cli}
 	}

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,5 +1,5 @@
 checks = ["all", "-ST1000", "-ST1016", "-U1000", "-S1000",
-	"-S1021", "-S1034", "-S1040", "-SA1019", "-SA4000"]
+	"-S1021", "-S1034", "-S1040", "-SA4000"]
 initialisms = ["ACL", "API", "ASCII", "CPU", "CSS", "DNS",
 	"EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID",
 	"IP", "JSON", "QPS", "RAM", "RPC", "SLA",


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Due to [deprecation, `client.NewEnvClient` function](https://pkg.go.dev/github.com/docker/docker/client#pkg-index) has been updated to `NewClientWithOpts(FromEnv)`

## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?


**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v19 and Go v1.16
* Edge Orchestration Release: v1.1.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
