### PR TITLE
Ignore docker pkg from dependabot since serious consideration is required

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     # Check for updates once a month
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "*docker*"
+
 # Enable version updates for Actions
   - package-ecosystem: "github-actions"
     # Look for `.github/workflows` in the `root` directory


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Packages related to docker engine should be excluded from dependabot since it requires [containerexecutor](https://github.com/lf-edge/edge-home-orchestration-go/blob/master/internal/controller/servicemgr/executor/containerexecutor/containerexecutor.go) code change.

## Type of change

- [x] CI system update