### PR TITLE
Remove build time stamp to be able to create a reproduced build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ export Q := @
 endif
 endif
 
-BUILD_DATE=${shell date +%Y%m%d.%H%M}
 VERSION := v$(shell cat VERSION)
 CONTAINER_VERSION="latest"
 DOCKER_IMAGE="lfedge/edge-home-orchestration-go"
@@ -54,8 +53,8 @@ GOCOVER		:= gocov
 GOMOBILE	:= gomobile
 DOCKER		:= docker
 GO_COMMIT_ID	:= $(shell git rev-parse --short HEAD)
-GO_LDFLAGS		:= -ldflags '-extldflags "-static" -X main.version=$(VERSION) -X main.commitID=$(GO_COMMIT_ID) -X main.buildTime=$(BUILD_DATE)'
-GO_MOBILE_LDFLAGS	:= -ldflags '-X main.version=$(VERSION) -X main.commitID=$(GO_COMMIT_ID) -X main.buildTime=$(BUILD_DATE)'
+GO_LDFLAGS		:= -ldflags '-extldflags "-static" -X main.version=$(VERSION) -X main.commitID=$(GO_COMMIT_ID)'
+GO_MOBILE_LDFLAGS	:= -ldflags '-X main.version=$(VERSION) -X main.commitID=$(GO_COMMIT_ID)'
 
 # Target parameters
 PKG_NAME	:= edge-orchestration

--- a/cmd/edge-orchestration/capi/main.go
+++ b/cmd/edge-orchestration/capi/main.go
@@ -84,7 +84,6 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/configuremgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
 	mnedcmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc"
 	scoringmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authenticator"
@@ -92,6 +91,7 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/nativeexecutor"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/dummy"
@@ -126,9 +126,9 @@ const (
 )
 
 var (
-	flagVersion                  bool
-	commitID, version, buildTime string
-	log                          = logmgr.GetInstance()
+	flagVersion       bool
+	commitID, version string
+	log               = logmgr.GetInstance()
 
 	orcheEngine orchestrationapi.Orche
 )
