### PR TITLE
[CloudSync] Saving the Client Data to avoid reconnection for same client in same home edge session

### DIFF
--- a/internal/common/mqtt/mqttconnection_test.go
+++ b/internal/common/mqtt/mqttconnection_test.go
@@ -20,13 +20,14 @@ import (
 	"testing"
 )
 
-//const Host = "broker.emqx.io"
-const Host = "ec2-54-175-241-64.compute-1.amazonaws.com"
+const Host = "broker.hivemq.com"
 const port = "1883"
 
 func TestStartMQTTClient(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		StartMQTTClient(Host)
+		InitClientData()
+		StartMQTTClient(Host, "testClient")
+		t.Log("Client connected")
 	})
 
 }

--- a/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
+++ b/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
@@ -58,29 +58,17 @@ func (_m *MockCloudSync) InitiateCloudSync(isCloudSet string) error {
 
 // InitiateCloudSync indicates an expected call of StartCloudSync
 func (_mr *MockCloudSyncMockRecorder) InitiateCloudSync(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "InitiateCloudSync", reflect.TypeOf((*MockCloudSync)(nil).StartCloudSync), arg0)
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "InitiateCloudSync", reflect.TypeOf((*MockCloudSync)(nil).InitiateCloudSync), arg0)
 }
 
 // StartCloudSync mocks base method
-func (_m *MockCloudSync) StartCloudSync(host string) error {
-	ret := _m.ctrl.Call(_m, "StartCloudSync", host)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// StartCloudSync indicates an expected call of StartCloudSync
-func (_mr *MockCloudSyncMockRecorder) StartCloudSync(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "StartCloudSync", reflect.TypeOf((*MockCloudSync)(nil).StartCloudSync), arg0)
-}
-
-// StartCloudSync mocks base method
-func (_m *MockCloudSync) RequestCloudSyncConf(message mqttmgr.Message, host string, clientID string) string {
+func (_m *MockCloudSync) RequestCloudSyncConf(host string, clientID string, message mqttmgr.Message, topic string) string {
 	ret := _m.ctrl.Call(_m, "RequestCloudSyncConf", host)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // StartCloudSync indicates an expected call of StartCloudSync
-func (_mr *MockCloudSyncMockRecorder) StartCRequestCloudSyncConfloudSync(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "RequestCloudSyncConf", reflect.TypeOf((*MockCloudSync)(nil).StartCloudSync), arg0)
+func (_mr *MockCloudSyncMockRecorder) RequestCloudSyncConfloudSync(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "RequestCloudSyncConf", reflect.TypeOf((*MockCloudSync)(nil).RequestCloudSyncConf), arg0)
 }

--- a/internal/orchestrationapi/mocks/mock_orchestration.go
+++ b/internal/orchestrationapi/mocks/mock_orchestration.go
@@ -105,7 +105,7 @@ func (mr *MockOrcheExternalAPIMockRecorder) RequestService(arg0 interface{}) *go
 }
 
 // RequestCloudSync mocks base method.
