### PR TITLE
Add format check in cmd folder

### DIFF
--- a/.github/workflows/lint-vet-gofmt-staticcheck-analysis.yml
+++ b/.github/workflows/lint-vet-gofmt-staticcheck-analysis.yml
@@ -30,7 +30,8 @@ jobs:
 
       - name: GoFmt Analysis
         run: |
-          if [[ $(gofmt -l ./internal) ]]; then exit 1; fi 
+          if [[ $(gofmt -l ./internal) ]]; then exit 1; fi
+          if [[ $(gofmt -l ./cmd) ]]; then exit 1; fi
 
       - name: Staticcheck Analysis
         run: |

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ fmt:
 	$(Q) make clean
 	$(call print_header, "Formatting source code using gofmt")
 	$(Q) gofmt -s -w ./internal
+	$(Q) gofmt -s -w ./cmd
 
 ## show help
 help:

--- a/cmd/edge-orchestration/capi/main.go
+++ b/cmd/edge-orchestration/capi/main.go
@@ -111,10 +111,10 @@ const (
 
 	edgeDir = "/var/edge-orchestration"
 
-	logPath                = edgeDir + "/log"
-	configPath             = edgeDir + "/apps"
-	dbPath                 = edgeDir + "/data/db"
-	certificateFilePath    = edgeDir + "/data/cert"
+	logPath             = edgeDir + "/log"
+	configPath          = edgeDir + "/apps"
+	dbPath              = edgeDir + "/data/db"
+	certificateFilePath = edgeDir + "/data/cert"
 
 	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
 	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"

--- a/cmd/edge-orchestration/javaapi/javaapi.go
+++ b/cmd/edge-orchestration/javaapi/javaapi.go
@@ -52,10 +52,10 @@ const (
 	platform      = "android"
 	executionType = "android"
 
-	logStr                 = "/log"
-	configStr              = "/apps"
-	dbStr                  = "/data/db"
-	certificateFile        = "/data/cert"
+	logStr          = "/log"
+	configStr       = "/apps"
+	dbStr           = "/data/db"
+	certificateFile = "/data/cert"
 
 	cipherKeyFile = "/user/orchestration_userID.txt"
 	deviceIDFile  = "/device/orchestration_deviceID.txt"

--- a/cmd/edge-orchestration/main.go
+++ b/cmd/edge-orchestration/main.go
@@ -56,10 +56,10 @@ const (
 
 	edgeDir = "/var/edge-orchestration"
 
-	logPath                = edgeDir + "/log"
-	configPath             = edgeDir + "/apps"
-	dbPath                 = edgeDir + "/data/db"
-	certificateFilePath    = edgeDir + "/data/cert"
+	logPath             = edgeDir + "/log"
+	configPath          = edgeDir + "/apps"
+	dbPath              = edgeDir + "/data/db"
+	certificateFilePath = edgeDir + "/data/cert"
 
 	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
 	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description
Added format check in `cmd` folder using gofmt utility 

## Type of change

Please delete options that are not relevant.

- [x] Code cleanup/refactoring
- [x] CI system update

# How Has This Been Tested?

Need to make formatting errors in `cmd` folder *.go files. And then run the command:
```
make fmt
```
After errors will be corrected.

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 and Go v1.16
* Edge Orchestration Release: v1.1.6

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
