### PR TITLE
[CloudSync] Adding the API to be exposed to thirdparty for Data Publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ RUN_OPTIONS += -e SECURE=true
 endif
 
 ifeq ($CONFIG_CLOUD_SYNC),y)
-RUN_OPTIONS += -e CLOUD_SYNC=""
+RUN_OPTIONS += -e CLOUD_SYNC=true
 endif
                                                                                                               
 # Go parameters

--- a/internal/common/mqtt/mqttconfig.go
+++ b/internal/common/mqtt/mqttconfig.go
@@ -46,8 +46,22 @@ type Message struct {
 	Payload string
 }
 
+var (
+	mqttClient *Client
+)
+
 // Config represents an attribute config setter for the `Client`.
 type Config func(*Client)
+
+//SetClient sets the client
+func SetClient(client *Client) {
+	mqttClient = client
+}
+
+//GetClient gets the client set
+func GetClient() *Client {
+	return mqttClient
+}
 
 // SetClientID sets the mqtt client id.
 func SetClientID(id string) Config {
@@ -78,7 +92,7 @@ func (c *Client) SetBrokerURL(protocol string) string {
 // NewClient returns a configured `Client`. Is mandatory
 func NewClient(configs ...Config) (*Client, error) {
 	client := &Client{
-		Qos: byte(0),
+		Qos: byte(1),
 	}
 
 	for _, config := range configs {
@@ -86,12 +100,12 @@ func NewClient(configs ...Config) (*Client, error) {
 	}
 
 	copts := MQTT.NewClientOptions()
-	copts.SetClientID(clientID)
 	copts.SetAutoReconnect(true)
 	copts.SetMaxReconnectInterval(1 * time.Second)
 	copts.SetOnConnectHandler(client.onConnect())
 	copts.SetConnectionLostHandler(func(c MQTT.Client, err error) {
 		log.Warn(logPrefix, " disconnected, reason: "+err.Error())
+		mqttClient.Connect()
 	})
 
 	client.ClientOptions = copts

--- a/internal/common/mqtt/mqttconnection.go
+++ b/internal/common/mqtt/mqttconnection.go
@@ -56,6 +56,22 @@ func (client *Client) onConnect() MQTT.OnConnectHandler {
 	return nil
 }
 
+// IsConnected checks if the client is connected or not
+func (client *Client) IsConnected() bool {
+	if client.Client == nil {
+		return false
+	}
+
+	return client.Client.IsConnected()
+}
+
+// Disconnect disconnects the connection
+func (client *Client) Disconnect(quiesce uint) {
+	if client.Client != nil {
+		client.Client.Disconnect(quiesce)
+	}
+}
+
 //StartMQTTClient is used to initiate the client and set the configuration
 func StartMQTTClient(brokerURL string) {
 
@@ -75,15 +91,19 @@ func StartMQTTClient(brokerURL string) {
 	if connectErr != nil {
 		log.Warn(logPrefix, connectErr)
 	}
+
+	SetClient(clientConfig)
+
 }
 
 //Publish is used to publish the client data to the cloud
-func Publish(client *Client, message Message, topic string) error {
+func (client *Client) Publish(message Message, topic string) error {
 
 	log.Info(logPrefix, "Publishing the data to cloud")
 	payload, err := json.Marshal(message)
 	if err != nil {
 		log.Warn(logPrefix, "Error in Json Marshalling", err)
+		return err
 	}
 	mqttClient := client.Client
 	for mqttClient == nil {

--- a/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
+++ b/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
@@ -22,6 +22,7 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	mqttmgr "github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	reflect "reflect"
 )
 
@@ -48,6 +49,18 @@ func (_m *MockCloudSync) EXPECT() *MockCloudSyncMockRecorder {
 	return _m.recorder
 }
 
+// InitiateCloudSync mocks base method
+func (_m *MockCloudSync) InitiateCloudSync(isCloudSet string) error {
+	ret := _m.ctrl.Call(_m, "InitiateCloudSync", isCloudSet)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InitiateCloudSync indicates an expected call of StartCloudSync
+func (_mr *MockCloudSyncMockRecorder) InitiateCloudSync(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "InitiateCloudSync", reflect.TypeOf((*MockCloudSync)(nil).StartCloudSync), arg0)
+}
+
 // StartCloudSync mocks base method
 func (_m *MockCloudSync) StartCloudSync(host string) error {
 	ret := _m.ctrl.Call(_m, "StartCloudSync", host)
@@ -58,4 +71,16 @@ func (_m *MockCloudSync) StartCloudSync(host string) error {
 // StartCloudSync indicates an expected call of StartCloudSync
 func (_mr *MockCloudSyncMockRecorder) StartCloudSync(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "StartCloudSync", reflect.TypeOf((*MockCloudSync)(nil).StartCloudSync), arg0)
+}
+
+// StartCloudSync mocks base method
+func (_m *MockCloudSync) RequestCloudSyncConf(message mqttmgr.Message, host string, clientID string) string {
+	ret := _m.ctrl.Call(_m, "RequestCloudSyncConf", host)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// StartCloudSync indicates an expected call of StartCloudSync
+func (_mr *MockCloudSyncMockRecorder) StartCRequestCloudSyncConfloudSync(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "RequestCloudSyncConf", reflect.TypeOf((*MockCloudSync)(nil).StartCloudSync), arg0)
 }

--- a/internal/orchestrationapi/mocks/mock_orchestration.go
+++ b/internal/orchestrationapi/mocks/mock_orchestration.go
@@ -22,10 +22,12 @@
 package mocks
 
 import (
+	reflect "reflect"
+
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	configuremgrtypes "github.com/lf-edge/edge-home-orchestration-go/internal/common/types/configuremgrtypes"
 	verifier "github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	orchestrationapi "github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
-	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -100,6 +102,20 @@ func (m *MockOrcheExternalAPI) RequestService(arg0 orchestrationapi.ReqeustServi
 func (mr *MockOrcheExternalAPIMockRecorder) RequestService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestService", reflect.TypeOf((*MockOrcheExternalAPI)(nil).RequestService), arg0)
+}
+
+// RequestCloudSync mocks base method.
+func (m *MockOrcheExternalAPI) RequestCloudSync(arg0 mqtt.Message, arg1 string, arg2 string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestCloudSync", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RequestCloudSync indicates an expected call of RequestService.
+func (mr *MockOrcheExternalAPIMockRecorder) RequestCloudSync(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestCloudSync", reflect.TypeOf((*MockOrcheExternalAPI)(nil).RequestService), arg0)
 }
 
 // RequestVerifierConf mocks base method.

--- a/internal/orchestrationapi/orchestration.go
+++ b/internal/orchestrationapi/orchestration.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/cloudsyncmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
 
@@ -54,6 +55,7 @@ type Orche interface {
 type OrcheExternalAPI interface {
 	RequestService(serviceInfo ReqeustService) ResponseService
 	verifier.Conf
+	RequestCloudSync(message mqtt.Message, topic string, clientID string) string
 }
 
 // OrcheInternalAPI is the interface implemented by internal REST API
@@ -215,7 +217,8 @@ func (o *orcheImpl) Start(deviceIDPath string, platform string, executionType st
 	resourceMonitorImpl.StartMonitoringResource()
 	o.discoverIns.StartDiscovery(deviceIDPath, platform, executionType)
 	o.storageIns.StartStorage("")
-	o.cloudsyncIns.StartCloudSync(os.Getenv("CLOUD_SYNC"))
+	cloudSyncState := os.Getenv("CLOUD_SYNC")
+	o.cloudsyncIns.InitiateCloudSync(cloudSyncState)
 	o.watcher.Watch(o)
 	o.Ready = true
 	time.Sleep(1000)

--- a/internal/orchestrationapi/orchestration_test.go
+++ b/internal/orchestrationapi/orchestration_test.go
@@ -224,7 +224,7 @@ func TestStart(t *testing.T) {
 			mockResourceutil.EXPECT().StartMonitoringResource(),
 			mockDiscovery.EXPECT().StartDiscovery(gomock.Eq(deviceIDPath), gomock.Eq(platform), gomock.Eq(executionType)),
 			mockStorage.EXPECT().StartStorage(gomock.Any()),
-			mockCloudSync.EXPECT().StartCloudSync(gomock.Any()),
+			mockCloudSync.EXPECT().InitiateCloudSync(gomock.Any()),
 			mockWatcher.EXPECT().Watch(gomock.Any()),
 		)
 

--- a/internal/orchestrationapi/orchestrationapi.go
+++ b/internal/orchestrationapi/orchestrationapi.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/networkhelper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/requestervalidator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/cloudsyncmgr"
@@ -126,6 +127,12 @@ func init() {
 	sysDBExecutor = sysDB.Query{}
 
 	helper = dbhelper.GetInstance()
+}
+
+//RequestCloudSync handles the request for cloud syncing
+func (orcheEngine *orcheImpl) RequestCloudSync(message mqtt.Message, topic string, clientID string) string {
+	log.Info("[RequestCloudSync]", "Requesting cloud sync")
+	return orcheEngine.cloudsyncIns.RequestCloudSyncConf(message, topic, clientID)
 }
 
 // RequestService handles service request (ex. offloading) from service application

--- a/internal/restinterface/externalhandler/externalhandler.go
+++ b/internal/restinterface/externalhandler/externalhandler.go
@@ -26,7 +26,9 @@ import (
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 
+	mqttmgr "github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/networkhelper"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/cloudsyncmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/common"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
@@ -72,6 +74,12 @@ func init() {
 			Method:      strings.ToUpper("Post"),
 			Pattern:     "/api/v1/orchestration/securemgr",
 			HandlerFunc: handler.APIV1RequestSecuremgrPost,
+		},
+		restinterface.Route{
+			Name:        "APIV1RequestCloudSyncmgrPost",
+			Method:      strings.ToUpper("Post"),
+			Pattern:     "/api/v1/orchestration/cloudsyncmgr",
+			HandlerFunc: handler.APIV1RequestCloudSyncmgrPost,
 		},
 	}
 	handler.netHelper = networkhelper.GetInstance()
@@ -344,6 +352,101 @@ SEND_RESP:
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
 	if err != nil {
 		log.Printf("[%s] cannot encryption", logPrefix)
+		h.helper.Response(w, nil, http.StatusServiceUnavailable)
+		return
+	}
+
+	h.helper.Response(w, respEncryptBytes, http.StatusOK)
+}
+
+// APIV1RequestCloudSyncmgrPost handles cloudsync publish request from service application
+func (h *Handler) APIV1RequestCloudSyncmgrPost(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[%s] APIV1RequestCloudSyncmgrPost", logPrefix)
+	if !h.isSetAPI {
+		log.Printf("[%s] does not set api", logPrefix)
+		h.helper.Response(w, nil, http.StatusServiceUnavailable)
+		return
+	} else if !h.IsSetKey {
+		log.Printf("[%s] does not set key", logPrefix)
+		h.helper.Response(w, nil, http.StatusServiceUnavailable)
+		return
+	}
+
+	reqAddr := strings.Split(r.RemoteAddr, ":")
+	var addr string
+	if strings.Contains(r.RemoteAddr, "::1") {
+		addr = "localhost"
+	} else {
+		addr = reqAddr[0]
+	}
+	ips, err := h.netHelper.GetIPs()
+	if err != nil {
+		h.helper.Response(w, nil, http.StatusServiceUnavailable)
+		return
+	} else if addr != "localhost" && addr != "127.0.0.1" && !common.HasElem(ips, addr) {
+		h.helper.Response(w, nil, http.StatusNotAcceptable)
+		return
+	}
+
+	var (
+		responseMsg    string
+		topic          string
+		messagePayload string
+		url            string
+	)
+
+	//request
+	encryptBytes, _ := ioutil.ReadAll(r.Body)
+
+	//Decrypt the request in json format
+	appCommand, err := h.Key.DecryptByteToJSON(encryptBytes)
+	if err != nil {
+		log.Printf("[%s] can not decryption", logPrefix)
+		h.helper.Response(w, nil, http.StatusServiceUnavailable)
+		return
+	}
+	publishMessage := mqttmgr.Message{}
+
+	appID, ok := appCommand["appid"].(string)
+	if ok {
+		publishMessage.AppID = appID
+	} else {
+		responseMsg = orchestrationapi.InvalidParameter
+		goto SEND_RESP
+	}
+
+	messagePayload, ok = appCommand["payload"].(string)
+	if ok {
+		publishMessage.Payload = messagePayload
+	} else {
+		responseMsg = orchestrationapi.InvalidParameter
+		goto SEND_RESP
+	}
+	topic, ok = appCommand["topic"].(string)
+	if !ok {
+		responseMsg = orchestrationapi.InvalidParameter
+		goto SEND_RESP
+	}
+	url, ok = appCommand["url"].(string)
+	if !ok {
+		responseMsg = orchestrationapi.InvalidParameter
+		goto SEND_RESP
+	}
+	cloudsyncmgr.GetInstance().StartCloudSync(url)
+	for mqttmgr.GetClient() == nil {
+		//Wait till the client is set
+	}
+	responseMsg = h.api.RequestCloudSync(publishMessage, topic, appID)
+
+SEND_RESP:
+	respJSONMsg := make(map[string]interface{})
+	respJSONMsg["Message"] = responseMsg
+	respJSONMsg["ServiceName"] = ""
+	respJSONMsg["RemoteTargetInfo"] = ""
+
+	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
+	if err != nil {
+		log.Printf("[%s] can not encryption", logPrefix)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description
provide mechanism to expose API that can be used by third party apps to publish data to MQTT broker running on AWS endpoint

Fixes # (#382 )

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
1.MQTT mosquitto broker is configured to be running in the AWS endpoint.
2. The edge orchestration is build and run using following command with option CLOUD_SYNC set to true
```
docker run -it -d --privileged --network="host" --name edge-orchestration -e CLOUD_SYNC=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
```
3. The logs are checked using the command
```
docker logs -f edge-orchestration
```
4. From the another terminal/post make a curl command as follows to publish data using home edge to the broker running on AWS endpoint
```
curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr' \
> --header 'Content-Type: text/plain' \
> --data-raw '{
>     "appid": "TV1",
>     "payload": "{Another data from TV1}",
>     "topic": "home/livingroom",
>     "url" : "ec2-54-144-110-26.compute-1.amazonaws.com"
> }'
```
5. You should obtain the following message for successful publish
```
{"Message":"Data published successfully to Cloud","RemoteTargetInfo":"","ServiceName":""}
```

**Test Configuration**:
* OS type & version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (v1.1.0)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