-func (m *MockOrcheExternalAPI) RequestCloudSync(arg0 mqtt.Message, arg1 string, arg2 string) string {
+func (m *MockOrcheExternalAPI) RequestCloudSync(arg0 string, arg1 string, arg2 mqtt.Message, arg3 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestCloudSync", arg0)
 	ret0, _ := ret[0].(string)

--- a/internal/orchestrationapi/orchestration.go
+++ b/internal/orchestrationapi/orchestration.go
@@ -53,7 +53,7 @@ type Orche interface {
 type OrcheExternalAPI interface {
 	RequestService(serviceInfo ReqeustService) ResponseService
 	verifier.Conf
-	RequestCloudSync(message mqtt.Message, topic string, clientID string) string
+	RequestCloudSync(host string, clientID string, message mqtt.Message, topic string) string
 }
 
 // OrcheInternalAPI is the interface implemented by internal REST API

--- a/internal/orchestrationapi/orchestrationapi.go
+++ b/internal/orchestrationapi/orchestrationapi.go
@@ -131,9 +131,9 @@ func init() {
 }
 
 //RequestCloudSync handles the request for cloud syncing
-func (orcheEngine *orcheImpl) RequestCloudSync(message mqtt.Message, topic string, clientID string) string {
+func (orcheEngine *orcheImpl) RequestCloudSync(host string, clientID string, message mqtt.Message, topic string) string {
 	log.Info("[RequestCloudSync]", "Requesting cloud sync")
-	return orcheEngine.cloudsyncIns.RequestCloudSyncConf(message, topic, clientID)
+	return orcheEngine.cloudsyncIns.RequestCloudSyncConf(host, clientID, message, topic)
 }
 
 // RequestService handles service request (ex. offloading) from service application

--- a/internal/restinterface/externalhandler/externalhandler.go
+++ b/internal/restinterface/externalhandler/externalhandler.go
@@ -27,7 +27,6 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	mqttmgr "github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/networkhelper"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/cloudsyncmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/common"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
@@ -391,7 +390,7 @@ func (h *Handler) APIV1RequestCloudSyncmgrPost(w http.ResponseWriter, r *http.Re
 		responseMsg    string
 		topic          string
 		messagePayload string
-		url            string
+		host           string
 	)
 
 	//request
@@ -426,16 +425,13 @@ func (h *Handler) APIV1RequestCloudSyncmgrPost(w http.ResponseWriter, r *http.Re
 		responseMsg = orchestrationapi.InvalidParameter
 		goto SEND_RESP
 	}
-	url, ok = appCommand["url"].(string)
+	host, ok = appCommand["url"].(string)
 	if !ok {
 		responseMsg = orchestrationapi.InvalidParameter
 		goto SEND_RESP
 	}
-	cloudsyncmgr.GetInstance().StartCloudSync(url)
-	for mqttmgr.GetClient() == nil {
-		//Wait till the client is set
-	}
-	responseMsg = h.api.RequestCloudSync(publishMessage, topic, appID)
+
+	responseMsg = h.api.RequestCloudSync(host, appID, publishMessage, topic)
 
 SEND_RESP:
 	respJSONMsg := make(map[string]interface{})


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description

Currently the client data was not stored and hence every time third party app request to publish the data connection is created.But this creates multiple connections by the same app to the broker. So this PR devises the method to store the client data for each app in a home edge session, so that app can directly publish the data.
The data of the client is stored in hashmap and app id sent in the request is used as client id to maintain uniqueness as required by mosquitto. When a client request for disconnect, the data is deleted from the table and on every connect successful the data is added to the table

Fixes # (#382)

## Type of change

- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
1.MQTT mosquitto broker is configured to be running in the AWS endpoint.
2. The edge orchestration is build and run using following command with option CLOUD_SYNC set to true
```
docker run -it -d --privileged --network="host" --name edge-orchestration -e CLOUD_SYNC=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
```
3. From the another terminal/post make a curl command as follows to publish data using home edge to the broker running on AWS endpoint

```
curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "appid": "com.nokia.homeedge1",
    "payload": "{Another data from TV1 and testdata}",
    "topic": "home1/livingroom",
    "url" : "ec2-54-205-12-98.compute-1.amazonaws.com"
}'

curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "appid": "com.nokia.homeedge1",
    "payload": "{Data from same client again}",
    "topic": "home1/livingroom",
    "url" : "ec2-54-205-12-98.compute-1.amazonaws.com"
}'
```
4.You should obtain the following message for successful publish
```
{"Message":"Data published successfully to Cloud","RemoteTargetInfo":"","ServiceName":""}
```
5. The Broker logs are checked in AWS and we observe following logs
```
1641480800: New connection from 49.207.219.60 on port 1883.
1641480800: New client connected from 49.207.219.60 as com.nokia.homeedge1 (p2, c1, k30).
1641480800: No will message specified.
1641480800: Sending CONNACK to com.nokia.homeedge1 (0, 0)
1641480800: Received PUBLISH from com.nokia.homeedge1 (d0, q0, r1, m0, 'home1/livingroom', ... (80 bytes))
1641480830: Received PINGREQ from com.nokia.homeedge1
1641480830: Sending PINGRESP to com.nokia.homeedge1
1641480850: Received PUBLISH from com.nokia.homeedge1 (d0, q0, r1, m0, 'home1/livingroom', ... (73 bytes))
```
Same client sending data but connection is established only once.

**Test Configuration**:
* OS type & version: ( Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (v1.1.0)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
