### PR TITLE
[CloudSync]Updated the code as per new Design

### DIFF
--- a/internal/common/mqtt/mqttconfig.go
+++ b/internal/common/mqtt/mqttconfig.go
@@ -58,8 +58,8 @@ type Key struct {
 }
 
 var (
-	subscribeData    map[string]string //topic-->published data  (//TODO in next PR)
-	subscriptionInfo map[Key][]string  //to store the appids mapped to {topic,url}
+	publishData      map[Key]string   //topic-->published data
+	subscriptionInfo map[Key][]string //to store the appids mapped to {topic,url}
 	//URLData stores the urls mapped to app id
 	URLData map[string][]string //to store the appids maped to urls
 	//MQTTClient stores the Client object mapped to urls
@@ -94,7 +94,7 @@ func SetPort(port uint) Config {
 // InitMQTTData creates an initialized hashmap
 func InitMQTTData() {
 	subscriptionInfo = make(map[Key][]string)
-	subscribeData = make(map[string]string)
+	publishData = make(map[Key]string)
 	URLData = make(map[string][]string)
 	MQTTClient = make(map[string]*Client)
 	dbIns := dbhelper.GetInstance()
@@ -125,16 +125,16 @@ func addSubscribeClient(appID string, topic string, url string) {
 	log.Info(logPrefix, subscriptionInfo[Key{topic, url}])
 }
 
-func addSubscribedData(topic string, message string) {
-	subscribeData[topic] = message
+func addPublishedData(topic string, host string, message string) {
+	publishData[Key{topic, host}] = message
 }
 
-//GetSubscribedData is used to get the data for topic subscribed
-func GetSubscribedData(topic string, clientID string, host string) string {
+//GetPublishedData is used to get the data for topic subscribed
+func GetPublishedData(topic string, clientID string, host string) string {
 	list := subscriptionInfo[Key{topic, host}]
 	for _, ID := range list {
 		if ID == clientID {
-			return subscribeData[topic]
+			return publishData[Key{topic, host}]
 		}
 	}
 	return "Client is not subscribed to the topic " + topic

--- a/internal/common/mqtt/mqttconnection.go
+++ b/internal/common/mqtt/mqttconnection.go
@@ -87,8 +87,8 @@ func StartMQTTClient(brokerURL string, appID string, mqttPort uint) string {
 	if mqttClient != nil {
 		log.Info(logPrefix, "Client is already connected")
 		//add it to URL Data if not present
-		clientList := URLData[brokerURL]
-		for _, id := range clientList {
+		appList := URLData[brokerURL]
+		for _, id := range appList {
 			if id == appID {
 				return ""
 			}
@@ -143,7 +143,9 @@ func (client *Client) Publish(message string, topic string) error {
 var messageHandler MQTT.MessageHandler = func(client MQTT.Client, msg MQTT.Message) {
 
 	log.Info(logPrefix, "Topic ", msg.Topic(), " registered.. ", string(msg.Payload()), " is the payload")
-	addSubscribedData(msg.Topic(), string(msg.Payload()))
+	options := client.OptionsReader()
+	path := options.Servers()
+	addPublishedData(msg.Topic(), path[0].Hostname(), string(msg.Payload()))
 }
 
 //Subscribe is used to subscribe to a topic

--- a/internal/controller/cloudsyncmgr/cloudsync.go
+++ b/internal/controller/cloudsyncmgr/cloudsync.go
@@ -161,7 +161,7 @@ func (c *CloudSyncImpl) RequestSubscribe(host string, appID string, topic string
 	return resp
 }
 
-// RequestSubscribedData is  to get the subscribed data
+// RequestSubscribedData is  to get the subscribed data for {topic,url}
 func (c *CloudSyncImpl) RequestSubscribedData(appID string, topic string, host string) string {
 	log.Info(logPrefix, "Requesting the data for ", logmgr.SanitizeUserInput(topic)) // lgtm [go/log-injection]
 	resp := ""
@@ -172,6 +172,6 @@ func (c *CloudSyncImpl) RequestSubscribedData(appID string, topic string, host s
 	if len(topic) == 0 {
 		return "No topic defined"
 	}
-	resp = mqttmgr.GetSubscribedData(topic, appID, host)
+	resp = mqttmgr.GetPublishedData(topic, appID, host)
 	return resp
 }

--- a/internal/restinterface/externalhandler/externalhandler.go
+++ b/internal/restinterface/externalhandler/externalhandler.go
@@ -46,7 +46,7 @@ const (
 	cannotEncryption  = "cannot encryption"
 	invalidInputParam = "Invalid input parameter"
 	topic             = "topic"
-	clientID          = "clientID"
+	appID             = "appID"
 	host              = "host"
 )
 
@@ -100,7 +100,7 @@ func init() {
 		restinterface.Route{
 			Name:        "APIV1RequestCloudSyncmgrGetSubscribedData",
 			Method:      strings.ToUpper("Get"),
-			Pattern:     "/api/v1/orchestration/cloudsyncmgr/getsubscribedata/{" + host + "}/{" + topic + "}/{" + clientID + "}",
+			Pattern:     "/api/v1/orchestration/cloudsyncmgr/getsubscribedata/{" + host + "}/{" + topic + "}/{" + appID + "}",
 			HandlerFunc: handler.APIV1RequestCloudSyncmgrGetSubscribedData,
 		},
 	}
@@ -586,7 +586,7 @@ func (h *Handler) APIV1RequestCloudSyncmgrGetSubscribedData(w http.ResponseWrite
 	}
 
 	vars := mux.Vars(r)
-	appID := vars[clientID]
+	appID := vars[appID]
 	topic := vars[topic]
 	host := vars[host]
 


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description

Updated the code as per new Design

Fixes # (#544 )

## Type of change
- [X] Code cleanup/refactoring

# How Has This Been Tested?
1.MQTT mosquitto broker is configured to be running in the AWS endpoint.
2. The edge orchestration is build and run using following command with option CLOUD_SYNC set to true
```
docker run -it -d --privileged --network="host" --name edge-orchestration -e CLOUD_SYNC=true -v /var/edge-orchestration/:/var/edge-orchestration/:rw -v /var/run/docker.sock:/var/run/docker.sock:rw -v /proc/:/process/:ro  lfedge/edge-home-orchestration-go:latest
be6431aa1e87ea03f3045826aaae13638f4e97a4fa51e9fd47586501e3cf7a1e
```
3. Call subscribe api for topic DesignII 
```
curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/subscribe' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "appid": "app81",
    "topic": "DesignII",
    "url" : "ec2-44-201-220-95.compute-1.amazonaws.com"
}'
{"Message":"Successfully subscribed to the topic DesignII"}
```
The logs obtained are 
```
INFO[2022-04-27T10:15:21Z]externalhandler.go:481 APIV1RequestCloudSyncmgrSubscribe [RestExternalInterface] APIV1RequestCloudSyncmgrSubscribe 
INFO[2022-04-27T10:15:21Z]orchestrationapi.go:141 RequestCloudSyncSubscribe [RequestCloudSync]Requesting cloud sync subscribe 
INFO[2022-04-27T10:15:21Z]cloudsync.go:128 RequestSubscribe [cloudsyncmgr] Subscribing the data to ec2-44-201-220-95.compute-1.amazonaws.com 
INFO[2022-04-27T10:15:21Z]mqttconnection.go:84 StartMQTTClient [MQTTConnectionMgr] Starting the MQTT Client 
INFO[2022-04-27T10:15:21Z]mqttconnection.go:53 onConnect Running MQTT.OnConnectHandler                
WARN[2022-04-27T10:15:21Z]mqttconnection.go:60 onConnectionLost [MQTTConnectionMgr] Connection to the client is disconnected 
INFO[2022-04-27T10:15:21Z]mqttconnection.go:53 onConnect Running MQTT.OnConnectHandler                
INFO[2022-04-27T10:15:21Z]mqttconnection.go:112 StartMQTTClient [MQTTConnectionMgr] The broker istcp://ec2-44-201-220-95.compute-1.amazonaws.com:1883 
INFO[2022-04-27T10:15:21Z]mqttconnection.go:41 Connect [MQTTConnectionMgr] MQTT Connected           
INFO[2022-04-27T10:15:21Z]mqttconnection.go:153 Subscribe [MQTTConnectionMgr] Subscribing to DesignII  
INFO[2022-04-27T10:15:23Z]mqttconfig.go:125 addSubscribeClient [MQTTConnectionMgr] [app81]                  
INFO[2022-04-27T10:15:23Z]route.go:130 func1 From [192.168.1.107:52716] POST /api/v1/orchestration/cloudsyncmgr/subscribe APIV1RequestCloudSyncmgrSubscribe 1.952837049s
```
4. Call publish for the same DesignII topic
```
curl --location --request POST 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/publish' \
--header 'Content-Type: text/plain' \
--data-raw '{
    "appid": "app11",
    "topic": "DesignII",
    "url" : "ec2-44-201-220-95.compute-1.amazonaws.com",
    "payload" : "Test message for testing Design Part 2 Tetsing agaain"
}'
{"Message":"Data published successfully to Cloudtcp://ec2-44-201-220-95.compute-1.amazonaws.com:1883","RemoteTargetInfo":"","ServiceName":""}
```
The logs obtained are 
```
INFO[2022-04-27T10:17:14Z]externalhandler.go:394 APIV1RequestCloudSyncmgrPublish [RestExternalInterface] APIV1RequestCloudSyncmgrPublish 
INFO[2022-04-27T10:17:14Z]orchestrationapi.go:135 RequestCloudSyncPublish [RequestCloudSync]Requesting cloud sync publish 
INFO[2022-04-27T10:17:14Z]cloudsync.go:89 RequestPublish [cloudsyncmgr] Publishing the data to the cloud 
INFO[2022-04-27T10:17:14Z]mqttconnection.go:84 StartMQTTClient [MQTTConnectionMgr] Starting the MQTT Client 
INFO[2022-04-27T10:17:14Z]mqttconnection.go:88 StartMQTTClient [MQTTConnectionMgr] Client is already connected 
INFO[2022-04-27T10:17:14Z]mqttconnection.go:130 Publish [MQTTConnectionMgr] Publishing the data to cloud 
INFO[2022-04-27T10:17:14Z]mqttconnection.go:145 func1 [MQTTConnectionMgr] Topic DesignII registered.. Test message for testing Design Part 2 Tetsing agaain is the payload 
INFO[2022-04-27T10:17:15Z]route.go:130 func1 From [192.168.1.107:52718] POST /api/v1/orchestration/cloudsyncmgr/publish APIV1RequestCloudSyncmgrPublish 1.001793807s
```
5. To test the getsubscribed data call the following curl command once with app81(subscribed app) and next with some random appid or topic
```
curl --location --request GET 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/getsubscribedata/ec2-44-201-220-95.compute-1.amazonaws.com/DesignII/app81'
{"Message":"Test message for testing Design Part 2 Tetsing agaain"}
```
The logs are
```
INFO[2022-04-27T10:19:06Z]externalhandler.go:561 APIV1RequestCloudSyncmgrGetSubscribedData [RestExternalInterface] APIV1RequestCloudSyncmgrGetSubscribedData 
INFO[2022-04-27T10:19:06Z]orchestrationapi.go:147 RequestSubscribedData [RequestCloudSync]Requesting SubscribedData  
INFO[2022-04-27T10:19:06Z]cloudsync.go:166 RequestSubscribedData [cloudsyncmgr] Requesting the data for DesignII 
INFO[2022-04-27T10:19:06Z]route.go:130 func1 From [192.168.1.107:52720] GET /api/v1/orchestration/cloudsyncmgr/getsubscribedata/ec2-44-201-220-95.compute-1.amazonaws.com/DesignII/app81 APIV1RequestCloudSyncmgrGetSubscribedData 204.696µs 
```
For app21 or topic Design
```
curl --location --request GET 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/getsubscribedata/ec2-44-201-220-95.compute-1.amazonaws.com/DesignII/app21'
{"Message":"Client is not subscribed to the topic DesignII"}
```
```
curl --location --request GET 'http://192.168.1.107:56001/api/v1/orchestration/cloudsyncmgr/getsubscribedata/ec2-44-201-220-95.compute-1.amazonaws.com/DesignI/app81'
{"Message":"Client is not subscribed to the topic DesignI"}
```
*Test Configuration**:
* OS type & version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (v1.1.1)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes