### PR TITLE
[CloudSync] Adding API to subscribe to a topic

### DIFF
--- a/internal/common/mqtt/mqttconnection.go
+++ b/internal/common/mqtt/mqttconnection.go
@@ -150,3 +150,23 @@ func (client *Client) Publish(message Message, topic string) error {
 	time.Sleep(time.Second)
 	return nil
 }
+
+var messageHandler MQTT.MessageHandler = func(client MQTT.Client, msg MQTT.Message) {
+
+	log.Info(logPrefix, "Topic ", msg.Topic(), " registered.. ", string(msg.Payload()), " is the payload")
+}
+
+//Subscribe is used to subscribe to a topic
+func (client *Client) Subscribe(topic string) error {
+	log.Info(logPrefix, "Subscribing to ", logmgr.SanitizeUserInput(topic)) // lgtm [go/log-injection]
+	mqttClient := client.Client
+	for mqttClient == nil {
+		time.Sleep(time.Second * 2)
+	}
+	token := mqttClient.Subscribe(topic, 0, messageHandler)
+	if token.Wait() && token.Error() != nil {
+		return token.Error()
+	}
+	time.Sleep(time.Second)
+	return nil
+}

--- a/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
+++ b/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
@@ -68,7 +68,19 @@ func (_m *MockCloudSync) RequestPublish(host string, clientID string, message mq
 	return ret0
 }
 
-// RequestPublish indicates an expected call of StartCloudSync
+// RequestPublish indicates an expected call of RequestPublish
 func (_mr *MockCloudSyncMockRecorder) RequestPublish(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "RequestPublish", reflect.TypeOf((*MockCloudSync)(nil).RequestPublish), arg0)
+}
+
+// RequestSubscribe mocks base method
+func (_m *MockCloudSync) RequestSubscribe(host string, clientID string, topic string) string {
+	ret := _m.ctrl.Call(_m, "RequestSubscribe", host)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RequestSubscribe indicates an expected call of RequestSubscribe
+func (_mr *MockCloudSyncMockRecorder) RequestSubscribe(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "RequestSubscribe", reflect.TypeOf((*MockCloudSync)(nil).RequestSubscribe), arg0)
 }

--- a/internal/orchestrationapi/mocks/mock_orchestration.go
+++ b/internal/orchestrationapi/mocks/mock_orchestration.go
@@ -118,6 +118,20 @@ func (mr *MockOrcheExternalAPIMockRecorder) RequestCloudSyncPublish(arg0, arg1 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestCloudSyncPublish", reflect.TypeOf((*MockOrcheExternalAPI)(nil).RequestCloudSyncPublish), arg0, arg1, arg2, arg3)
 }
 
+// RequestCloudSync mocks base method.
+func (m *MockOrcheExternalAPI) RequestCloudSyncSubscribe(arg0 string, arg1 string, arg2 string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestCloudSyncSubscribe", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RequestCloudSync indicates an expected call of RequestService.
+func (mr *MockOrcheExternalAPIMockRecorder) RequestCloudSyncSubscribe(arg0, arg1 interface{}, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestCloudSyncSubscribe", reflect.TypeOf((*MockOrcheExternalAPI)(nil).RequestCloudSyncSubscribe), arg0, arg1, arg2)
+}
+
 // RequestVerifierConf mocks base method.
 func (m *MockOrcheExternalAPI) RequestVerifierConf(arg0 verifier.RequestVerifierConf) verifier.ResponseVerifierConf {
 	m.ctrl.T.Helper()

--- a/internal/orchestrationapi/orchestration.go
+++ b/internal/orchestrationapi/orchestration.go
@@ -54,6 +54,7 @@ type OrcheExternalAPI interface {
 	RequestService(serviceInfo ReqeustService) ResponseService
 	verifier.Conf
 	RequestCloudSyncPublish(host string, clientID string, message mqtt.Message, topic string) string
+	RequestCloudSyncSubscribe(host string, clientID string, topic string) string
 }
 
 // OrcheInternalAPI is the interface implemented by internal REST API

--- a/internal/orchestrationapi/orchestrationapi.go
+++ b/internal/orchestrationapi/orchestrationapi.go
@@ -136,6 +136,12 @@ func (orcheEngine *orcheImpl) RequestCloudSyncPublish(host string, clientID stri
 	return orcheEngine.cloudsyncIns.RequestPublish(host, clientID, message, topic)
 }
 
+//RequestCloudSyncSubscribe handles the request for cloud subscribing
+func (orcheEngine *orcheImpl) RequestCloudSyncSubscribe(host string, clientID string, topic string) string {
+	log.Info("[RequestCloudSync]", "Requesting cloud sync subscribe")
+	return orcheEngine.cloudsyncIns.RequestSubscribe(host, clientID, topic)
+}
+
 // RequestService handles service request (ex. offloading) from service application
 func (orcheEngine *orcheImpl) RequestService(serviceInfo ReqeustService) ResponseService {
 	log.Printf("[RequestService] %s: %v\n", logmgr.SanitizeUserInput(serviceInfo.ServiceName), serviceInfo.ServiceInfo) // lgtm [go/log-injection]


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description

Currently Cloudsync has API to publish the data to cloud endpoint(AWS). This PR adds the API to subscribe to the topic.

UsageExample
Subscribe to the topic
curl --location --request POST 'http://{EdgeOrchestration IP}:56001/api/v1/orchestration/cloudsyncmgr/subscribe'

Fixes # (#382)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
1.MQTT mosquitto broker is configured to be running in the AWS endpoint.
2. The edge orchestration is build and run using following command with option CLOUD_SYNC set to true
```
docker run -it -d --privileged --network="host" --name edge-orchestration -e CLOUD_SYNC=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
```
3. Call the subscribe API using curl request
```
curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/subscribe' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "appid": "testsamsung",
    "topic": "homeedge/livingroom",
    "url" : "ec2-54-166-90-45.compute-1.amazonaws.com"
}'
```
Onsuccessful completion of API you get following response with status code 200 
```
{"Message":"Sucessfully Subscribed to the topichomeedge/livingroom","RemoteTargetInfo":"","ServiceName":""}
```
4. The docker logs can be checked using
```
docker logs -f edge-orchestration
```
Following logs are obtained
```
INFO[2022-03-03T06:52:37Z]mqttconnection.go:120 StartMQTTClient [MQTTConnectionMgr] The broker istcp://ec2-54-166-90-45.compute-1.amazonaws.com:1883 
INFO[2022-03-03T06:52:38Z]mqttconnection.go:42 Connect [MQTTConnectionMgr] MQTT Connected           
INFO[2022-03-03T06:52:38Z]mqttconnection.go:162 Subscribe [MQTTConnectionMgr] Subscribing the data to cloud 
INFO[2022-03-03T06:52:39Z]mqttconnection.go:156 func1 Topic homeedge/livingroom registered.. {"AppID":"testsamsung","Payload":"Testdata for subscribing"} is the payload  
INFO[2022-03-03T06:52:39Z]route.go:130 func1 From [192.168.1.107:60916] POST /api/v1/orchestration/cloudsyncmgr/subscribe APIV1RequestCloudSyncmgrSubscribe 2.071073096s 
```

**Test Configuration**:
* OS type & version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (v1.1.0)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
