### PR TITLE
[Security] Move securemgr components initialization to securemgr.go

### DIFF
--- a/cmd/edge-orchestration/capi/main.go
+++ b/cmd/edge-orchestration/capi/main.go
@@ -87,8 +87,7 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
 	mnedcmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc"
 	scoringmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authenticator"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authorizer"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/nativeexecutor"
@@ -116,9 +115,6 @@ const (
 	configPath             = edgeDir + "/apps"
 	dbPath                 = edgeDir + "/data/db"
 	certificateFilePath    = edgeDir + "/data/cert"
-	containerWhiteListPath = edgeDir + "/data/cwl"
-	passPhraseJWTPath      = edgeDir + "/data/jwt"
-	rbacRulePath           = edgeDir + "/data/rbac"
 
 	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
 	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"
@@ -155,14 +151,12 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 	isSecured := false
 	if secure == 1 {
 		log.Println(logPrefix, "Orchestration init with secure option")
+		securemgr.Start(edgeDir)
 		isSecured = true
 	}
 
 	cipher := dummy.GetCipher(cipherKeyFilePath)
 	if isSecured {
-		verifier.Init(containerWhiteListPath)
-		authenticator.Init(passPhraseJWTPath)
-		authorizer.Init(rbacRulePath)
 		cipher = sha256.GetCipher(cipherKeyFilePath)
 	}
 

--- a/cmd/edge-orchestration/javaapi/javaapi.go
+++ b/cmd/edge-orchestration/javaapi/javaapi.go
@@ -34,8 +34,7 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/configuremgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr"
 	scoringmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authenticator"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authorizer"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/androidexecutor"
@@ -60,9 +59,6 @@ const (
 	configStr              = "/apps"
 	dbStr                  = "/data/db"
 	certificateFile        = "/data/cert"
-	containerWhiteListPath = "/data/cwl"
-	passPhraseJWTPath      = "/data/jwt"
-	rbacRulePath           = "/data/rbac"
 
 	cipherKeyFile = "/user/orchestration_userID.txt"
 	deviceIDFile  = "/device/orchestration_deviceID.txt"
@@ -186,9 +182,7 @@ func OrchestrationInit(executeCallback ExecuteCallback, edgeDir string, isSecure
 
 	cipher := dummy.GetCipher(cipherKeyFilePath)
 	if isSecured {
-		verifier.Init(containerWhiteListPath)
-		authenticator.Init(passPhraseJWTPath)
-		authorizer.Init(rbacRulePath)
+		securemgr.Start(edgeDir)
 		cipher = sha256.GetCipher(cipherKeyFilePath)
 	}
 

--- a/cmd/edge-orchestration/main.go
+++ b/cmd/edge-orchestration/main.go
@@ -31,8 +31,7 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/configuremgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authenticator"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authorizer"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
 	mnedcmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc"
@@ -61,9 +60,6 @@ const (
 	configPath             = edgeDir + "/apps"
 	dbPath                 = edgeDir + "/data/db"
 	certificateFilePath    = edgeDir + "/data/cert"
-	containerWhiteListPath = edgeDir + "/data/cwl"
-	passPhraseJWTPath      = edgeDir + "/data/jwt"
-	rbacRulePath           = edgeDir + "/data/rbac"
 
 	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
 	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"
@@ -104,15 +100,13 @@ func orchestrationInit() error {
 	if len(secure) > 0 {
 		if strings.Compare(strings.ToLower(secure), "true") == 0 {
 			log.Println(logPrefix, "Orchestration init with secure option")
+			securemgr.Start(edgeDir)
 			isSecured = true
 		}
 	}
 
 	cipher := dummy.GetCipher(cipherKeyFilePath)
 	if isSecured {
-		verifier.Init(containerWhiteListPath)
-		authenticator.Init(passPhraseJWTPath)
-		authorizer.Init(rbacRulePath)
 		cipher = sha256.GetCipher(cipherKeyFilePath)
 	}
 

--- a/internal/controller/securemgr/securemgr.go
+++ b/internal/controller/securemgr/securemgr.go
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2022 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+
+package securemgr
+
+import (
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authenticator"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authorizer"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
+)
+
+// Handle Platform Dependencies
+const (
+	logPrefix              = "[securemgr]"
+	certificateFilePath    = "/data/cert"
+	containerWhiteListPath = "/data/cwl"
+	passPhraseJWTPath      = "/data/jwt"
+	rbacRulePath           = "/data/rbac"
+)
+
+// SecuremgrImpl structure
+type SecuremgrImpl struct {
+	IsSecured bool
+}
+
+var (
+	securemgrIns *SecuremgrImpl
+	log          = logmgr.GetInstance()
+)
+
+func init() {
+	securemgrIns = new(SecuremgrImpl)
+}
+
+// GetInstance gives the SecuremgrImpl singletone instance
+func GetInstance() *SecuremgrImpl {
+	return securemgrIns
+}
+
+// Start initializes the securemgr components
+func Start(edgeDir string) {
+	verifier.Init(edgeDir + containerWhiteListPath)
+	authenticator.Init(edgeDir + passPhraseJWTPath)
+	authorizer.Init(edgeDir + rbacRulePath)
+	securemgrIns.IsSecured = true
+
+	log.Info("Start securemgr")
+}


### PR DESCRIPTION
# Description

This is the first step in refactoring the `securemgr`. Moving securemgr components initialization to securemgr instance.

Fixes #441 

## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?

To test the secure components, you need to run the commands described [here](https://github.com/lf-edge/edge-home-orchestration-go/blob/master/docs/secure_manager.md)


**Test Configuration**:
* OS type & version: (e.g., Ubuntu 18.04)
* Hardware: x86-64
* Toolchain: Docker v17.6 and Go v1.16
* Edge Orchestration Release: v1.1.4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
