### PR TITLE
Add GetServerIP and GetMetadataServerIP test code

### DIFF
--- a/internal/controller/storagemgr/config/yaml_test.go
+++ b/internal/controller/storagemgr/config/yaml_test.go
@@ -104,10 +104,8 @@ var (
 func TestYaml(t *testing.T) {
 	SetYaml(testName, testManufacture, testModel, testDescription, testLabel, testResource)
 
-	b, err := YamlMarshal()
+	_, err := YamlMarshal()
 	if err != nil {
 		t.Fatal("Unexpected Error")
 	}
-
-	log.Println(string(b))
 }


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

## Type of change
- [x] Code cleanup/refactoring

# How Has This Been Tested?
```
make test-go internal/controller/storagemgr/config
```

## RESULT
```
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/toml.go      GetServerIP             100.00% (4/4)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/toml.go      GetMetadataServerIP     100.00% (4/4)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/toml.go      SetWritable             100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/toml.go      SetDevice               100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/toml.go      SetDeviceList           100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/toml.go      SetClients              100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/toml.go      TomlMarshal             100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/toml.go      SetService              100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/toml.go      SetRegistry             100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/yaml.go      SetYaml                 100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config/yaml.go      YamlMarshal             100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config              -------------------     100.00% (17/17)

Total Coverage: 100.00% (17/17)

```

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 and Go v1.17
* Edge Orchestration Release: v1.1.9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
