### PR TITLE
[DataStorage] APIs to add Event and delete Events from database based on event ids

### DIFF
--- a/internal/controller/storagemgr/storagedriver/storagehandler.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler.go
@@ -21,16 +21,16 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config"
-	dbhelper "github.com/lf-edge/edge-home-orchestration-go/internal/db/helper"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper"
 	"io/ioutil"
 	"math"
 	"net/http"
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config"
+	dbhelper "github.com/lf-edge/edge-home-orchestration-go/internal/db/helper"
+	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper"
 	"github.com/spf13/cast"
 
 	"github.com/edgexfoundry/device-sdk-go/pkg/models"
@@ -49,12 +49,16 @@ const (
 	handlerContextKey ctxKey = "StorageHandler"
 	configPath               = "res/configuration.toml"
 	numberOfReadings         = "readingCount"
+	eventIDKey               = "id"
+	event                    = "event"
 
 	apiResourceRoute               = clients.ApiBase + "/device/{" + deviceNameKey + "}/resource/{" + resourceNameKey + "}"
 	apiResourceRouteMultiple       = clients.ApiBase + "/device/{" + deviceNameKey + "}/resource/{" + resourceNameKey + "}/{" + numberOfReadings + "}"
 	apiWithoutResRoute             = clients.ApiBase + "/resource/{" + resourceNameKey + "}"
 	apiWithoutResRouteMultiple     = clients.ApiBase + "/resource/{" + resourceNameKey + "}/{" + numberOfReadings + "}"
 	apiWithoutResRouteTimeMultiple = clients.ApiBase + "/start/{" + startKey + "}/end/{" + endKey + "}/{" + numberOfReadings + "}"
+	apiEventAddRoute               = clients.ApiBase + "/{" + event + "}"
+	apiEventDeleteRoute            = clients.ApiBase + "/event/id/{" + eventIDKey + "}"
 )
 
 var (
@@ -98,6 +102,12 @@ func (handler StorageHandler) Start() error {
 	}
 	if err := handler.service.AddRoute(apiWithoutResRouteTimeMultiple, handler.addContext(deviceHandler), http.MethodGet); err != nil {
 		return fmt.Errorf("unable to add required route: %s: %s", apiWithoutResRouteTimeMultiple, err.Error())
+	}
+	if err := handler.service.AddRoute(apiEventAddRoute, handler.addContext(deviceHandler), http.MethodPost); err != nil {
+		return fmt.Errorf("unable to add required route: %s: %s", apiEventAddRoute, err.Error())
+	}
+	if err := handler.service.AddRoute(apiEventDeleteRoute, handler.addContext(deviceHandler), http.MethodDelete); err != nil {
+		return fmt.Errorf("unable to add required route: %s: %s", apiEventDeleteRoute, err.Error())
 	}
 	return nil
 }
@@ -170,9 +180,39 @@ func (handler StorageHandler) processAsyncGetRequest(writer http.ResponseWriter,
 	handler.helper.Response(writer, resp, http.StatusOK)
 }
 
-// processGetAsyncRequest is used to handle Async POST Requests
+//addEvent is used to handle the add event Post requests
+func (handler StorageHandler) addEvent(writer http.ResponseWriter, request *http.Request) {
+	readingAPI := "/api/v1/" + event
+	serverIP, readingPort, err := config.GetServerIP(configPath)
+
+	if err != nil {
+		http.Error(writer, "Configuration File Not Found", http.StatusNotFound)
+		return
+	}
+
+	requestURL := handler.helper.MakeTargetURL(serverIP, readingPort, readingAPI)
+	reqBody, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		http.Error(writer, "Error in getting body", http.StatusBadRequest)
+	}
+	resp, statusCode, err := handler.helper.DoPost(requestURL, reqBody)
+	if err != nil {
+		http.Error(writer, "Error in doing Post request :", statusCode)
+		return
+	}
+	eventid := string(resp)
+	log.Debug(fmt.Sprintf("Event Id is %s", eventid))
+	handler.helper.Response(writer, resp, http.StatusOK)
+}
+
+// processAsyncPostRequest is used to handle Async POST Requests
 func (handler StorageHandler) processAsyncPostRequest(writer http.ResponseWriter, request *http.Request) {
 	vars := mux.Vars(request)
+	event := vars[event]
+	if event != "" {
+		handler.addEvent(writer, request)
+		return
+	}
 	deviceName := vars[deviceNameKey]
 	var err error
 	if deviceName == "" {
@@ -253,6 +293,30 @@ func (handler StorageHandler) processAsyncPostRequest(writer http.ResponseWriter
 	handler.asyncValues <- asyncValues
 }
 
+//processDeleteRequest is used to handle the Async Delete Request
+func (handler StorageHandler) processDeleteRequest(writer http.ResponseWriter, request *http.Request) {
+	vars := mux.Vars(request)
+	ID := vars[eventIDKey]
+
+	log.Debug(fmt.Sprintf("Received DELETE for Event ID=%s", logmgr.SanitizeUserInput(ID))) // lgtm [go/log-injection]
+	var deleteAPI string
+	if ID != "" {
+		deleteAPI = "/api/v1/event/id/" + ID
+	}
+	serverIP, readingPort, err := config.GetServerIP(configPath)
+	if err != nil {
+		http.Error(writer, "Configuration File Not Found", http.StatusNotFound)
+		return
+	}
+	requestURL := handler.helper.MakeTargetURL(serverIP, readingPort, deleteAPI)
+	resp, _, err := handler.helper.DoDelete(requestURL)
+	if err != nil {
+		http.Error(writer, "Resource not found", http.StatusNotFound)
+		return
+	}
+	handler.helper.Response(writer, resp, http.StatusOK)
+}
+
 func (handler StorageHandler) readBodyAsString(request *http.Request) (string, error) {
 	if request.Body == nil {
 		return "", fmt.Errorf("no request body provided")
@@ -301,6 +365,8 @@ func deviceHandler(writer http.ResponseWriter, request *http.Request) {
 		handler.processAsyncGetRequest(writer, request)
 	case "POST":
 		handler.processAsyncPostRequest(writer, request)
+	case "DELETE":
+		handler.processDeleteRequest(writer, request)
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description
Currently DataStorage has APIs to add data to the database or get the reading. API to delete a record from database is not present. This PR will add an API to delete record from CoreData given the Event ID

Usage Example
Add an Event
curl --location --request POST 'http://{DeviceServiceIP:Port}/api/v1/event'
Delete an Event
curl --location --request DELETE 'http://192.168.1.107:49986/api/v1/event/id/{EventID}"

Fixes # (issue)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
1. Run the Docker container for Edge-orchestration 
```
docker run -it -d --privileged --network="host" --name edge-orchestration  -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
```
2. Post an event by calling the API
curl --location --request POST 'http://192.168.1.107:49986/api/v1/event' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "device":"camera",
    "readings":[{
        "name":"cowcount",
        "value":"9"
    }]
}'
This will return an id of the event (In this example it returned 0d8d6738-5968-4b6c-92eb-1d45b2b3740a) 

3. Call the delete API using 
curl --location --request DELETE 'http://192.168.1.107:49986/api/v1/event/id/0d8d6738-5968-4b6c-92eb-1d45b2b3740a'

This will return true in case of success

**Test Configuration**:
* OS type & version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (v1.1.0)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
