### PR TITLE
[CloudSync] Save the Subscribed data & Adding API to get data

### DIFF
--- a/docs/cloudsync_mqtt.md
+++ b/docs/cloudsync_mqtt.md
@@ -266,7 +266,8 @@ The edge orchestration is build and run using following command with option CLOU
 ```
 docker run -it -d --privileged --network="host" --name edge-orchestration -e CLOUD_SYNC=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
 ```
-From the another terminal/post make a curl command as follows to publish data using home edge to the broker running on AWS endpoint
+From another terminal/post, it is recommended to make a curl command as follows to publish data using home edge to the broker running on AWS endpoint<br>
+***Please Note :***  Donot use '/' in topic name field.
 
 ```
 curl --location --request POST 'http://<ip where edgeorchestration is running>:56001/api/v1/orchestration/cloudsyncmgr/publish' \
@@ -274,7 +275,23 @@ curl --location --request POST 'http://<ip where edgeorchestration is running>:5
 --data-raw '{
     "appid": "<appid of service app>",
     "payload": "{Another data from TV1 and testdata}",
-    "topic": "home1/livingroom",
+    "topic": "home1-livingroom",
     "url" : "<AWS public IP>"
 }'
+```
+From another terminal/post,it is recommended to make a curl post command as follows to subscribe to topic using home edge to the broker running on AWS endpoint
+
+```
+curl --location --request POST 'http://<ip where edge-orchestration is running>:56001/api/v1/orchestration/cloudsyncmgr/subscribe' \
+--header 'Content-Type: text/plain' \
+--data-raw '{
+    "appid": "<appid of the service app>",
+    "topic": "kitchen1",
+    "url" : "<AWS public IP>"
+}'
+```
+From another terminal/post,it is recommended make a curl get command as follows to get the data received on subscribed topic by passing the clientid(appid) and topic in the request header
+
+```
+curl --location --request GET 'http://<ip where edge-orchestration is running>:56001/api/v1/orchestration/cloudsyncmgr/getsubscribedata/<topicname>/<appid>'
 ```

--- a/internal/common/mqtt/mqttconfig.go
+++ b/internal/common/mqtt/mqttconfig.go
@@ -49,14 +49,10 @@ type Client struct {
 	protocol string
 }
 
-//Message is used to wrap the app id and payload into one and publish to broker
-type Message struct {
-	AppID   string
-	Payload string
-}
-
 var (
-	clientData map[string]*Client
+	publishData     map[string]*Client
+	subscribeData   map[string]string    //topic-->published data
+	subscribeClient map[string][]*Client //topic-->multiple clients
 )
 
 // Config represents an attribute config setter for the `Client`.
@@ -83,9 +79,11 @@ func SetPort(port uint) Config {
 	}
 }
 
