### PR TITLE
[Javaapi] Adding code to set the storage in Javaapi for building Aar

### DIFF
--- a/cmd/edge-orchestration/javaapi/javaapi.go
+++ b/cmd/edge-orchestration/javaapi/javaapi.go
@@ -36,6 +36,7 @@ import (
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/androidexecutor"
+	storagemgr "github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/dummy"
@@ -191,6 +192,7 @@ func OrchestrationInit(executeCallback ExecuteCallback, edgeDir string, isSecure
 
 	builder := orchestrationapi.OrchestrationBuilder{}
 	builder.SetWatcher(configuremgr.GetInstance(configPath, executionType))
+	builder.SetStorage(storagemgr.GetInstance())
 	builder.SetDiscovery(discoverymgr.GetInstance())
 	builder.SetVerifierConf(verifier.GetInstance())
 	builder.SetScoring(scoringmgr.GetInstance())


### PR DESCRIPTION
# Description
The builder registers the interfaces required for initializing the Orchestration. The Javaapi file is used to build the aar to be used as library in android project. The Orchestration Init function of Javaapi was missing the code to set the storage instance. Hence the appropriate code is added for the same.

## Type of change
 Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Storage instance has been set Javaapi file and aar is generated using make build-object-java command.
2. The aar is imported and Orchestration Init is called.
3. It is observed that the log shows that the Builder.build() is completed.



**Test Configuration**:
* OS type & version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (v1.1.0)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
