### PR TITLE
[CloudSync] Update CloudSync code as per new Design

### DIFF
--- a/internal/common/mqtt/mqttconnection_test.go
+++ b/internal/common/mqtt/mqttconnection_test.go
@@ -27,15 +27,15 @@ var port uint = 1883
 
 const InvalidHost = "invalid"
 
-func initializeTest(Host string, clientID string) {
+func initializeTest(Host string, appID string) {
 	InitMQTTData()
-	StartMQTTClient(Host, clientID, port)
+	StartMQTTClient(Host, appID, port)
 }
 
 func TestStartMQTTClient(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		initializeTest(Host, "testClient")
-		client := publishData["testClient"]
+		client := MQTTClient["testClient"]
 		if client != nil {
 			message := "Test data for testing"
 			client.Publish(message, "home/livingroom")
@@ -59,7 +59,7 @@ func TestStartMQTTClient(t *testing.T) {
 func TestCheckforConnection(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		initializeTest(Host, "CheckConnection")
-		client := publishData["CheckConnection"]
+		client := MQTTClient["CheckConnection"]
 		isConnected := checkforConnection(Host, client, port)
 		expected := 0
 		if isConnected != expected {
@@ -71,19 +71,19 @@ func TestCheckforConnection(t *testing.T) {
 
 func TestIsClientConnected(t *testing.T) {
 	t.Run("Fail", func(t *testing.T) {
-		client := publishData["CheckConnection"]
+		client := MQTTClient["CheckConnection"]
 		connStatus := client.IsConnected()
 		expected := false
 		if connStatus != expected {
 			t.Errorf("Expected %v but received %v", expected, connStatus)
 		}
-
-		client.Client = nil
-		connStatus = client.IsConnected()
-		if connStatus != expected {
-			t.Errorf("Expected %v but received %v", expected, connStatus)
+		if client != nil {
+			client.Client = nil
+			connStatus = client.IsConnected()
+			if connStatus != expected {
+				t.Errorf("Expected %v but received %v", expected, connStatus)
+			}
 		}
-
 		client = nil
 		connStatus = client.IsConnected()
 		if connStatus != expected {

--- a/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
+++ b/internal/controller/cloudsyncmgr/mocks/mocks_cloudsync.go
@@ -61,7 +61,7 @@ func (_mr *MockCloudSyncMockRecorder) InitiateCloudSync(arg0 interface{}) *gomoc
 }
 
 // RequestPublish mocks base method
-func (_m *MockCloudSync) RequestPublish(host string, clientID string, message string, topic string) string {
+func (_m *MockCloudSync) RequestPublish(host string, appID string, message string, topic string) string {
 	ret := _m.ctrl.Call(_m, "RequestPublish", host)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -73,7 +73,7 @@ func (_mr *MockCloudSyncMockRecorder) RequestPublish(arg0 interface{}) *gomock.C
 }
 
 // RequestSubscribe mocks base method
-func (_m *MockCloudSync) RequestSubscribe(host string, clientID string, topic string) string {
+func (_m *MockCloudSync) RequestSubscribe(host string, appID string, topic string) string {
 	ret := _m.ctrl.Call(_m, "RequestSubscribe", host)
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -85,8 +85,8 @@ func (_mr *MockCloudSyncMockRecorder) RequestSubscribe(arg0 interface{}) *gomock
 }
 
 // RequestSubscribedData mocks base method
-func (_m *MockCloudSync) RequestSubscribedData(clientID string, topic string) string {
-	ret := _m.ctrl.Call(_m, "RequestSubscribedData", clientID)
+func (_m *MockCloudSync) RequestSubscribedData(appID string, topic string, host string) string {
+	ret := _m.ctrl.Call(_m, "RequestSubscribedData", appID)
 	ret0, _ := ret[0].(string)
 	return ret0
 }

--- a/internal/orchestrationapi/mocks/mock_orchestration.go
+++ b/internal/orchestrationapi/mocks/mock_orchestration.go
@@ -131,17 +131,17 @@ func (mr *MockOrcheExternalAPIMockRecorder) RequestCloudSyncSubscribe(arg0, arg1
 }
 
 // RequestSubscribedData mocks base method.
-func (m *MockOrcheExternalAPI) RequestSubscribedData(arg0 string, arg1 string) string {
+func (m *MockOrcheExternalAPI) RequestSubscribedData(arg0 string, arg1 string, arg2 string) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RequestSubscribedData", arg0, arg1)
+	ret := m.ctrl.Call(m, "RequestSubscribedData", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // RequestSubscribedData indicates an expected call of RequestSubscribedData.
-func (mr *MockOrcheExternalAPIMockRecorder) RequestSubscribedData(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockOrcheExternalAPIMockRecorder) RequestSubscribedData(arg0, arg1 interface{}, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSubscribedData", reflect.TypeOf((*MockOrcheExternalAPI)(nil).RequestSubscribedData), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSubscribedData", reflect.TypeOf((*MockOrcheExternalAPI)(nil).RequestSubscribedData), arg0, arg1, arg2)
 }
 
 // RequestVerifierConf mocks base method.

--- a/internal/orchestrationapi/orchestration.go
+++ b/internal/orchestrationapi/orchestration.go
@@ -53,8 +53,8 @@ type OrcheExternalAPI interface {
 	RequestService(serviceInfo ReqeustService) ResponseService
 	verifier.Conf
 	RequestCloudSyncPublish(host string, clientID string, message string, topic string) string
-	RequestCloudSyncSubscribe(host string, clientID string, topic string) string
-	RequestSubscribedData(clientID string, topic string) string
+	RequestCloudSyncSubscribe(host string, appID string, topic string) string
+	RequestSubscribedData(clientID string, topic string, host string) string
 }
 
 // OrcheInternalAPI is the interface implemented by internal REST API

--- a/internal/orchestrationapi/orchestrationapi.go
+++ b/internal/orchestrationapi/orchestrationapi.go
@@ -131,21 +131,21 @@ func init() {
 }
 
 //RequestCloudSyncPublish handles the request for cloud syncing
-func (orcheEngine *orcheImpl) RequestCloudSyncPublish(host string, clientID string, message string, topic string) string {
+func (orcheEngine *orcheImpl) RequestCloudSyncPublish(host string, appID string, message string, topic string) string {
 	log.Info(cloudsyncLogPrefix, "Requesting cloud sync publish")
-	return orcheEngine.cloudsyncIns.RequestPublish(host, clientID, message, topic)
+	return orcheEngine.cloudsyncIns.RequestPublish(host, appID, message, topic)
 }
 
 //RequestCloudSyncSubscribe handles the request for cloud subscribing
-func (orcheEngine *orcheImpl) RequestCloudSyncSubscribe(host string, clientID string, topic string) string {
+func (orcheEngine *orcheImpl) RequestCloudSyncSubscribe(host string, appID string, topic string) string {
 	log.Info(cloudsyncLogPrefix, "Requesting cloud sync subscribe")
-	return orcheEngine.cloudsyncIns.RequestSubscribe(host, clientID, topic)
+	return orcheEngine.cloudsyncIns.RequestSubscribe(host, appID, topic)
 }
 
 //RequestSubscribedData request for the data on subscribed topic
-func (orcheEngine *orcheImpl) RequestSubscribedData(clientID string, topic string) string {
+func (orcheEngine *orcheImpl) RequestSubscribedData(appID string, topic string, host string) string {
 	log.Info(cloudsyncLogPrefix, "Requesting SubscribedData")
-	return orcheEngine.cloudsyncIns.RequestSubscribedData(clientID, topic)
+	return orcheEngine.cloudsyncIns.RequestSubscribedData(appID, topic, host)
 }
 
 // RequestService handles service request (ex. offloading) from service application

--- a/internal/restinterface/externalhandler/externalhandler.go
+++ b/internal/restinterface/externalhandler/externalhandler.go
@@ -47,6 +47,7 @@ const (
 	invalidInputParam = "Invalid input parameter"
 	topic             = "topic"
 	clientID          = "clientID"
+	host              = "host"
 )
 
 // Handler struct
@@ -99,7 +100,7 @@ func init() {
 		restinterface.Route{
 			Name:        "APIV1RequestCloudSyncmgrGetSubscribedData",
 			Method:      strings.ToUpper("Get"),
-			Pattern:     "/api/v1/orchestration/cloudsyncmgr/getsubscribedata/{" + topic + "}/{" + clientID + "}",
+			Pattern:     "/api/v1/orchestration/cloudsyncmgr/getsubscribedata/{" + host + "}/{" + topic + "}/{" + clientID + "}",
 			HandlerFunc: handler.APIV1RequestCloudSyncmgrGetSubscribedData,
 		},
 	}
@@ -585,9 +586,11 @@ func (h *Handler) APIV1RequestCloudSyncmgrGetSubscribedData(w http.ResponseWrite
 	}
 
 	vars := mux.Vars(r)
-	clientID := vars[clientID]
+	appID := vars[clientID]
 	topic := vars[topic]
-	resp := h.api.RequestSubscribedData(clientID, topic)
+	host := vars[host]
+
+	resp := h.api.RequestSubscribedData(appID, topic, host)
 	respJSONMsg := make(map[string]interface{})
 	respJSONMsg["Message"] = resp
 	respEncryptBytes, err := h.Key.EncryptJSONToByte(respJSONMsg)


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description
The cloudsync Code is modified as per the new design. In this PR, URLData, SubscriptionInfo, MQTTClient have been updated as per the new design

Fixes # (#535)

## Type of change
- [X] Code cleanup/refactoring

# How Has This Been Tested?
1.MQTT mosquitto broker is configured to be running in the AWS endpoint.
2. The edge orchestration is build and run using following command with option CLOUD_SYNC set to true
```
docker run -it -d --privileged --network="host" --name edge-orchestration -e CLOUD_SYNC=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
be6431aa1e87ea03f3045826aaae13638f4e97a4fa51e9fd47586501e3cf7a1e
```
3. Call subscribe api for topic Design 
```
curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/subscribe' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "appid": "com.samsung.app1",
    "topic": "Design",
    "url" : "ec2-3-86-91-72.compute-1.amazonaws.com"
}'
```
The output obtained is
```
{"Message":"Successfully subscribed to the topic Design"}
```
4. Call the Publish API 
```
curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/publish' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "appid": "com.samsung.app2",
    "topic": "Design",
    "url" : "ec2-3-86-91-72.compute-1.amazonaws.com",
    "payload" : "Test message for testing"
}'
```
The output obtained is
```
{"Message":"Data published successfully to Cloudtcp://ec2-3-86-91-72.compute1.amazonaws.com:1883", "RemoteTargetInfo":"","ServiceName":""}
```
5. Call the getsubscribeddata API using curl
```
curl --location --request GET 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/getsubscribedata/ec2-3-86-91-72.compute-1.amazonaws.com/Design/com.samsung.app1'
```
The output obtained is
```
{"Message":"Test message for testing"}
```
*Test Configuration**:
* OS type & version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (v1.1.1)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes