### PR TITLE
Code update to use MQTT broker in secure mode (mutual authentication …

### DIFF
--- a/cmd/edge-orchestration/capi/main.go
+++ b/cmd/edge-orchestration/capi/main.go
@@ -114,7 +114,7 @@ const (
 	logPath             = edgeDir + "/log"
 	configPath          = edgeDir + "/apps"
 	dbPath              = edgeDir + "/data/db"
-	certificateFilePath = edgeDir + "/data/cert"
+	certificateFilePath = edgeDir + "/certs"
 
 	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
 	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"

--- a/cmd/edge-orchestration/javaapi/javaapi.go
+++ b/cmd/edge-orchestration/javaapi/javaapi.go
@@ -55,7 +55,7 @@ const (
 	logStr          = "/log"
 	configStr       = "/apps"
 	dbStr           = "/data/db"
-	certificateFile = "/data/cert"
+	certificateFile = "/certs"
 
 	cipherKeyFile = "/user/orchestration_userID.txt"
 	deviceIDFile  = "/device/orchestration_deviceID.txt"

--- a/cmd/edge-orchestration/main.go
+++ b/cmd/edge-orchestration/main.go
@@ -59,7 +59,7 @@ const (
 	logPath             = edgeDir + "/log"
 	configPath          = edgeDir + "/apps"
 	dbPath              = edgeDir + "/data/db"
-	certificateFilePath = edgeDir + "/data/cert"
+	certificateFilePath = edgeDir + "/certs"
 
 	cipherKeyFilePath = edgeDir + "/user/orchestration_userID.txt"
 	deviceIDFilePath  = edgeDir + "/device/orchestration_deviceID.txt"

--- a/docs/cloudsync_mqtt.md
+++ b/docs/cloudsync_mqtt.md
@@ -3,9 +3,8 @@
 1. [Introduction](#1-Introduction)
 2. [Launching and Configuring EC2 Instance](#2-Launching-and-Configuring-EC2-Instance)
 3. [Installing MQTT Broker on AWS](#3-Installing-MQTT-Broker-on-AWS)
-4. [Certificate Generation for MQTT](#4-Certificate-Generation-for-MQTT)
-5. [Configurations for MQTT broker](#5-Configurations-for-MQTT)
-6. [Run CloudSync](#6-Run-Cloudsync)
+4. [Configurations for MQTT broker](#4-Configurations-for-MQTT)
+5. [Run CloudSync](#5-Run-Cloudsync)
 
 # 1. Introduction
 This module would be responsible for sending the data (can be sensor data or any reading or image/video data, etc.) collected from different devices in the home environment to a cloud Endpoint (AWS). This Sync to the cloud will be using a API Call by the service application. The broker used is mosquitto which is setup at AWS endpoint. The Service Application will make a POST API call which will then check first for the connection to the broker and then establish a connection if not present to further publish the data to the cloud. After successful publish or in case of failure corresponding response is sent back to the service application<br><br>
@@ -61,215 +60,83 @@ sudo apt-get install mosquitto
 sudo apt-get install mosquitto-clients
 ```
 
-# 4. Certificate Generation for MQTT
+# 4. Configurations for MQTT broker
+The Edge-Orchestration can be run in two modes: normal and secure, therefore the MQTT broker can be run in the following configurations `/etc/mosquitto/mosquitto.conf`
 
-### Create a basic configuration file:
+**Normal** (No security, port 1883)
 ```
-$ touch openssl-ca.cnf
-```
-Then, add the following to it:
-```
-HOME            = .
-RANDFILE        = $ENV::HOME/.rnd
+# Place your local configuration in /etc/mosquitto/conf.d/
+#
+# A full description of the configuration file is at
+# /usr/share/doc/mosquitto/examples/mosquitto.conf.example
 
-####################################################################
-[ ca ]
-default_ca    = CA_default      # The default ca section
+persistence true
+persistence_location /var/lib/mosquitto/
 
-[ CA_default ]
+log_dest file /var/log/mosquitto/mosquitto.log
 
-default_days     = 1000         # How long to certify for
-default_crl_days = 30           # How long before next CRL
-default_md       = sha256       # Use public key default MD
-preserve         = no           # Keep passed DN ordering
+include_dir /etc/mosquitto/conf.d
 
-x509_extensions = ca_extensions # The extensions to add to the cert
-
-email_in_dn     = no            # Don't concat the email in the DN
-copy_extensions = copy          # Required to copy SANs from CSR to cert
-
-####################################################################
-[ req ]
-default_bits       = 4096
-default_keyfile    = cakey.pem
-distinguished_name = ca_distinguished_name
-x509_extensions    = ca_extensions
-string_mask        = utf8only
-
-####################################################################
-[ ca_distinguished_name ]
-countryName         = Country Name (2 letter code)
-countryName_default = US
-
-stateOrProvinceName         = State or Province Name (full name)
-stateOrProvinceName_default = Maryland
-
-localityName                = Locality Name (eg, city)
-localityName_default        = Baltimore
-
-organizationName            = Organization Name (eg, company)
-organizationName_default    = Test CA, Limited
-
-organizationalUnitName         = Organizational Unit (eg, division)
-organizationalUnitName_default = Server Research Department
-
-commonName         = Common Name (e.g. server FQDN or YOUR name) /** In this case you can use *.compute-1.amazonaws.com ***/
-commonName_default = Test CA
-
-emailAddress         = Email Address
-emailAddress_default = test@example.com
-
-####################################################################
-[ ca_extensions ]
-
-subjectKeyIdentifier   = hash
-authorityKeyIdentifier = keyid:always, issuer
-basicConstraints       = critical, CA:true
-keyUsage               = keyCertSign, cRLSign
-```
-Then, execute the following. The -nodes omits the password or passphrase so you can examine the certificate.
-```
-$ openssl req -x509 -config openssl-ca.cnf -newkey rsa:4096 -sha256 -nodes -out cacert.pem -outform PEM
-```
-After the command executes, cacert.pem will be your certificate for CA operations, and cakey.pem will be the private key. Recall the private key does not have a password or passphrase
-
-### Create Another Configuration file using
-```
-$ touch openssl-server.cnf
-```
-Then open it, and add the following.
-```
-HOME            = .
-RANDFILE        = $ENV::HOME/.rnd
-
-####################################################################
-[ req ]
-default_bits       = 2048
-default_keyfile    = serverkey.pem
-distinguished_name = server_distinguished_name
-req_extensions     = server_req_extensions
-string_mask        = utf8only
-
-####################################################################
-[ server_distinguished_name ]
-countryName         = Country Name (2 letter code)
-countryName_default = US
-
-stateOrProvinceName         = State or Province Name (full name)
-stateOrProvinceName_default = MD
-
-localityName         = Locality Name (eg, city)
-localityName_default = Baltimore
-
-organizationName            = Organization Name (eg, company)
-organizationName_default    = Test Server, Limited
-
-commonName           = Common Name (e.g. server FQDN or YOUR name)
-commonName_default   = Test Server
-
-emailAddress         = Email Address
-emailAddress_default = test@example.com
-
-####################################################################
-[ server_req_extensions ]
-
-subjectKeyIdentifier = hash
-basicConstraints     = CA:FALSE
-keyUsage             = digitalSignature, keyEncipherment
-subjectAltName       = @alternate_names
-nsComment            = "OpenSSL Generated Certificate"
-
-####################################################################
-[ alternate_names ]
-
-DNS.1  = example.com
-DNS.2  = www.example.com
-DNS.3  = mail.example.com
-DNS.4  = ftp.example.com
-
-```
-Then, create the server certificate request
-```
-$ openssl req -config openssl-server.cnf -newkey rsa:2048 -sha256 -nodes -out servercert.csr -outform PEM
-```
-After this command executes, you will have a request in servercert.csr and a private key in serverkey.pem
-
-Next, you have to sign it with your CA.open openssl-ca.cnf and add the following two sections.
-```
-####################################################################
-[ signing_policy ]
-countryName            = optional
-stateOrProvinceName    = optional
-localityName           = optional
-organizationName       = optional
-organizationalUnitName = optional
-commonName             = supplied
-emailAddress           = optional
-
-####################################################################
-[ signing_req ]
-subjectKeyIdentifier   = hash
-authorityKeyIdentifier = keyid,issuer
-basicConstraints       = CA:FALSE
-keyUsage               = digitalSignature, keyEncipherment
-```
-Add the following to the [ CA_default ] section of openssl-ca.cnf.
-```
-base_dir      = .
-certificate   = $base_dir/cacert.pem   # The CA certifcate
-private_key   = $base_dir/cakey.pem    # The CA private key
-new_certs_dir = $base_dir              # Location for new certs after signing
-database      = $base_dir/index.txt    # Database index file
-serial        = $base_dir/serial.txt   # The current serial number
-
-unique_subject = no  # Set to 'no' to allow creation of
-                     # several certificates with same subject.
-
-```
-Third, touch index.txt and serial.txt:
-```
-$ touch index.txt
-$ echo '01' > serial.txt
-```
-Then, perform the following:
-```
-$ openssl ca -config openssl-ca.cnf -policy signing_policy -extensions signing_req -out servercert.pem -infiles servercert.csr
+listener 1883:0.0.0.0
+allow_anonymous true
 ```
 
-### Copying the Certificates
-1. Copy the servercert.pem, serverkey.pem and cacert.pem file to /etc/mosquitto/certs
-2. Mention the path of the certs in the configuration file of mosquitto
-3. Copy the cacert.pem file in /var/edge-orchestration/mqtt/certs folder in client side
-4. Mosquitto broker allows to generate password for the users you want to allow connection.For example password can be generated for User A in a file named A.txt and path can be specified in the configuration file. Similarly the password can be generated for another user say User C as C.txt with password saved in it.
-** By Default allow_anonymous has to be kept true
+**Secure** (With TLS certificates, port 8883)
+```
+# Place your local configuration in /etc/mosquitto/conf.d/
+#
+# A full description of the configuration file is at
+# /usr/share/doc/mosquitto/examples/mosquitto.conf.example
 
+persistence true
+persistence_location /var/lib/mosquitto/
 
+log_dest file /var/log/mosquitto/mosquitto.log
 
-# 5. Configurations for MQTT broker
-MQTT broker provides the following secure mode
-1. TLS Handshake to secure the channel of communication
-2. Creating passwords for users whom we want the communication to be allowed for the broker thereby specifying the authorization
-So mosquitto allows one to store the password file in any location and provide the path in mosquitto conf file.
+include_dir /etc/mosquitto/conf.d
 
-### 3 level of Security between MQTT broker and client communication
+listener 8883:0.0.0.0
+allow_anonymous false
 
-    1. Allow_anonymous = true (No security, port 1883)
-    2. Allow_anonymous = true (With TLS Certificates making only channel of communication secure but allow any user to communicate who has the certs,port 8883)
-    3. Allow_anonymous = false (With TLS certificate and password for specific users thereby providing authentication for communication,port 8883)
+cafile /etc/mosquitto/certs/ca-crt.pem
+certfile /etc/mosquitto/certs/hen-crt.pem
+keyfile /etc/mosquitto/certs/hen-key.pem
 
+require_certificate true
+use_identity_as_username true
+```
 
-***Please Note :*** By Default the allow_anonymous = true should be mentioned in the configuration file. As the security level is increased the value can be changed and passwords can be included
+> How to generate `cafile`, `certfile` and  `keyfile` is described [here](https://github.com/lf-edge/edge-home-orchestration-go/blob/master/docs/secure_manager.md#53-generation-key-infrastructure)
 
-# 6. Run Cloudsync 
+# 5. Run Cloudsync 
 
-The edge orchestration is build and run using following command with option CLOUD_SYNC set to true
+**Normal mode**
+The edge-orchestration is build and run using following command with option CLOUD_SYNC set to true
 ```
 docker run -it -d --privileged --network="host" --name edge-orchestration -e CLOUD_SYNC=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
 ```
 From the another terminal/post make a curl command as follows to publish data using home edge to the broker running on AWS endpoint
 
 ```
-curl --location --request POST 'http://<ip where edgeorchestration is running>:56001/api/v1/orchestration/cloudsyncmgr/publish' \
+curl --location --request POST 'http://<ip where edge-orchestration is running>:56001/api/v1/orchestration/cloudsyncmgr/publish' \
+--header 'Content-Type: text/plain' \
+--data-raw '{
+    "appid": "<appid of service app>",
+    "payload": "{Another data from TV1 and testdata}",
+    "topic": "home1/livingroom",
+    "url" : "<AWS public IP>"
+}'
+```
+**Secure mode**
+The edge-orchestration is build and run using following command with option `CLOUD_SYNC` and `SECURE` set to true
+```
+docker run -it -d --privileged --network="host" --name edge-orchestration -e CLOUD_SYNC=true -e SECURE=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
+```
+From the another terminal/post make a curl command as follows to publish data using home edge to the broker running on AWS endpoint
+
+```
+curl --location --request POST 'http://<ip where edge-orchestration is running>:56001/api/v1/orchestration/cloudsyncmgr/publish' \
+-H "Authorization: $EDGE_ORCHESTRATION_TOKEN" \
 --header 'Content-Type: text/plain' \
 --data-raw '{
     "appid": "<appid of service app>",

--- a/docs/platforms/x86_64_linux/x86_64_linux.md
+++ b/docs/platforms/x86_64_linux/x86_64_linux.md
@@ -122,7 +122,7 @@ Note that you can visit [Swagger Editor](https://editor.swagger.io/) to graphica
   - Same network connected among the devices.
   - Same Authentication key in /var/edge-orchestration/user/orchestration_userID.txt
     - To let the Edge Orchestration devices communicate with each other, each devices should have same authentication key in:
-`/var/edge-orchestration/data/cert/edge-orchestration.key` (Any cert file can be authentication key)
+`/var/edge-orchestration/certs/edge-orchestration.key` (Any cert file can be authentication key)
   - Edge Orchestration Docker image
     - Please see the above [How to build](#how-to-build) to know how to build Edge Orchestration Docker image
   - If you use in secure mode, you must [deploy the key infrastructure](../../secure_manager.md#53-generation-key-infrastructure). 
@@ -186,8 +186,8 @@ docker logs -f edge-orchestration
 2019/10/16 07:35:45 discovery.go:371: [deviceDetectionRoutine] netInfo     : IPv4({$discovery_ip_list})
 2019/10/16 07:35:45 discovery.go:372: [deviceDetectionRoutine] serviceInfo : Services([])
 2019/10/16 07:35:45 discovery.go:373: 
-2019/10/16 07:35:45 tls.go:40: SetCertFilePath:  /var/edge-orchestration/data/cert
-2019/10/16 07:35:45 tls.go:40: SetCertFilePath:  /var/edge-orchestration/data/cert
+2019/10/16 07:35:45 tls.go:40: SetCertFilePath:  /var/edge-orchestration/certs
+2019/10/16 07:35:45 tls.go:40: SetCertFilePath:  /var/edge-orchestration/certs
 2019/10/16 07:35:45 route.go:76: {APIV1Ping GET /api/v1/ping 0x8090f0}
 2019/10/16 07:35:45 route.go:76: {APIV1ServicemgrServicesPost POST /api/v1/servicemgr/services 0x809160}
 2019/10/16 07:35:45 route.go:76: {APIV1ServicemgrServicesNotificationServiceIDPost POST /api/v1/servicemgr/services/notification/{serviceid} 0x8091c0}

--- a/docs/secure_manager.md
+++ b/docs/secure_manager.md
@@ -295,10 +295,10 @@ The **[Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_L
 
 @startuml
   autonumber
-  CA->>CA: Generate CA Root Certificate ca.crt ca.key
-  "Node (192.168.0.100)"->>"Node (192.168.0.100)": Generate private key hen.key, request hen.csr
+  CA->>CA: Generate CA Root Certificate ca-crt.pem ca-key.pem
+  "Node (192.168.0.100)"->>"Node (192.168.0.100)": Generate private key hen-key.pem, request hen.csr
   "Node (192.168.0.100)"->>CA: Send hen.csr to CA
-  CA-->>"Node (192.168.0.100)": Send ca.crt and hen.crt to Node
+  CA-->>"Node (192.168.0.100)": Send ca-crt.pem and hen-crt.pem to Node
   Note right of CA: For each Node, must be executed items 2-4
 @enduml
 ```
@@ -310,23 +310,23 @@ The **[Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_L
 Before starting work the _Home Edge Network_, need to create a key infrastructure (for a certification authority and for each node separately).
 
 There are two scripts: 
- * [tools/gen_ca_cert.sh](../tools/gen_ca_cert.sh) for generation of CA Root Certificate, that consists of a private key `ca.key` and a self-signed root certificate `ca.crt`
- * [tools/gen_hen_cert.sh](../tools/gen_hen_cert.sh) for generation of Home Edge Node (HEN) Certificate, that consists of a private key `hen.key` and a signature HEN certificate: `hen.crt`
+ * [tools/gen_ca_cert.sh](../tools/gen_ca_cert.sh) for generation of CA Root Certificate, that consists of a private key `ca-key.pem` and a self-signed root certificate `ca-crt.pem`
+ * [tools/gen_hen_cert.sh](../tools/gen_hen_cert.sh) for generation of Home Edge Node (HEN) Certificate, that consists of a private key `hen-key.pem` and a signature HEN certificate: `hen-crt.pem`
  
 #### CA Root Certificate
 Generating a CA Root Certificate only needs to be done once for _Home Edge Network_ by running command:
 ```shell
 tools/gen_ca_cert.sh
 ```
-As a result, we get the private key `cert/ca.key` and self-signed root certificate `cert/ca.crt`. The certificate must be saved on all nodes in the `/var/edge-orchestration/data/cert/` folder.
+As a result, we get the private key `certs/ca-key.pem` and self-signed root certificate `certs/ca-crt.pem`. The certificate must be saved on all nodes in the `/var/edge-orchestration/certs/` folder.
 
 #### Home Edge Node (HEN) Certificate
-Generate HEN Certificate private key : hen.key
+Generate HEN Certificate private key : hen-key.pem
 
-For each node, need to create a private key `hen.key` and a certificate `hen.crt`. To do this, need to start the script and specify the node IP address. 
+For each node, need to create a private key `hen-key.pem` and a certificate `hen-crt.pem`. To do this, need to start the script and specify the node IP address. 
 ```shell
 tools/gen_hen_cert.sh 192.168.0.100
 ```
-As a result, the key and certificate will be created in the `cert/<IP>/`. They must be copied into the `/var/edge-orchestration/data/cert/` folder on a node with the specified IP address
+As a result, the key and certificate will be created in the `certs/<IP>/`. They must be copied into the `/var/edge-orchestration/certs/` folder on a node with the specified IP address
 
 ---

--- a/internal/common/fscreator/fscreator.go
+++ b/internal/common/fscreator/fscreator.go
@@ -29,8 +29,8 @@ const (
 
 var edgeDirs = []string{
 	"/apps",
+	"/certs",
 	"/data/db",
-	"/data/cert",
 	"/datastorage",
 	"/device",
 	"/log",

--- a/internal/common/mqtt/mqttconfig.go
+++ b/internal/common/mqtt/mqttconfig.go
@@ -32,8 +32,10 @@ import (
 )
 
 const (
-	edgeDir      = "/var/edge-orchestration"
-	caCertConfig = edgeDir + "/mqtt/certs/cacert.pem"
+	edgeDir = "/var/edge-orchestration"
+	caCert  = edgeDir + "/certs/ca-crt.pem"
+	henCert = edgeDir + "/certs/hen-crt.pem"
+	henKey  = edgeDir + "/certs/hen-key.pem"
 )
 
 // Client is a wrapper on top of `MQTT.Client`
@@ -124,14 +126,22 @@ func checkforConnection(brokerURL string, mqttClient *Client, mqttPort uint) int
 //NewTLSConfig creates a tls config for mqtt client
 func NewTLSConfig() (*tls.Config, error) {
 	certpool := x509.NewCertPool()
-	ca, err := ioutil.ReadFile(caCertConfig)
+	ca, err := ioutil.ReadFile(caCert)
 	if err != nil {
 		log.Warn(logPrefix, err.Error())
 		return nil, err
 	}
+
 	certpool.AppendCertsFromPEM(ca)
+
+	cert, err := tls.LoadX509KeyPair(henCert, henKey)
+	if err != nil {
+		return nil, err
+	}
 	return &tls.Config{
-		RootCAs: certpool,
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		RootCAs:      certpool,
 	}, nil
 }
 

--- a/internal/controller/discoverymgr/mnedc/connectionutil/networkconnectionutil.go
+++ b/internal/controller/discoverymgr/mnedc/connectionutil/networkconnectionutil.go
@@ -21,12 +21,20 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	"io/ioutil"
 	"net"
+
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 )
 
 type networkUtilImpl struct{}
+
+const (
+	edgeDir = "/var/edge-orchestration"
+	caCert  = edgeDir + "/certs/ca-crt.pem"
+	henCert = edgeDir + "/certs/hen-crt.pem"
+	henKey  = edgeDir + "/certs/hen-key.pem"
+)
 
 var (
 	networkUtilIns networkUtilImpl
@@ -38,7 +46,7 @@ func init() {
 }
 
 func createClientConfig() (*tls.Config, error) {
-	caCertPEM, err := ioutil.ReadFile("/var/edge-orchestration/data/cert/ca.crt")
+	caCertPEM, err := ioutil.ReadFile(caCert)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +57,7 @@ func createClientConfig() (*tls.Config, error) {
 		panic("failed to parse root certificate")
 	}
 
-	cert, err := tls.LoadX509KeyPair("/var/edge-orchestration/data/cert/hen.crt", "/var/edge-orchestration/data/cert/hen.key")
+	cert, err := tls.LoadX509KeyPair(henCert, henKey)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +73,7 @@ func createClientConfig() (*tls.Config, error) {
 }
 
 func createServerConfig() (*tls.Config, error) {
-	caCertPEM, err := ioutil.ReadFile("/var/edge-orchestration/data/cert/ca.crt")
+	caCertPEM, err := ioutil.ReadFile(caCert)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +84,7 @@ func createServerConfig() (*tls.Config, error) {
 		panic("failed to parse root certificate")
 	}
 
-	cert, err := tls.LoadX509KeyPair("/var/edge-orchestration/data/cert/hen.crt", "/var/edge-orchestration/data/cert/hen.key")
+	cert, err := tls.LoadX509KeyPair(henCert, henKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/securemgr/securemgr.go
+++ b/internal/controller/securemgr/securemgr.go
@@ -27,7 +27,7 @@ import (
 // Handle Platform Dependencies
 const (
 	logPrefix              = "[securemgr]"
-	certificateFilePath    = "/data/cert"
+	certificateFilePath    = "/certs"
 	containerWhiteListPath = "/data/cwl"
 	passPhraseJWTPath      = "/data/jwt"
 	rbacRulePath           = "/data/rbac"

--- a/internal/restinterface/resthelper/client/tlshelper/tlshelper.go
+++ b/internal/restinterface/resthelper/client/tlshelper/tlshelper.go
@@ -35,6 +35,13 @@ var (
 	wellKnownPort map[string]string
 )
 
+const (
+	edgeDir = "/var/edge-orchestration"
+	caCert  = edgeDir + "/certs/ca-crt.pem"
+	henCert = edgeDir + "/certs/hen-crt.pem"
+	henKey  = edgeDir + "/certs/hen-key.pem"
+)
+
 // TLSHelper struct
 type TLSHelper struct{}
 
@@ -47,7 +54,7 @@ func init() {
 }
 
 func createClientConfig() (*tls.Config, error) {
-	caCertPEM, err := ioutil.ReadFile("/var/edge-orchestration/data/cert/ca.crt")
+	caCertPEM, err := ioutil.ReadFile(caCert)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +65,7 @@ func createClientConfig() (*tls.Config, error) {
 		panic("failed to parse root certificate")
 	}
 
-	cert, err := tls.LoadX509KeyPair("/var/edge-orchestration/data/cert/hen.crt", "/var/edge-orchestration/data/cert/hen.key")
+	cert, err := tls.LoadX509KeyPair(henCert, henKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/restinterface/route/tlsserver/tlsserver.go
+++ b/internal/restinterface/route/tlsserver/tlsserver.go
@@ -22,8 +22,16 @@ import (
 
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	"io/ioutil"
+
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
+)
+
+const (
+	edgeDir = "/var/edge-orchestration"
+	caCert  = edgeDir + "/certs/ca-crt.pem"
+	henCert = edgeDir + "/certs/hen-crt.pem"
+	henKey  = edgeDir + "/certs/hen-key.pem"
 )
 
 var (
@@ -39,7 +47,7 @@ type TLSListenerServer interface {
 type TLSServer struct{}
 
 func createServerConfig() (*tls.Config, error) {
-	caCertPEM, err := ioutil.ReadFile("/var/edge-orchestration/data/cert/ca.crt")
+	caCertPEM, err := ioutil.ReadFile(caCert)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +58,7 @@ func createServerConfig() (*tls.Config, error) {
 		panic("failed to parse root certificate")
 	}
 
-	cert, err := tls.LoadX509KeyPair("/var/edge-orchestration/data/cert/hen.crt", "/var/edge-orchestration/data/cert/hen.key")
+	cert, err := tls.LoadX509KeyPair(henCert, henKey)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/gen_ca_cert.sh
+++ b/tools/gen_ca_cert.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-mkdir -p ./cert
+mkdir -p ./certs
 
 # CA Root Certificate
-# Generate root certificate private key: ca.key
-openssl genrsa -out ./cert/ca.key 2048
+# Generate root private key: ca-key.pem
+openssl genrsa -out ./certs/ca-key.pem 2048
 
-# Generate a self-signed root certificate: ca.crt
-openssl req -new -key ./cert/ca.key -x509 -days 3650 -out ./cert/ca.crt -subj /C=KR/ST=Seoul/O="Samsung Electronics"/CN="Home Edge CA Root"
+# Generate a self-signed root certificate: ca-crt.pem
+openssl req -new -key ./certs/ca-key.pem -x509 -days 3650 -out ./certs/ca-crt.pem -outform PEM -subj /C=KR/ST=Seoul/O="Samsung Electronics"/CN="Home Edge CA Root"

--- a/tools/gen_hen_cert.sh
+++ b/tools/gen_hen_cert.sh
@@ -12,14 +12,14 @@ then
     exit 1
 fi
 
-mkdir -p ./cert/$1
+mkdir -p ./certs/$1
 
 # Home Edge Node (HEN) Certificate
-# Generate HEN Certificate private key : hen.key
-openssl genrsa -out ./cert/$1/hen.key 2048
+# Generate HEN private key: hen-key.pem
+openssl genrsa -out ./certs/$1/hen-key.pem 2048
 
 # Generate HEN Certificate request: hen.csr
-openssl req -new -nodes -key ./cert/$1/hen.key -out ./cert/$1/hen.csr -subj /C=KR/ST=Seoul/O="Samsung Electronics"/CN="Home Edge Node Certificate"
+openssl req -new -nodes -key ./certs/$1/hen-key.pem -out ./certs/$1/hen.csr -subj /C=KR/ST=Seoul/O="Samsung Electronics"/CN="Home Edge Node Certificate"
 
-# Signature HEN Certificate: hen.crt
-openssl x509 -req -extfile <(printf "subjectAltName=IP:$1") -days 365 -in ./cert/$1/hen.csr -CA ./cert/ca.crt -CAkey ./cert/ca.key -CAcreateserial -out ./cert/$1/hen.crt
+# Signature HEN Certificate: hen-crt.pem
+openssl x509 -req -extfile <(printf "subjectAltName=IP:$1") -days 365 -in ./certs/$1/hen.csr -CA ./certs/ca-crt.pem -CAkey ./certs/ca-key.pem -CAcreateserial -out ./certs/$1/hen-crt.pem -outform PEM


### PR DESCRIPTION
…with TLS certificates)

Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description
Code update to use the broker in secure mode (mutual authentication with certificates). The use of TLS certificates will provide a simpler and more secure connection with the broker. In addition, the deployment of key infrastructure is necessary for other components. 

Fixes #471 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code cleanup/refactoring
- [x] Documentation update

# How Has This Been Tested?
Description is in the updated `docs/cloudsync_mqtt.md`

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v17.6 and Go v1.16
* Edge Orchestration Release: v1.1.9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
