### PR TITLE
[CI] Add depependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+# Enable version updates for gomod
+  - package-ecosystem: "gomod"
+    # Look for `gomod` in the `root` directory
+    directory: "/"
+    # Check for updates once a day
+    schedule:
+      interval: "daily"
+# Enable version updates for Actions
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    # Check for updates once a day
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Dependabot is a bot, which monitors our dependencies. It automatically creates PRs with a given interval, if the dependencies are updated. This will allow us to respond more quickly to components updates and vulnerability fixes. Previously, I only used it to monitor updates, I think we need to try as it will automatically suggest PR with updates (this is part of my first experience).
Also it is one of OpenSSF Score Card requirements

**I would like to point out** that we may not accept all PRs, only those that we consider necessary. 

Fixes #478 

## Type of change

- [x] CI system update

For example:
![image](https://user-images.githubusercontent.com/45031429/154447989-03aaef58-e60d-4c32-885a-fd21b38b38ef.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