-// InitClientData creates an initialized hashmap
-func InitClientData() {
-	clientData = make(map[string]*Client)
+// InitMQTTData creates an initialized hashmap
+func InitMQTTData() {
+	publishData = make(map[string]*Client)
+	subscribeClient = make(map[string][]*Client)
+	subscribeData = make(map[string]string)
 }
 
 func (c *Client) setProtocol() {
@@ -98,13 +96,34 @@ func (c *Client) setProtocol() {
 
 // CheckifClientExist used to check if the client conn object exist
 func CheckifClientExist(clientID string) *Client {
-	client := clientData[clientID]
+	client := publishData[clientID]
 	return client
 }
 
-// addClientData is used to add the client object based on client id
-func addClientData(client *Client, clientID string) {
-	clientData[clientID] = client
+// addpublishData is used to add the client object based on client id
+func addPublishData(client *Client, clientID string) {
+	publishData[clientID] = client
+}
+
+// addSubscribeClient is used to add the client info for a topic
+func addSubscribeClient(client *Client, topic string) {
+	subscribeClient[topic] = append(subscribeClient[topic], client)
+}
+
+func addSubscribedData(topic string, message string) {
+	subscribeData[topic] = message
+}
+
+//GetSubscribedData is used to get the data for topic subscribed
+func GetSubscribedData(topic string, clientID string) string {
+	list := subscribeClient[topic]
+	for _, client := range list {
+		if client.ID == clientID {
+			return subscribeData[topic]
+		}
+	}
+	return "Client is not subscribed to the topic " + topic
+
 }
 
 //SetBrokerURL returns the broker url for connection

--- a/internal/common/mqtt/mqttconnection_test.go
+++ b/internal/common/mqtt/mqttconnection_test.go
@@ -28,16 +28,16 @@ var port uint = 1883
 const InvalidHost = "invalid"
 
 func initializeTest(Host string, clientID string) {
-	InitClientData()
+	InitMQTTData()
 	StartMQTTClient(Host, clientID, port)
 }
 
 func TestStartMQTTClient(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		initializeTest(Host, "testClient")
-		client := clientData["testClient"]
+		client := publishData["testClient"]
 		if client != nil {
-			message := Message{"appid", "Test data for testing"}
+			message := "Test data for testing"
 			client.Publish(message, "home/livingroom")
 		}
 		err := StartMQTTClient(Host, "testClient", port)
@@ -47,7 +47,7 @@ func TestStartMQTTClient(t *testing.T) {
 		}
 	})
 	t.Run("Fail", func(t *testing.T) {
-		InitClientData()
+		InitMQTTData()
 		err := StartMQTTClient(InvalidHost, "testClientFailure", port)
 		expected := "dial tcp: lookup invalid: Temporary failure in name resolution"
 		if !strings.Contains(err, expected) {
@@ -59,7 +59,7 @@ func TestStartMQTTClient(t *testing.T) {
 func TestCheckforConnection(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		initializeTest(Host, "CheckConnection")
-		client := clientData["CheckConnection"]
+		client := publishData["CheckConnection"]
 		isConnected := checkforConnection(Host, client, port)
 		expected := 0
 		if isConnected != expected {
@@ -71,7 +71,7 @@ func TestCheckforConnection(t *testing.T) {
 
 func TestIsClientConnected(t *testing.T) {
 	t.Run("Fail", func(t *testing.T) {
-		client := clientData["CheckConnection"]
+		client := publishData["CheckConnection"]
 		connStatus := client.IsConnected()
 		expected := false
 		if connStatus != expected {

--- a/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
+++ b/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
@@ -22,7 +22,6 @@ package mocks
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	mqttmgr "github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	reflect "reflect"
 )
 
@@ -62,7 +61,7 @@ func (_mr *MockCloudSyncMockRecorder) InitiateCloudSync(arg0 interface{}) *gomoc
 }
 
 // RequestPublish mocks base method
-func (_m *MockCloudSync) RequestPublish(host string, clientID string, message mqttmgr.Message, topic string) string {
+func (_m *MockCloudSync) RequestPublish(host string, clientID string, message string, topic string) string {
 	ret := _m.ctrl.Call(_m, "RequestPublish", host)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -83,4 +82,16 @@ func (_m *MockCloudSync) RequestSubscribe(host string, clientID string, topic st
 // RequestSubscribe indicates an expected call of RequestSubscribe
 func (_mr *MockCloudSyncMockRecorder) RequestSubscribe(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "RequestSubscribe", reflect.TypeOf((*MockCloudSync)(nil).RequestSubscribe), arg0)
+}
+
+// RequestSubscribedData mocks base method
+func (_m *MockCloudSync) RequestSubscribedData(clientID string, topic string) string {
+	ret := _m.ctrl.Call(_m, "RequestSubscribedData", clientID)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RequestSubscribedData indicates an expected call of RequestSubscribedData
+func (_mr *MockCloudSyncMockRecorder) RequestSubscribedData(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "RequestSubscribedData", reflect.TypeOf((*MockCloudSync)(nil).RequestSubscribedData), arg0)
 }

--- a/internal/orchestrationapi/mocks/mock_orchestration.go
+++ b/internal/orchestrationapi/mocks/mock_orchestration.go
@@ -22,12 +22,10 @@
 package mocks
 
 import (
-	reflect "reflect"
-
-	"github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	configuremgrtypes "github.com/lf-edge/edge-home-orchestration-go/internal/common/types/configuremgrtypes"
 	verifier "github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	orchestrationapi "github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
+	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -105,7 +103,7 @@ func (mr *MockOrcheExternalAPIMockRecorder) RequestService(arg0 interface{}) *go
 }
 
 // RequestCloudSyncPublish mocks base method
-func (m *MockOrcheExternalAPI) RequestCloudSyncPublish(arg0 string, arg1 string, arg2 mqtt.Message, arg3 string) string {
+func (m *MockOrcheExternalAPI) RequestCloudSyncPublish(arg0 string, arg1 string, arg2 string, arg3 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestCloudSyncPublish", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
@@ -118,7 +116,7 @@ func (mr *MockOrcheExternalAPIMockRecorder) RequestCloudSyncPublish(arg0, arg1 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestCloudSyncPublish", reflect.TypeOf((*MockOrcheExternalAPI)(nil).RequestCloudSyncPublish), arg0, arg1, arg2, arg3)
 }
 
-// RequestCloudSync mocks base method.
+// RequestCloudSyncSubscribe mocks base method.
 func (m *MockOrcheExternalAPI) RequestCloudSyncSubscribe(arg0 string, arg1 string, arg2 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestCloudSyncSubscribe", arg0, arg1, arg2)
@@ -126,10 +124,24 @@ func (m *MockOrcheExternalAPI) RequestCloudSyncSubscribe(arg0 string, arg1 strin
 	return ret0
 }
 
-// RequestCloudSync indicates an expected call of RequestService.
+// RequestCloudSyncSubscribe indicates an expected call of RequestCloudSyncSubscribe.
 func (mr *MockOrcheExternalAPIMockRecorder) RequestCloudSyncSubscribe(arg0, arg1 interface{}, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestCloudSyncSubscribe", reflect.TypeOf((*MockOrcheExternalAPI)(nil).RequestCloudSyncSubscribe), arg0, arg1, arg2)
+}
+
+// RequestSubscribedData mocks base method.
+func (m *MockOrcheExternalAPI) RequestSubscribedData(arg0 string, arg1 string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequestSubscribedData", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RequestSubscribedData indicates an expected call of RequestSubscribedData.
+func (mr *MockOrcheExternalAPIMockRecorder) RequestSubscribedData(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSubscribedData", reflect.TypeOf((*MockOrcheExternalAPI)(nil).RequestSubscribedData), arg0, arg1)
 }
 
 // RequestVerifierConf mocks base method.

--- a/internal/orchestrationapi/orchestration.go
+++ b/internal/orchestrationapi/orchestration.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/networkhelper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/requestervalidator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/resourceutil"
@@ -53,8 +52,9 @@ type Orche interface {
 type OrcheExternalAPI interface {
 	RequestService(serviceInfo ReqeustService) ResponseService
 	verifier.Conf
-	RequestCloudSyncPublish(host string, clientID string, message mqtt.Message, topic string) string
+	RequestCloudSyncPublish(host string, clientID string, message string, topic string) string
 	RequestCloudSyncSubscribe(host string, clientID string, topic string) string
+	RequestSubscribedData(clientID string, topic string) string
 }
 
 // OrcheInternalAPI is the interface implemented by internal REST API

--- a/internal/orchestrationapi/orchestrationapi.go
+++ b/internal/orchestrationapi/orchestrationapi.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/networkhelper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/requestervalidator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/cloudsyncmgr"
@@ -112,7 +111,8 @@ const (
 	//InternalServerError is key for internal server error
 	InternalServerError = "INTERNAL_SERVER_ERROR"
 	// NotAllowedCommand is key for not allowed command
-	NotAllowedCommand = "NOT_ALLOWED_COMMAND"
+	NotAllowedCommand  = "NOT_ALLOWED_COMMAND"
+	cloudsyncLogPrefix = "[RequestCloudSync]"
 )
 
 var (
@@ -131,15 +131,21 @@ func init() {
 }
 
 //RequestCloudSyncPublish handles the request for cloud syncing
-func (orcheEngine *orcheImpl) RequestCloudSyncPublish(host string, clientID string, message mqtt.Message, topic string) string {
-	log.Info("[RequestCloudSync]", "Requesting cloud sync publish")
+func (orcheEngine *orcheImpl) RequestCloudSyncPublish(host string, clientID string, message string, topic string) string {
+	log.Info(cloudsyncLogPrefix, "Requesting cloud sync publish")
 	return orcheEngine.cloudsyncIns.RequestPublish(host, clientID, message, topic)
 }
 
 //RequestCloudSyncSubscribe handles the request for cloud subscribing
 func (orcheEngine *orcheImpl) RequestCloudSyncSubscribe(host string, clientID string, topic string) string {
-	log.Info("[RequestCloudSync]", "Requesting cloud sync subscribe")
+	log.Info(cloudsyncLogPrefix, "Requesting cloud sync subscribe")
 	return orcheEngine.cloudsyncIns.RequestSubscribe(host, clientID, topic)
+}
+
+//RequestSubscribedData request for the data on subscribed topic
+func (orcheEngine *orcheImpl) RequestSubscribedData(clientID string, topic string) string {
+	log.Info(cloudsyncLogPrefix, "Requesting SubscribedData")
+	return orcheEngine.cloudsyncIns.RequestSubscribedData(clientID, topic)
 }
 
 // RequestService handles service request (ex. offloading) from service application


### PR DESCRIPTION
# Description
After Subscribing to the topic, Code has been added to store the data published on subscribed topic and to provide the API to retrieve the stored data
UsageExample

Getting the data subscribed to a topic

curl --location --request GET 'http://{EdgeOrchestration IP}:56001/api/v1/orchestration/cloudsyncmgr/getsubscribedata/<topicname>/<appid>'

Fixes # (#382)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
1.MQTT mosquitto broker is configured to be running in the AWS endpoint.
2. The edge orchestration is build and run using following command with option CLOUD_SYNC set to true
```
docker run -it -d --privileged --network="host" --name edge-orchestration -e CLOUD_SYNC=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
```
3.Call the subscribe API using curl request

```
curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/subscribe' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "appid": "app2",
    "topic": "kitchen",
    "url" : "ec2-52-6-247-126.compute-1.amazonaws.com"
}'
```
4. Call publish on the same topic using curl request
```
curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/publish' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "appid": "app4",
    "topic": "kitchen",
    "url" : "ec2-52-6-247-126.compute-1.amazonaws.com",
    "payload" : "Test message for kitchen1..."
}'
```
5. Call the fetch data API using curl request for the topic kitchen and appid app2
```
curl --location --request GET 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/getsubscribedata/kitchen/app2'
```
You should get the message sent by app4 in above example. So the output received is
```
{"Message":"Test message for kitchen1..."}
```
6. Now Call the curl command for topic bedroom
```
curl --location --request GET 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/getsubscribedata/bedroom/app2'
```
The response received is 
```
{"Message":"Client is not subscribed to the topic bedroom"}
```

**Test Configuration**:
* OS type & version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (v1.1.0)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
