### PR TITLE
Check input parameter (hash) of verifier and refactore the log messag…

### DIFF
--- a/internal/controller/securemgr/authenticator/authenticator.go
+++ b/internal/controller/securemgr/authenticator/authenticator.go
@@ -43,7 +43,7 @@ const (
 )
 
 var (
-	logPrefix             = "[securemgr: authenticator]"
+	logPrefix             = "[securemgr: authenticator] "
 	log                   = logmgr.GetInstance()
 	authenticatorIns      *AuthenticationImpl
 	passphrase            = []byte{}
@@ -72,7 +72,7 @@ func Init(passPhraseJWTPath string) {
 	if _, err := os.Stat(passPhraseJWTPath); err != nil {
 		err := os.MkdirAll(passPhraseJWTPath, os.ModePerm)
 		if err != nil {
-			log.Panicf("%s Failed to create passPhraseJWTPath: %s\n", logPrefix, err)
+			log.Panic(logPrefix, "Failed to create passPhraseJWTPath: ", err)
 			return
 		}
 	}
@@ -86,13 +86,13 @@ func Init(passPhraseJWTPath string) {
 		passphrase = []byte(randString(16))
 		err = ioutil.WriteFile(passPhraseJWTFilePath, passphrase, 0666)
 		if err != nil {
-			log.Println(logPrefix, "Cannot create passPhraseJWT.txt:", err)
+			log.Error(logPrefix, "Cannot create passPhraseJWT.txt: ", err)
 		}
 	}
 
 	verifyBytes, err := ioutil.ReadFile(passPhraseJWTPath + "/" + pubKeyPath)
 	if err != nil {
-		log.Println(logPrefix, err)
+		log.Error(logPrefix, err)
 	} else {
 		verifyKey, err = jwt.ParseRSAPublicKeyFromPEM(verifyBytes)
 		if err != nil {
@@ -130,8 +130,8 @@ var IsAuthorizedRequest = func(next http.Handler) http.Handler {
 		if r.Header["Authorization"] != nil {
 
 			token, err := jwt.Parse(r.Header["Authorization"][0], func(token *jwt.Token) (interface{}, error) {
-				// log.Println(token.Claims)
-				// log.Printf("%s Signing method: %v\n", logPrefix, jwt.GetSigningMethod(fmt.Sprintf("%v", token.Header["alg"])))
+				// log.Debug(logPrefix, token.Claims)
+				// log.Info(logPrefix, "Signing method: ", jwt.GetSigningMethod(fmt.Sprintf("%v", token.Header["alg"])))
 
 				switch token.Header["alg"] {
 				case "HS256":
@@ -152,7 +152,7 @@ var IsAuthorizedRequest = func(next http.Handler) http.Handler {
 			})
 
 			if err != nil {
-				log.Println(logPrefix, err.Error())
+				log.Error(logPrefix, err.Error())
 			}
 
 			if token.Valid {
@@ -164,7 +164,7 @@ var IsAuthorizedRequest = func(next http.Handler) http.Handler {
 				}
 			}
 		} else {
-			log.Println(logPrefix, "Request doesn't contain an Authorization token")
+			log.Error(logPrefix, "Request doesn't contain an Authorization token")
 		}
 	})
 }

--- a/internal/controller/securemgr/authorizer/authorizer.go
+++ b/internal/controller/securemgr/authorizer/authorizer.go
@@ -49,7 +49,7 @@ const (
 )
 
 var (
-	logPrefix             = "[securemgr: RBAC]"
+	logPrefix             = "[securemgr: RBAC] "
 	log                   = logmgr.GetInstance()
 	rbacPolicyFilePath    = ""
 	rbacAuthModelFilePath = ""
@@ -87,7 +87,7 @@ func Init(rbacRulePath string) {
 	if _, err := os.Stat(rbacRulePath); err != nil {
 		err := os.MkdirAll(rbacRulePath, os.ModePerm)
 		if err != nil {
-			log.Panicf("%s Failed to create rbacRulePath %s: %s\n", logPrefix, rbacRulePath, err)
+			log.Panic(logPrefix, "Failed to create rbacRulePath", rbacRulePath, ": ", err)
 			return
 		}
 	}
@@ -95,7 +95,7 @@ func Init(rbacRulePath string) {
 	if _, err := os.Stat(rbacPolicyFilePath); err != nil {
 		err = ioutil.WriteFile(rbacPolicyFilePath, []byte(policyTemplate), 0664)
 		if err != nil {
-			log.Panicf("%s Cannot create %s: %s\n", logPrefix, rbacPolicyFilePath, err)
+			log.Panic(logPrefix, "Cannot create ", rbacPolicyFilePath, ": ", err)
 		}
 	}
 
@@ -103,7 +103,7 @@ func Init(rbacRulePath string) {
 	if _, err := os.Stat(rbacAuthModelFilePath); err != nil {
 		err = ioutil.WriteFile(rbacAuthModelFilePath, []byte(authModelTemplate), 0664)
 		if err != nil {
-			log.Panicf("%s Cannot create %s: %s\n", logPrefix, rbacAuthModelFilePath, err)
+			log.Panic(logPrefix, "Cannot create ", rbacAuthModelFilePath, ": ", err)
 		}
 	}
 
@@ -119,7 +119,7 @@ func Init(rbacRulePath string) {
 func Authorizer(name string, r *http.Request) error {
 	user, err := users.findByName(name)
 	if err != nil {
-		log.Println(logPrefix, err)
+		log.Info(logPrefix, err)
 		return err
 	}
 
@@ -128,20 +128,20 @@ func Authorizer(name string, r *http.Request) error {
 		role = "unknow"
 	}
 
-	// log.Print("user.Name = ", user.Name)
-	// log.Print("user.Role = ", user.Role)
-	// log.Print("r.URL.Path = ", r.URL.Path)
-	// log.Print("r.Method = ", r.Method)
+	// log.Debug("user.Name = ", user.Name)
+	// log.Debug("user.Role = ", user.Role)
+	// log.Debug("r.URL.Path = ", r.URL.Path)
+	// log.Debug("r.Method = ", r.Method)
 
 	// casbin enforce
 	res, err := enf.EnforceSafe(role, r.URL.Path, r.Method)
 	if err != nil {
-		log.Println(logPrefix, "Error: ", err)
+		log.Error(logPrefix, err)
 		return err
 	}
 	if res {
 		return nil
 	}
-	log.Println(logPrefix, "Unauthorized request")
+	log.Error(logPrefix, "Unauthorized request")
 	return errors.New("unauthorized request")
 }

--- a/internal/controller/securemgr/verifier/verifier.go
+++ b/internal/controller/securemgr/verifier/verifier.go
@@ -35,6 +35,8 @@ const (
 	InvalidParameter  = "INVALID_PARAMETER"
 	SecureMgrError    = "INTERNAL_SECUREMGR_ERROR"
 	NotAllowedCommand = "NOT_ALLOWED_COMMAND"
+
+	cannotCreateFile = "cannot create file: "
 )
 
 // VerificationImpl structure
@@ -42,7 +44,7 @@ type VerificationImpl struct{}
 
 var (
 	containerWhiteList []string
-	logPrefix          = "[securemgr: verifier]"
+	logPrefix          = "[securemgr: verifier] "
 	log                = logmgr.GetInstance()
 	verifierIns        *VerificationImpl
 	initialized        = false
@@ -85,7 +87,7 @@ func initContainerWhiteList() error {
 		containerWhiteList = nil
 		err = ioutil.WriteFile(cwlFilePath, []byte(""), 0666)
 		if err != nil {
-			log.Println(logPrefix, "cannot create "+cwlFileName+": ", err)
+			log.Error(logPrefix, cannotCreateFile, cwlFileName, ": ", err)
 		}
 	} else {
 		containerWhiteList = strings.Split(string(fileContent), "\n")
@@ -93,7 +95,7 @@ func initContainerWhiteList() error {
 			containerWhiteList = containerWhiteList[:len(containerWhiteList)-1]
 		}
 		//for _, whitelistItem := range containerWhiteList {
-		//	log.Println(logPrefix, whitelistItem)
+		//	log.Debug(logPrefix, whitelistItem)
 		//}
 	}
 	return err
@@ -127,7 +129,7 @@ func Init(cwlPath string) {
 	if _, err := os.Stat(cwlPath); err != nil {
 		err := os.MkdirAll(cwlPath, os.ModePerm)
 		if err != nil {
-			log.Panicf("Failed to create cwlPath %s: %s\n", cwlPath, err)
+			log.Panic(logPrefix, "Failed to create cwlPath", cwlPath, ": ", err)
 		}
 	}
 	cwlFilePath = cwlPath + "/" + cwlFileName
@@ -155,27 +157,27 @@ func addHashToContainerWhiteList(hash string) error {
 		fileContentStr := hash + "\n"
 		err = ioutil.WriteFile(cwlFilePath, []byte(fileContentStr), 0666)
 		if err != nil {
-			log.Printf("%s cannot create %s file: %s\n", logPrefix, cwlFileName, err)
+			log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 			return err
 		}
 		containerWhiteList = append(containerWhiteList, hash)
 	} else {
 		fileContentStr := string(fileContent)
-		log.Println(logPrefix, "Len filecontentstr = ", len(fileContentStr))
+		log.Debug(logPrefix, "Len filecontentstr = ", len(fileContentStr))
 		containerWhiteList = strings.Split(fileContentStr, "\n")
 		if len(containerWhiteList) > 0 {
 			containerWhiteList = containerWhiteList[:len(containerWhiteList)-1]
 		}
 		for _, whitelistItem := range containerWhiteList {
 			if whitelistItem == hash {
-				log.Info(logPrefix, " container's hash ", logmgr.SanitizeUserInput(hash), " already exists in container white list") // lgtm [go/log-injection]
+				log.Info(logPrefix, "container's hash ", logmgr.SanitizeUserInput(hash), " already exists in container white list") // lgtm [go/log-injection]
 				return nil
 			}
 		}
 		fileContentStr = fileContentStr + hash + "\n"
 		err = ioutil.WriteFile(cwlFilePath, []byte(fileContentStr), 0666)
 		if err != nil {
-			log.Printf("%s cannot create %s file: %s\n", logPrefix, cwlFileName, err)
+			log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 			return err
 		}
 		containerWhiteList = append(containerWhiteList, hash)
@@ -190,27 +192,27 @@ func delHashFromContainerWhiteList(hash string) error {
 	if err != nil {
 		err = ioutil.WriteFile(cwlFilePath, []byte(""), 0666)
 		if err != nil {
-			log.Printf("%s cannot create %s file: %s\n", logPrefix, cwlFileName, err)
+			log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 			return err
 		}
 	} else {
 		fileContentStr := string(fileContent)
 		digestIndex := strings.Index(fileContentStr, hash)
 		if digestIndex == -1 {
-			log.Printf("%s hash: %s not found in %s\n", logPrefix, logmgr.SanitizeUserInput(hash), cwlFileName) // lgtm [go/log-injection]
+			log.Info(logPrefix, "hash: ", logmgr.SanitizeUserInput(hash), " not found in ", cwlFileName) // lgtm [go/log-injection]
 			return nil
 		}
 		fileContentStr = fileContentStr[:digestIndex] + fileContentStr[digestIndex+65:]
 		err = ioutil.WriteFile(cwlFilePath, []byte(fileContentStr), 0666)
 		if err != nil {
-			log.Printf("%s cannot create %s file: %s\n", logPrefix, cwlFileName, err)
+			log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 			return err
 		}
 		containerWhiteList = strings.Split(fileContentStr, "\n")
 		if len(containerWhiteList) > 0 {
 			containerWhiteList = containerWhiteList[:len(containerWhiteList)-1]
 		}
-		log.Printf("%s hash: %s successfully deleted from %s file\n", logPrefix, logmgr.SanitizeUserInput(hash), cwlFileName) // lgtm [go/log-injection]
+		log.Info(logPrefix, "hash: ", logmgr.SanitizeUserInput(hash), " successfully deleted from ", cwlFileName, " file") // lgtm [go/log-injection]
 	}
 	return nil
 }
@@ -219,11 +221,11 @@ func delHashFromContainerWhiteList(hash string) error {
 func delAllHashFromContainerWhiteList() error {
 	err := ioutil.WriteFile(cwlFilePath, []byte(""), 0666)
 	if err != nil {
-		log.Printf("%s cannot create %s file: %s\n", logPrefix, cwlFileName, err)
+		log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 		return err
 	}
 	containerWhiteList = nil
-	log.Printf("%s all hashes successfully deleted from %s file\n", logPrefix, cwlFileName)
+	log.Info(logPrefix, "all hashes successfully deleted from ", cwlFileName, " file")
 	return err
 }
 
@@ -231,16 +233,16 @@ func delAllHashFromContainerWhiteList() error {
 func printAllHashFromContainerWhiteList() {
 	if containerWhiteList != nil {
 		for idx, whitelistItem := range containerWhiteList {
-			log.Printf("%s container's hash[%d]: len = %d %s\n", logPrefix, idx, len(whitelistItem), logmgr.SanitizeUserInput(whitelistItem)) // lgtm [go/log-injection]
+			log.Info(logPrefix, "container's hash[", idx, "]: ", logmgr.SanitizeUserInput(whitelistItem)) // lgtm [go/log-injection]
 		}
 	} else {
-		log.Println(logPrefix, "container white list is empty")
+		log.Info(logPrefix, "container white list is empty")
 	}
 }
 
 // RequestVerifierConf is Verifier configuration request handler
 func (verifier *VerificationImpl) RequestVerifierConf(containerInfo RequestVerifierConf) ResponseVerifierConf {
-	log.Info(logPrefix, " command type: ", logmgr.SanitizeUserInput(containerInfo.CmdType)) // lgtm [go/log-injection]
+	log.Info(logPrefix, "command type: ", logmgr.SanitizeUserInput(containerInfo.CmdType)) // lgtm [go/log-injection]
 	switch containerInfo.CmdType {
 	case "addHashCWL":
 		for _, containerDesc := range containerInfo.Desc {
@@ -273,7 +275,7 @@ func (verifier *VerificationImpl) RequestVerifierConf(containerInfo RequestVerif
 	case "printAllHashCWL":
 		printAllHashFromContainerWhiteList()
 	default:
-		log.Println(logPrefix, "command does not supported: ", logmgr.SanitizeUserInput(containerInfo.CmdType)) // lgtm [go/log-injection]
+		log.Info(logPrefix, "command does not supported: ", logmgr.SanitizeUserInput(containerInfo.CmdType)) // lgtm [go/log-injection]
 		return ResponseVerifierConf{
 			Message:       NotAllowedCommand,
 			SecureCmpName: "verifier",

--- a/internal/controller/securemgr/verifier/verifier_test.go
+++ b/internal/controller/securemgr/verifier/verifier_test.go
@@ -163,7 +163,7 @@ func TestDelHashFromContainerWhiteList(t *testing.T) {
 		}
 
 		if err := delHashFromContainerWhiteList(fakehashExtraContainer); err != nil {
-			log.Println(logPrefix, "Can't create "+cwlFileName+": ", err)
+			t.Error(unexpectedSuccess)
 		}
 
 		if err := containerHashIsInWhiteList(fakehashExtraContainer); err == nil {

--- a/tools/jwt_gen.sh
+++ b/tools/jwt_gen.sh
@@ -5,8 +5,9 @@ FILEPUBKEY=/var/edge-orchestration/data/jwt/app_rsa.key
 
 device_id=`cat /var/edge-orchestration/device/orchestration_deviceID.txt`
 
+# Token life time 24h = 86400s
 payload="{
-	\"exp\": $(($(date +%s)+600)),
+	\"exp\": $(($(date +%s)+86400)),
 	\"iat\": $(date +%s),
 	\"deviceid\": \"${device_id}\",
 	\"aud\": \"$2\"


### PR DESCRIPTION
…e format

Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

1) Added hash check as input parameter
2) Unified message log format
3) Increased JWT validity time up to 24 hours 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup/refactoring

# How Has This Been Tested?

Use in secure mode will demonstrate operability. [How to run in secure mode](https://github.com/lf-edge/edge-home-orchestration-go/blob/master/docs/secure_manager.md) 

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 and Go v1.16
* Edge Orchestration Release: v1.1.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