@@ -144,7 +144,6 @@ func OrchestrationInit(secure C.int, mnedc C.int) C.int {
 	log.Println(logPrefix, "OrchestrationInit")
 	log.Println(">>> commitID  : ", commitID)
 	log.Println(">>> version   : ", version)
-	log.Println(">>> buildTime : ", buildTime)
 	wrapper.SetBoltDBPath(dbPath)
 
 	if err := fscreator.CreateFileSystem(edgeDir); err != nil {

--- a/cmd/edge-orchestration/javaapi/javaapi.go
+++ b/cmd/edge-orchestration/javaapi/javaapi.go
@@ -21,7 +21,6 @@ package javaapi
 import (
 	"bytes"
 	"fmt"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper"
 	"net/http"
 	"strings"
 	"sync"
@@ -30,7 +29,6 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/fscreator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/networkhelper"
-
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/configuremgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr"
 	scoringmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr"
@@ -39,9 +37,8 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/androidexecutor"
-
+	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
-
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/dummy"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/sha256"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/client/restclient"

--- a/cmd/edge-orchestration/main.go
+++ b/cmd/edge-orchestration/main.go
@@ -27,16 +27,16 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/sigmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/cloudsyncmgr"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/configuremgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr"
+	mnedcmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authenticator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authorizer"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
-	mnedcmgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc"
 	executor "github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/containerexecutor"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/dummy"
@@ -71,8 +71,8 @@ const (
 )
 
 var (
-	commitID, version, buildTime string
-	log                          = logmgr.GetInstance()
+	commitID, version string
+	log               = logmgr.GetInstance()
 )
 
 func main() {
@@ -88,7 +88,6 @@ func orchestrationInit() error {
 	log.Println(logPrefix, "OrchestrationInit")
 	log.Println(">>> commitID  : ", commitID)
 	log.Println(">>> version   : ", version)
-	log.Println(">>> buildTime : ", buildTime)
 	wrapper.SetBoltDBPath(dbPath)
 
 	if err := fscreator.CreateFileSystem(edgeDir); err != nil {

--- a/docs/platforms/x86_64_linux/x86_64_android.md
+++ b/docs/platforms/x86_64_linux/x86_64_android.md
@@ -56,7 +56,7 @@ GO111MODULE=on go mod vendor
 -------------------------------------------
 mkdir -p /home/virtual-pc/projects/edge-home-orchestration-go/bin/javaapi/output
 rm -rf /home/virtual-pc/projects/edge-home-orchestration-go/vendor
-gomobile bind -ldflags '-X main.version= -X main.commitID=687e09c -X main.buildTime=20210213.0915' -o /home/virtual-pc/projects/edge-home-orchestration-go/bin/javaapi/output/liborchestration.aar -target=android/amd64 -androidapi=23 /home/virtual-pc/projects/edge-home-orchestration-go/cmd/edge-orchestration/javaapi || exit 1
+gomobile bind -ldflags '-X main.version= -X main.commitID=687e09c ' -o /home/virtual-pc/projects/edge-home-orchestration-go/bin/javaapi/output/liborchestration.aar -target=android/amd64 -androidapi=23 /home/virtual-pc/projects/edge-home-orchestration-go/cmd/edge-orchestration/javaapi || exit 1
 ls -al /home/virtual-pc/projects/edge-home-orchestration-go/bin/javaapi/output
 total 8368
 drwxrwxr-x 2 virtual-pc virtual-pc    4096 Feb 13 09:16 .

--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -179,7 +179,6 @@ docker logs -f edge-orchestration
 2019/10/16 07:35:45 main_secured.go:89: [interface] OrchestrationInit
 2019/10/16 07:35:45 main_secured.go:90: >>> commitID  :  c3041ae
 2019/10/16 07:35:45 main_secured.go:91: >>> version   :  v1.1.0
-2019/10/16 07:35:45 main_secured.go:92: >>> buildTime :  {build time}
 2019/10/16 07:35:45 discovery.go:256: [discoverymgr] UUID :  {$UUID}
 2019/10/16 07:35:45 discovery.go:338: [discoverymgr] [{$discovery_ip_list}]
 2019/10/16 07:35:45 discovery.go:369: [deviceDetectionRoutine] edge-orchestration-{$UUID}

--- a/docs/platforms/x86_64_linux/x86_64_native.md
+++ b/docs/platforms/x86_64_linux/x86_64_native.md
@@ -14,7 +14,7 @@ make distclean ; make create_context CONFIGFILE=x86_64n ; make
 --------------------------------------
   Create Static object of Orchestration for amd64
 --------------------------------------
-CGO_ENABLED=1 GOARM= GOARCH=amd64 CC="gcc" GO111MODULE=on go build -ldflags '-extldflags "-static" -X main.version= -X main.commitID=53f3afa -X main.buildTime=20211027.1228' -o /home/virtual-pc/projects/edge-home-orchestration-go/bin/capi/output/lib/linux_x86-64/liborchestration.a -buildmode=c-archive /home/virtual-pc/projects/edge-home-orchestration-go/cmd/edge-orchestration/capi || exit 1
+CGO_ENABLED=1 GOARM= GOARCH=amd64 CC="gcc" GO111MODULE=on go build -ldflags '-extldflags "-static" -X main.version= -X main.commitID=53f3afa' -o /home/virtual-pc/projects/edge-home-orchestration-go/bin/capi/output/lib/linux_x86-64/liborchestration.a -buildmode=c-archive /home/virtual-pc/projects/edge-home-orchestration-go/cmd/edge-orchestration/capi || exit 1
 total 39772
 drwxrwxr-x 2 virtual-pc virtual-pc     4096 жов 27 12:28 .
 drwxrwxr-x 3 virtual-pc virtual-pc     4096 жов 27 12:28 ..
@@ -73,7 +73,6 @@ sudo ./edge-orchestration
 2020/07/20 09:24:10 main.go:158: [interface] OrchestrationInit
 2020/07/20 09:24:10 main.go:159: >>> commitID  :  094ca91
 2020/07/20 09:24:10 main.go:160: >>> version   :  v1.1.0
-2020/07/20 09:24:10 main.go:161: >>> buildTime :  20200720.0832
 2020/07/20 09:24:10 discovery.go:257: [discoverymgr] UUID :  1da15e3d-09d4-4f80-ad72-6ca943dd5bcf
 2020/07/20 09:24:11 helper.go:99: [http://10.0.2.15:56002/api/v1/ping] reqeust get failed !!, err = Get "http://10.0.2.15:56002/api/v1/ping": dial tcp 10.0.2.15:56002: connect: connection refused
 Get "http://10.0.2.15:56002/api/v1/ping": dial tcp 10.0.2.15:56002: connect: connection refused


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

On the way to achieving the OpenSSF Best Practice "gold" badge, the condition "The project MUST have a reproducible build." must be met. This PR removes the build time dependency. 

## Type of change

- [x] Code cleanup/refactoring
- [x] Documentation update

# How Has This Been Tested?

You need to build twice and compare (`diff` utility) the executable files (`bin/edge-orchestration`). They must be the same. 

**Test Configuration**:
* OS type & version: Ubuntu 20.04)
* Hardware: x86-64
* Toolchain: Docker v20.10 and Go v1.16
* Edge Orchestration Release: v1.1.5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
