### PR TITLE
Refactore the log message format

### DIFF
--- a/cmd/edge-orchestration/capi/main.go
+++ b/cmd/edge-orchestration/capi/main.go
@@ -82,10 +82,9 @@ import (
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/fscreator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
-
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/configuremgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
 	mnedcmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc"
 	scoringmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authenticator"
@@ -93,9 +92,8 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/nativeexecutor"
-
+	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
-
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/dummy"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/sha256"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/client/restclient"
@@ -103,11 +101,9 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/tls"
-
-	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper"
 )
 
-const logPrefix = "interface"
+const logPrefix = "[interface]"
 
 // Handle Platform Dependencies
 const (
@@ -145,7 +141,7 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 	flag.Parse()
 
 	logmgr.InitLogfile(logPath)
-	log.Printf("[%s] OrchestrationInit", logPrefix)
+	log.Println(logPrefix, "OrchestrationInit")
 	log.Println(">>> commitID  : ", commitID)
 	log.Println(">>> version   : ", version)
 	log.Println(">>> buildTime : ", buildTime)
@@ -158,7 +154,7 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 
 	isSecured := false
 	if secure == 1 {
-		log.Println("Orchestration init with secure option")
+		log.Println(logPrefix, "Orchestration init with secure option")
 		isSecured = true
 	}
 
@@ -187,7 +183,7 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 	builder.SetClient(restIns)
 	orcheEngine = builder.Build()
 	if orcheEngine == nil {
-		log.Fatalf("[%s] Orchestaration initialize fail", logPrefix)
+		log.Fatalf("%s Orchestaration initialize fail", logPrefix)
 		return -1
 	}
 
@@ -202,7 +198,7 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 
 	internalapi, err := orchestrationapi.GetInternalAPI()
 	if err != nil {
-		log.Fatalf("[%s] Orchestaration internal api : %s", logPrefix, err.Error())
+		log.Fatalf("%s Orchestaration internal api : %s", logPrefix, err.Error())
 	}
 	ihandle := internalhandler.GetHandler()
 	ihandle.SetOrchestrationAPI(internalapi)
@@ -215,7 +211,7 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 
 	externalapi, err := orchestrationapi.GetExternalAPI()
 	if err != nil {
-		log.Fatalf("[%s] Orchestaration external api : %s", logPrefix, err.Error())
+		log.Fatalf("%s Orchestaration external api : %s", logPrefix, err.Error())
 	}
 	ehandle := externalhandler.GetHandler()
 	ehandle.SetOrchestrationAPI(externalapi)
@@ -224,7 +220,7 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 
 	restEdgeRouter.Start()
 
-	log.Println(logPrefix, "orchestration init done")
+	log.Println(logPrefix, "Orchestration init done")
 	mnedcmgr.GetServerInstance().SetCipher(cipher)
 	if isSecured {
 		mnedcmgr.GetServerInstance().SetCertificateFilePath(certificateFilePath)
@@ -234,10 +230,10 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 	isMNEDCClient := false
 	if mnedc == 1 {
 		isMNEDCServer = true
-		log.Println("Orchestration init with MNEDC server option")
+		log.Println(logPrefix, "Orchestration init with MNEDC server option")
 	} else if mnedc == 2 {
 		isMNEDCClient = true
-		log.Println("Orchestration init with MNEDC client option")
+		log.Println(logPrefix, "Orchestration init with MNEDC client option")
 	}
 
 	go func() {
@@ -253,7 +249,7 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 // OrchestrationRequestService performs request from service applications which uses orchestration service
 //export OrchestrationRequestService
 func OrchestrationRequestService(cAppName *C.char, cSelfSelection C.int, cRequester *C.char, serviceInfo *C.RequestServiceInfo, count C.int) C.ResponseService {
-	log.Printf("[%s] OrchestrationRequestService", logPrefix)
+	log.Printf("%s OrchestrationRequestService", logPrefix)
 
 	appName := C.GoString(cAppName)
 
@@ -272,7 +268,7 @@ func OrchestrationRequestService(cAppName *C.char, cSelfSelection C.int, cReques
 
 	externalAPI, err := orchestrationapi.GetExternalAPI()
 	if err != nil {
-		log.Fatalf("[%s] Orchestaration external api : %s", logPrefix, err.Error())
+		log.Fatalf("%s Orchestaration external api : %s", logPrefix, err.Error())
 	}
 
 	selfSel := true
@@ -293,7 +289,7 @@ func OrchestrationRequestService(cAppName *C.char, cSelfSelection C.int, cReques
 		ServiceInfo:      requestInfos,
 		ServiceRequester: requester,
 	})
-	log.Println("requestService handle : ", res)
+	log.Println(logPrefix, "requestService handle : ", res)
 
 	ret := C.ResponseService{}
 	ret.Message = C.CString(res.Message)

--- a/cmd/edge-orchestration/javaapi/javaapi.go
+++ b/cmd/edge-orchestration/javaapi/javaapi.go
@@ -52,7 +52,7 @@ import (
 
 // Handle Platform Dependencies
 const (
-	logPrefix     = "interface"
+	logPrefix     = "[interface]"
 	platform      = "android"
 	executionType = "android"
 
@@ -109,7 +109,7 @@ func (r *ReqeustService) SetExecutionCommand(execType string, command string) {
 	switch execType {
 	case "native", "android", "container":
 	default:
-		log.Printf("[%s] Invalid execution type: %s", logPrefix, execType)
+		log.Printf("%s Invalid execution type: %s", logPrefix, execType)
 		return
 	}
 
@@ -180,7 +180,7 @@ func OrchestrationInit(executeCallback ExecuteCallback, edgeDir string, isSecure
 	}
 
 	logmgr.InitLogfile(logPath)
-	log.Printf("[%s] OrchestrationInit", logPrefix)
+	log.Printf("%s OrchestrationInit", logPrefix)
 
 	wrapper.SetBoltDBPath(dbPath)
 
@@ -209,7 +209,7 @@ func OrchestrationInit(executeCallback ExecuteCallback, edgeDir string, isSecure
 
 	orcheEngine = builder.Build()
 	if orcheEngine == nil {
-		log.Fatalf("[%s] Orchestration initialize fail", logPrefix)
+		log.Fatalf("%s Orchestration initialize fail", logPrefix)
 		return
 	}
 
@@ -227,7 +227,7 @@ func OrchestrationInit(executeCallback ExecuteCallback, edgeDir string, isSecure
 
 	internalapi, err := orchestrationapi.GetInternalAPI()
 	if err != nil {
-		log.Fatalf("[%s] Orchestration internal api : %s", logPrefix, err.Error())
+		log.Fatalf("%s Orchestration internal api : %s", logPrefix, err.Error())
 	}
 	ihandle := internalhandler.GetHandler()
 	ihandle.SetOrchestrationAPI(internalapi)
@@ -249,12 +249,12 @@ func OrchestrationInit(executeCallback ExecuteCallback, edgeDir string, isSecure
 
 // OrchestrationRequestService performs request from service applications which uses orchestration service
 func OrchestrationRequestService(request *ReqeustService) *ResponseService {
-	log.Printf("[%s] OrchestrationRequestService", logPrefix)
+	log.Printf("%s OrchestrationRequestService", logPrefix)
 	log.Println("Service name: ", request.ServiceName)
 
 	externalAPI, err := orchestrationapi.GetExternalAPI()
 	if err != nil {
-		log.Fatalf("[%s] Orchestaration external api : %s", logPrefix, err.Error())
+		log.Fatalf("%s Orchestaration external api : %s", logPrefix, err.Error())
 	}
 
 	changed := orchestrationapi.ReqeustService{

--- a/cmd/edge-orchestration/main.go
+++ b/cmd/edge-orchestration/main.go
@@ -28,31 +28,27 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/sigmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/cloudsyncmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
-
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/configuremgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr"
-	mnedcmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authenticator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authorizer"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
+	mnedcmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc"
 	executor "github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/containerexecutor"
-
+	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
-
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/dummy"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/sha256"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/client/restclient"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/externalhandler"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route"
-
-	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/webui"
 )
 
-const logPrefix = "interface"
+const logPrefix = "[interface]"
 
 // Handle Platform Dependencies
 const (
@@ -81,7 +77,7 @@ var (
 
 func main() {
 	if err := orchestrationInit(); err != nil {
-		log.Fatalf("[%s] Orchestaration initialize fail : %s", logPrefix, err.Error())
+		log.Fatalf("%s Orchestaration initialize fail : %s", logPrefix, err.Error())
 	}
 	sigmgr.Watch()
 }
@@ -89,7 +85,7 @@ func main() {
 // orchestrationInit runs orchestration service and discovers other orchestration services in other devices
 func orchestrationInit() error {
 	logmgr.InitLogfile(logPath)
-	log.Printf("[%s] OrchestrationInit", logPrefix)
+	log.Println(logPrefix, "OrchestrationInit")
 	log.Println(">>> commitID  : ", commitID)
 	log.Println(">>> version   : ", version)
 	log.Println(">>> buildTime : ", buildTime)
@@ -107,7 +103,7 @@ func orchestrationInit() error {
 	isSecured := false
 	if len(secure) > 0 {
 		if strings.Compare(strings.ToLower(secure), "true") == 0 {
-			log.Println("Orchestration init with secure option")
+			log.Println(logPrefix, "Orchestration init with secure option")
 			isSecured = true
 		}
 	}
@@ -140,7 +136,7 @@ func orchestrationInit() error {
 
 	orcheEngine := builder.Build()
 	if orcheEngine == nil {
-		log.Fatalf("[%s] Orchestaration initialize fail", logPrefix)
+		log.Fatalf("%s Orchestration initialize fail", logPrefix)
 		return errors.New("fail to init orchestration")
 	}
 
@@ -155,7 +151,7 @@ func orchestrationInit() error {
 
 	internalapi, err := orchestrationapi.GetInternalAPI()
 	if err != nil {
-		log.Fatalf("[%s] Orchestaration internal api : %s", logPrefix, err.Error())
+		log.Fatalf("%s Orchestaration internal api : %s", logPrefix, err.Error())
 	}
 	ihandle := internalhandler.GetHandler()
 	ihandle.SetOrchestrationAPI(internalapi)
@@ -169,7 +165,7 @@ func orchestrationInit() error {
 	// external rest api
 	externalapi, err := orchestrationapi.GetExternalAPI()
 	if err != nil {
-		log.Fatalf("[%s] Orchestaration external api : %s", logPrefix, err.Error())
+		log.Fatalf("%s Orchestaration external api : %s", logPrefix, err.Error())
 	}
 	ehandle := externalhandler.GetHandler()
 	ehandle.SetOrchestrationAPI(externalapi)
@@ -196,7 +192,7 @@ func orchestrationInit() error {
 	if strings.Compare(strings.ToLower(ui), "true") == 0 {
 		webui.Start()
 	}
-	log.Println(logPrefix, "orchestration init done")
+	log.Println(logPrefix, "Orchestration init done")
 
 	return nil
 }

--- a/internal/common/networkhelper/detector/detector_netlink.go
+++ b/internal/common/networkhelper/detector/detector_netlink.go
@@ -24,7 +24,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-const logPrefix = "detector_netlink"
+const logPrefix = "[detectornetlink]"
 
 type detectorImpl struct{}
 
@@ -79,10 +79,10 @@ func detectionHandler(detect netlink.AddrUpdate) bool {
 	}
 
 	if updatedAddr.NewAddr {
-		log.Println(logPrefix, "[DetectionHandler]", "New Connection : ", updatedAddr.LinkAddress.IP)
+		log.Println(logPrefix, "New Connection : ", updatedAddr.LinkAddress.IP)
 		return true
 	}
 
-	log.Println(logPrefix, "[DetectionHandler]", "Disconnected : ", updatedAddr.LinkAddress.IP)
+	log.Println(logPrefix, "Disconnected : ", updatedAddr.LinkAddress.IP)
 	return true
 }

--- a/internal/common/resourceutil/resourceutil.go
+++ b/internal/common/resourceutil/resourceutil.go
@@ -66,7 +66,7 @@ const (
 	// NetRTT defined network/rtt
 	NetRTT = "network/rtt"
 
-	logPrefix             = "resourceutil"
+	logPrefix             = "[resourceutil]"
 	defaultProcessingTime = 5
 )
 

--- a/internal/controller/scoringmgr/scoringmgr.go
+++ b/internal/controller/scoringmgr/scoringmgr.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	logPrefix = "scoringmgr"
+	logPrefix = "[scoringmgr]"
 	// InvalidScore is used to indicate 0.0 in case of error
 	InvalidScore = 0.0
 )

--- a/internal/restinterface/cipher/cipher.go
+++ b/internal/restinterface/cipher/cipher.go
@@ -18,7 +18,7 @@
 // Package cipher implements simple encrypting and decrypting message
 package cipher
 
-const logPrefix = "cipher"
+const logPrefix = "[cipher]"
 
 // IEdgeCipherer is the interface implemented by encryption/decryption functions
 type IEdgeCipherer interface {

--- a/internal/restinterface/externalhandler/externalhandler.go
+++ b/internal/restinterface/externalhandler/externalhandler.go
@@ -36,7 +36,14 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper"
 )
 
-const logPrefix = "RestExternalInterface"
+const logPrefix = "[RestExternalInterface]"
+
+const (
+	doesNotSetAPI    = " does not set API"
+	doesNotSetKey    = " does not set key"
+	cannotDecryption = " cannot decryption"
+	cannotEncryption = " cannot encryption"
+)
 
 // Handler struct
 type Handler struct {
@@ -96,13 +103,13 @@ func (h *Handler) SetOrchestrationAPI(o orchestrationapi.OrcheExternalAPI) {
 
 // APIV1RequestServicePost handles service request from service application
 func (h *Handler) APIV1RequestServicePost(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[%s] APIV1RequestServicePost", logPrefix)
+	log.Info(logPrefix, " APIV1RequestServicePost")
 	if !h.isSetAPI {
-		log.Printf("[%s] does not set api", logPrefix)
+		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	} else if !h.IsSetKey {
-		log.Printf("[%s] does not set key", logPrefix)
+		log.Error(logPrefix, doesNotSetKey)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -142,7 +149,7 @@ func (h *Handler) APIV1RequestServicePost(w http.ResponseWriter, r *http.Request
 
 	appCommand, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
-		log.Printf("[%s] can not decryption", logPrefix)
+		log.Error(logPrefix, cannotDecryption)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -240,7 +247,7 @@ SEND_RESP:
 
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
 	if err != nil {
-		log.Printf("[%s] can not encryption", logPrefix)
+		log.Error(logPrefix, cannotEncryption)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -250,13 +257,13 @@ SEND_RESP:
 
 // APIV1RequestSecuremgrPost handles securemgr request from securemgr configure application
 func (h *Handler) APIV1RequestSecuremgrPost(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[%s] APIV1RequestSecuremgrPost", logPrefix)
+	log.Info(logPrefix, " APIV1RequestSecuremgrPost")
 	if !h.isSetAPI {
-		log.Printf("[%s] does not set api", logPrefix)
+		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	} else if !h.IsSetKey {
-		log.Printf("[%s] does not set key", logPrefix)
+		log.Error(logPrefix, doesNotSetKey)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -290,7 +297,7 @@ func (h *Handler) APIV1RequestSecuremgrPost(w http.ResponseWriter, r *http.Reque
 
 	appCommand, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
-		log.Printf("[%s] cannot decryption", logPrefix)
+		log.Error(logPrefix, cannotDecryption)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -349,7 +356,7 @@ SEND_RESP:
 
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
 	if err != nil {
-		log.Printf("[%s] cannot encryption", logPrefix)
+		log.Error(logPrefix, cannotEncryption)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -359,13 +366,13 @@ SEND_RESP:
 
 // APIV1RequestCloudSyncmgrPost handles cloudsync publish request from service application
 func (h *Handler) APIV1RequestCloudSyncmgrPost(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[%s] APIV1RequestCloudSyncmgrPost", logPrefix)
+	log.Info(logPrefix, " APIV1RequestCloudSyncmgrPost")
 	if !h.isSetAPI {
-		log.Printf("[%s] does not set api", logPrefix)
+		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	} else if !h.IsSetKey {
-		log.Printf("[%s] does not set key", logPrefix)
+		log.Error(logPrefix, doesNotSetKey)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -399,7 +406,7 @@ func (h *Handler) APIV1RequestCloudSyncmgrPost(w http.ResponseWriter, r *http.Re
 	//Decrypt the request in json format
 	appCommand, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
-		log.Printf("[%s] can not decryption", logPrefix)
+		log.Error(logPrefix, cannotDecryption)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -441,7 +448,7 @@ SEND_RESP:
 
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
 	if err != nil {
-		log.Printf("[%s] can not encryption", logPrefix)
+		log.Error(logPrefix, cannotEncryption)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}

--- a/internal/restinterface/internalhandler/internalhandler.go
+++ b/internal/restinterface/internalhandler/internalhandler.go
@@ -35,7 +35,14 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper"
 )
 
-const logPrefix = "RestInternalInterface"
+const logPrefix = "[RestInternalInterface]"
+
+const (
+	doesNotSetAPI    = " does not set API"
+	doesNotSetKey    = " does not set key"
+	cannotDecryption = " cannot decryption "
+	cannotEncryption = " cannot encryption "
+)
 
 // Handler struct
 type Handler struct {
@@ -132,13 +139,13 @@ func (h *Handler) APIV1Ping(w http.ResponseWriter, r *http.Request) {
 
 // APIV1ServicemgrServicesPost handles service execution request from remote orchestration
 func (h *Handler) APIV1ServicemgrServicesPost(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[%s] APIV1ServicemgrServicesPost", logPrefix)
+	log.Info(logPrefix, " APIV1ServicemgrServicesPost")
 	if !h.isSetAPI {
-		log.Printf("[%s] does not set api", logPrefix)
+		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	} else if !h.IsSetKey {
-		log.Printf("[%s] does not set key", logPrefix)
+		log.Error(logPrefix, doesNotSetKey)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -148,19 +155,19 @@ func (h *Handler) APIV1ServicemgrServicesPost(w http.ResponseWriter, r *http.Req
 
 	appInfo, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
-		log.Printf("[%s] can not decryption", logPrefix)
+		log.Error(logPrefix, cannotDecryption)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
 
 	appInfo["NotificationTargetURL"] = remoteAddr
 
-	log.Printf("[%s] Requested AppInfo", logPrefix)
-	log.Printf("[%s] Requester    : %s", logPrefix, logmgr.SanitizeUserInput(appInfo["Requester"].(string)))                      // lgtm [go/log-injection]
-	log.Printf("[%s] ServiceID    : %s", logPrefix, logmgr.SanitizeUserInput(fmt.Sprintf("%f", appInfo["ServiceID"])))            // lgtm [go/log-injection]
-	log.Printf("[%s] ServiceName  : %s", logPrefix, logmgr.SanitizeUserInput(appInfo["ServiceName"].(string)))                    // lgtm [go/log-injection]
-	log.Printf("[%s] NotificationTargetURL : %s", logPrefix, logmgr.SanitizeUserInput(appInfo["NotificationTargetURL"].(string))) // lgtm [go/log-injection]
-	log.Printf("[%s] ExecutionCmd : %s", logPrefix, logmgr.SanitizeUserInput(fmt.Sprintf("%v", appInfo["UserArgs"])))             // lgtm [go/log-injection]
+	log.Printf("%s Requested AppInfo", logPrefix)
+	log.Printf("%s Requester    : %s", logPrefix, logmgr.SanitizeUserInput(appInfo["Requester"].(string)))                      // lgtm [go/log-injection]
+	log.Printf("%s ServiceID    : %s", logPrefix, logmgr.SanitizeUserInput(fmt.Sprintf("%f", appInfo["ServiceID"])))            // lgtm [go/log-injection]
+	log.Printf("%s ServiceName  : %s", logPrefix, logmgr.SanitizeUserInput(appInfo["ServiceName"].(string)))                    // lgtm [go/log-injection]
+	log.Printf("%s NotificationTargetURL : %s", logPrefix, logmgr.SanitizeUserInput(appInfo["NotificationTargetURL"].(string))) // lgtm [go/log-injection]
+	log.Printf("%s ExecutionCmd : %s", logPrefix, logmgr.SanitizeUserInput(fmt.Sprintf("%v", appInfo["UserArgs"])))             // lgtm [go/log-injection]
 
 	args := make([]string, 0)
 	for _, arg := range appInfo["UserArgs"].([]interface{}) {
@@ -194,7 +201,7 @@ func (h *Handler) APIV1ServicemgrServicesPost(w http.ResponseWriter, r *http.Req
 
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
 	if err != nil {
-		log.Printf("[%s] can not encryption", logPrefix)
+		log.Error(logPrefix, cannotEncryption)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -204,13 +211,13 @@ func (h *Handler) APIV1ServicemgrServicesPost(w http.ResponseWriter, r *http.Req
 
 // APIV1ServicemgrServicesNotificationServiceIDPost handles service notification request from remote orchestration
 func (h *Handler) APIV1ServicemgrServicesNotificationServiceIDPost(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[%s] APIV1ServicemgrServicesNotificationServiceIDPost", logPrefix)
+	log.Info(logPrefix, " APIV1ServicemgrServicesNotificationServiceIDPost")
 	if !h.isSetAPI {
-		log.Printf("[%s] does not set api", logPrefix)
+		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	} else if !h.IsSetKey {
-		log.Printf("[%s] does not set key", logPrefix)
+		log.Error(logPrefix, doesNotSetKey)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -219,7 +226,7 @@ func (h *Handler) APIV1ServicemgrServicesNotificationServiceIDPost(w http.Respon
 
 	statusNotification, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
-		log.Printf("[%s] can not decryption", logPrefix)
+		log.Error(logPrefix, cannotDecryption)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -238,13 +245,13 @@ func (h *Handler) APIV1ServicemgrServicesNotificationServiceIDPost(w http.Respon
 
 // APIV1ScoringmgrScoreLibnameGet handles scoring request from remote orchestration
 func (h *Handler) APIV1ScoringmgrScoreLibnameGet(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[%s] APIV1ScoringmgrScoreLibnameGet", logPrefix)
+	log.Info(logPrefix, " APIV1ScoringmgrScoreLibnameGet")
 	if !h.isSetAPI {
-		log.Printf("[%s] does not set api", logPrefix)
+		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	} else if !h.IsSetKey {
-		log.Printf("[%s] does not set key", logPrefix)
+		log.Error(logPrefix, doesNotSetKey)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -252,7 +259,7 @@ func (h *Handler) APIV1ScoringmgrScoreLibnameGet(w http.ResponseWriter, r *http.
 	encryptBytes, _ := ioutil.ReadAll(r.Body)
 	Info, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
-		log.Printf("[%s] can not decryption %s", logPrefix, err.Error())
+		log.Error(logPrefix, cannotDecryption, err.Error())
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -261,7 +268,7 @@ func (h *Handler) APIV1ScoringmgrScoreLibnameGet(w http.ResponseWriter, r *http.
 
 	scoreValue, err := h.api.GetScore(devID.(string))
 	if err != nil {
-		log.Printf("[%s] GetScore fail : %s", logPrefix, err.Error())
+		log.Error(logPrefix, " GetScore fail : ", err.Error())
 		h.helper.Response(w, nil, http.StatusInternalServerError)
 		return
 	}
@@ -271,7 +278,7 @@ func (h *Handler) APIV1ScoringmgrScoreLibnameGet(w http.ResponseWriter, r *http.
 
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
 	if err != nil {
-		log.Printf("[%s] can not encryption %s", logPrefix, err.Error())
+		log.Error(logPrefix, cannotEncryption, err.Error())
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -281,13 +288,13 @@ func (h *Handler) APIV1ScoringmgrScoreLibnameGet(w http.ResponseWriter, r *http.
 
 // APIV1ScoringmgrResourceGet handles Resource request from remote orchestration
 func (h *Handler) APIV1ScoringmgrResourceGet(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[%s] APIV1ScoringmgrResourceGet", logPrefix)
+	log.Info(logPrefix, " APIV1ScoringmgrResourceGet")
 	if !h.isSetAPI {
-		log.Printf("[%s] does not set api", logPrefix)
+		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	} else if !h.IsSetKey {
-		log.Printf("[%s] does not set key", logPrefix)
+		log.Error(logPrefix, doesNotSetKey)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -295,7 +302,7 @@ func (h *Handler) APIV1ScoringmgrResourceGet(w http.ResponseWriter, r *http.Requ
 	encryptBytes, _ := ioutil.ReadAll(r.Body)
 	Info, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
-		log.Printf("[%s] can not decryption %s", logPrefix, err.Error())
+		log.Error(logPrefix, cannotDecryption, err.Error())
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -304,14 +311,14 @@ func (h *Handler) APIV1ScoringmgrResourceGet(w http.ResponseWriter, r *http.Requ
 
 	resourceValue, err := h.api.GetResource(devID.(string))
 	if err != nil {
-		log.Printf("[%s] GetResource fail : %s", logPrefix, err.Error())
+		log.Error(logPrefix, " GetResource fail : ", err.Error())
 		h.helper.Response(w, nil, http.StatusInternalServerError)
 		return
 	}
 
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(resourceValue)
 	if err != nil {
-		log.Printf("[%s] can not encryption %s", logPrefix, err.Error())
+		log.Error(logPrefix, cannotEncryption, err.Error())
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -321,13 +328,13 @@ func (h *Handler) APIV1ScoringmgrResourceGet(w http.ResponseWriter, r *http.Requ
 
 //APIV1DiscoverymgrMNEDCDeviceInfoPost handles device info from MNEDC server
 func (h *Handler) APIV1DiscoverymgrMNEDCDeviceInfoPost(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[%s] APIV1DiscoveryFromMNEDCServer", logPrefix)
+	log.Info(logPrefix, " APIV1DiscoveryFromMNEDCServer")
 	if !h.isSetAPI {
-		log.Printf("[%s] does not set api", logPrefix)
+		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	} else if !h.IsSetKey {
-		log.Printf("[%s] does not set key", logPrefix)
+		log.Error(logPrefix, doesNotSetKey)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -336,7 +343,7 @@ func (h *Handler) APIV1DiscoverymgrMNEDCDeviceInfoPost(w http.ResponseWriter, r 
 	Info, err := h.Key.DecryptByteToJSON(encryptBytes)
 
 	if err != nil {
-		log.Printf("[%s] can not decryption %s", logPrefix, err.Error())
+		log.Error(logPrefix, cannotDecryption, err.Error())
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -356,13 +363,13 @@ func (h *Handler) APIV1DiscoverymgrMNEDCDeviceInfoPost(w http.ResponseWriter, r 
 
 //APIV1DiscoverymgrOrchestrationInfoGet handles device info requests from peers
 func (h *Handler) APIV1DiscoverymgrOrchestrationInfoGet(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[%s] APIV1DiscoverymgrOrchestrationInfoGet", logPrefix)
+	log.Info(logPrefix, " APIV1DiscoverymgrOrchestrationInfoGet")
 	if !h.isSetAPI {
-		log.Printf("[%s] does not set api", logPrefix)
+		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	} else if !h.IsSetKey {
-		log.Printf("[%s] does not set key", logPrefix)
+		log.Error(logPrefix, doesNotSetKey)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -370,7 +377,7 @@ func (h *Handler) APIV1DiscoverymgrOrchestrationInfoGet(w http.ResponseWriter, r
 	platform, execution, serviceList, err := h.api.GetOrchestrationInfo()
 
 	if err != nil {
-		log.Printf("[%s] can not encryption %s", logPrefix, err.Error())
+		log.Error(logPrefix, cannotEncryption, err.Error())
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}
@@ -382,7 +389,7 @@ func (h *Handler) APIV1DiscoverymgrOrchestrationInfoGet(w http.ResponseWriter, r
 
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)
 	if err != nil {
-		log.Printf("[%s] can not encryption %s", logPrefix, err.Error())
+		log.Error(logPrefix, cannotEncryption, err.Error())
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)
 		return
 	}


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

For the same output of messages in the log, refactoring format log was made.

## Type of change

- [x] Code cleanup/refactoring

# How Has This Been Tested?

```
docker run -it -d --privileged --network="host" --name edge-orchestration -e SECURE=true -e CLOUD_SYNC=true -e LOGLEVEL=Debug -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
```

**Test Configuration**:
* OS type & version: Ubuntu 18.04
* Hardware: x86-64
* Toolchain: Docker v20.10 and Go v1.16
* Edge Orchestration Release: v1.1.4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
