### PR TITLE
Expand test coverage of scoringmgr, internalhandler, tlsserver

### DIFF
--- a/internal/controller/discoverymgr/mnedc/servercontrol.go
+++ b/internal/controller/discoverymgr/mnedc/servercontrol.go
@@ -91,7 +91,9 @@ func startMNEDCBroadcastServer() {
 		http.HandleFunc("/register", handleClientInfo)
 		go http.ListenAndServe(":"+strconv.Itoa(broadcastServerPort), nil)
 	} else {
-		go tlsserver.TLSServer{Certspath: serverIns.GetCertificateFilePath()}.ListenAndServe(":"+strconv.Itoa(broadcastServerPort), http.HandlerFunc(handleClientInfo))
+		s := tlsserver.TLSServer{Certspath: serverIns.GetCertificateFilePath()}
+		go s.ListenAndServe(":"+strconv.Itoa(broadcastServerPort), http.HandlerFunc(handleClientInfo))
+		// go tlsserver.TLSServer{Certspath: serverIns.GetCertificateFilePath()}.ListenAndServe(":"+strconv.Itoa(broadcastServerPort), http.HandlerFunc(handleClientInfo))
 	}
 }
 

--- a/internal/controller/scoringmgr/scoringmgr_test.go
+++ b/internal/controller/scoringmgr/scoringmgr_test.go
@@ -18,6 +18,7 @@
 package scoringmgr
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/resourceutil"
@@ -26,32 +27,255 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
+const (
+	unexpectedSuccess = "unexpected success"
+	unexpectedFail    = "unexpected fail"
+)
+
 var (
 	dummyDevID    = "devID"
 	expectedScore = 0.5948754760361981
 )
 
 func TestGetScore_ExpectedSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	resourceutilMockObj := resourceUtilMock.NewMockGetResource(ctrl)
+		resourceutilMockObj := resourceUtilMock.NewMockGetResource(ctrl)
 
-	gomock.InOrder(
-		resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
-		resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
-		resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, nil),
-		resourceutilMockObj.EXPECT().GetResource(resourceutil.NetBandwidth).Return(10.0, nil),
-		resourceutilMockObj.EXPECT().SetDeviceID(dummyDevID),
-		resourceutilMockObj.EXPECT().GetResource(resourceutil.NetRTT).Return(10.0, nil),
-	)
-	resourceIns = resourceutilMockObj
+		gomock.InOrder(
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.NetBandwidth).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().SetDeviceID(dummyDevID),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.NetRTT).Return(10.0, nil),
+		)
+		resourceIns = resourceutilMockObj
 
-	score, err := GetInstance().GetScore(dummyDevID)
-	if err != nil {
-		t.Errorf("Unexpected error return : %s", err.Error())
-	}
-	if score != expectedScore {
-		t.Error("score : ", score, " expectedScore : ", expectedScore)
-	}
+		score, err := GetInstance().GetScore(dummyDevID)
+		if err != nil {
+			t.Error(unexpectedFail, err.Error())
+		}
+		if score != expectedScore {
+			t.Error(unexpectedFail, "score : ", score, " expectedScore : ", expectedScore)
+		}
+	})
+}
+
+func TestGetResource(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		resourceutilMockObj := resourceUtilMock.NewMockGetResource(ctrl)
+
+		gomock.InOrder(
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.NetBandwidth).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().SetDeviceID(dummyDevID),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.NetRTT).Return(10.0, nil),
+		)
+		resourceIns = resourceutilMockObj
+		_, err := GetInstance().GetResource(dummyDevID)
+		if err != nil {
+			t.Error(unexpectedFail, err.Error())
+		}
+	})
+	t.Run("Fail", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		resourceutilMockObj := resourceUtilMock.NewMockGetResource(ctrl)
+
+		t.Run("CPUUsage", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			_, err := GetInstance().GetResource(dummyDevID)
+			if err == nil {
+				t.Error(unexpectedSuccess)
+			}
+		})
+		t.Run("CPUCount", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			_, err := GetInstance().GetResource(dummyDevID)
+			if err == nil {
+				t.Error(unexpectedSuccess)
+			}
+		})
+		t.Run("CPUFreq", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			_, err := GetInstance().GetResource(dummyDevID)
+			if err == nil {
+				t.Error(unexpectedSuccess)
+			}
+		})
+		t.Run("NetBandwidth", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.NetBandwidth).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			_, err := GetInstance().GetResource(dummyDevID)
+			if err == nil {
+				t.Error(unexpectedSuccess)
+			}
+		})
+		t.Run("NetRTT", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.NetBandwidth).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().SetDeviceID(dummyDevID),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.NetRTT).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			_, err := GetInstance().GetResource(dummyDevID)
+			if err == nil {
+				t.Error(unexpectedSuccess)
+			}
+		})
+
+	})
+}
+
+func TestCalculateScore(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		resourceutilMockObj := resourceUtilMock.NewMockGetResource(ctrl)
+
+		gomock.InOrder(
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.NetBandwidth).Return(10.0, nil),
+			resourceutilMockObj.EXPECT().SetDeviceID(dummyDevID),
+			resourceutilMockObj.EXPECT().GetResource(resourceutil.NetRTT).Return(10.0, nil),
+		)
+		resourceIns = resourceutilMockObj
+		score := calculateScore(dummyDevID)
+		if score != expectedScore {
+			t.Error(unexpectedFail, "score : ", score, " expectedScore : ", expectedScore)
+		}
+	})
+	t.Run("Fail", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		resourceutilMockObj := resourceUtilMock.NewMockGetResource(ctrl)
+
+		t.Run("CPUUsage", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			score := calculateScore(dummyDevID)
+			if score != InvalidScore {
+				t.Error(unexpectedSuccess, "score : ", score, " expectedScore : ", InvalidScore)
+			}
+		})
+		t.Run("CPUCount", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			score := calculateScore(dummyDevID)
+			if score != InvalidScore {
+				t.Error(unexpectedSuccess, "score : ", score, " expectedScore : ", InvalidScore)
+			}
+		})
+		t.Run("CPUFreq", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			score := calculateScore(dummyDevID)
+			if score != InvalidScore {
+				t.Error(unexpectedSuccess, "score : ", score, " expectedScore : ", InvalidScore)
+			}
+		})
+		t.Run("NetBandwidth", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.NetBandwidth).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			score := calculateScore(dummyDevID)
+			if score != InvalidScore {
+				t.Error(unexpectedSuccess, "score : ", score, " expectedScore : ", InvalidScore)
+			}
+		})
+		t.Run("NetRTT", func(t *testing.T) {
+			gomock.InOrder(
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUUsage).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUCount).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.CPUFreq).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.NetBandwidth).Return(10.0, nil),
+				resourceutilMockObj.EXPECT().SetDeviceID(dummyDevID),
+				resourceutilMockObj.EXPECT().GetResource(resourceutil.NetRTT).Return(10.0, errors.New("")),
+			)
+			resourceIns = resourceutilMockObj
+			score := calculateScore(dummyDevID)
+			if score != InvalidScore {
+				t.Error(unexpectedSuccess, "score : ", score, " expectedScore : ", InvalidScore)
+			}
+		})
+	})
+}
+
+func TestGetScoreWithResource(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		resource := make(map[string]interface{})
+		resource["cpuUsage"] = 10.0
+		resource["cpuCount"] = 10.0
+		resource["cpuFreq"] = 10.0
+		resource["netBandwidth"] = 10.0
+		resource["rtt"] = 10.0
+		_, err := GetInstance().GetScoreWithResource(resource)
+		if err != nil {
+			t.Error(unexpectedFail, err.Error())
+		}
+	})
+	t.Run("Fail", func(t *testing.T) {
+		resource := make(map[string]interface{})
+		resource["error"] = 10.0
+		_, err := GetInstance().GetScoreWithResource(resource)
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+	})
+}
+
+func TestRenderingScore(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		score := renderingScore(-0.1)
+		if score != 0 {
+			t.Error(unexpectedFail, "score : ", score, " expectedScore : 0")
+		}
+
+	})
 }

--- a/internal/restinterface/resthelper/client/tlshelper/tlshelper.go
+++ b/internal/restinterface/resthelper/client/tlshelper/tlshelper.go
@@ -51,17 +51,19 @@ func init() {
 func createClientConfig(certspath string) (*tls.Config, error) {
 	caCertPEM, err := ioutil.ReadFile(certspath + "/ca-crt.pem")
 	if err != nil {
+		log.Panic(err.Error())
 		return nil, err
 	}
 
 	roots := x509.NewCertPool()
 	ok := roots.AppendCertsFromPEM(caCertPEM)
 	if !ok {
-		panic("failed to parse root certificate")
+		log.Panic("failed to parse root certificate")
 	}
 
 	cert, err := tls.LoadX509KeyPair(certspath+"/hen-crt.pem", certspath+"/hen-key.pem")
 	if err != nil {
+		log.Panic(err.Error())
 		return nil, err
 	}
 	return &tls.Config{
@@ -81,11 +83,7 @@ func (s TLSHelper) Do(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("invalid URL port %q", req.URL.Port())
 	}
 
-	config, err := createClientConfig(s.Certspath)
-	if err != nil {
-		log.Fatal("config failed: ", err)
-	}
-
+	config, _ := createClientConfig(s.Certspath)
 	tlsconn, err := tls.Dial("tcp", req.URL.Host, config)
 	if err != nil {
 		return nil, err

--- a/internal/restinterface/route/route.go
+++ b/internal/restinterface/route/route.go
@@ -110,7 +110,8 @@ func (r RestRouter) listenAndServe() {
 	switch r.IsSetCert {
 	case true:
 		log.Info(logPrefix, "Internal ListenAndServeTLS")
-		go tlsserver.TLSServer{Certspath: r.GetCertificateFilePath()}.ListenAndServe(":"+strconv.Itoa(ConstInternalPort), r.routerInternal)
+		s := tlsserver.TLSServer{Certspath: r.GetCertificateFilePath()}
+		go s.ListenAndServe(":"+strconv.Itoa(ConstInternalPort), r.routerInternal)
 	default:
 		log.Info(logPrefix, "Internal ListenAndServe")
 		go http.ListenAndServe(":"+strconv.Itoa(ConstInternalPort), r.routerInternal)


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Expand test coverage of scoringmgr, internalhandler, tlsserver

## Type of change

- [x] Test Coverage update

```
make test internal/controller/scoringmgr
```
```
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr/scoringmgr.go	 ScoringImpl.GetResource		 100.00% (28/28)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr/scoringmgr.go	 calculateScore				 100.00% (20/20)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr/scoringmgr.go	 ScoringImpl.GetScoreWithResource	 100.00% (6/6)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr/scoringmgr.go	 renderingScore				 100.00% (4/4)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr/scoringmgr.go	 init					 100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr/scoringmgr.go	 ScoringImpl.GetScore			 100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr/scoringmgr.go	 GetInstance				 100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr/scoringmgr.go	 netScore				 100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr/scoringmgr.go	 cpuScore				 100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr			 --------------------------------	 100.00% (65/65)

Total Coverage: 100.00% (65/65)
```
```
make test internal/restinterface/internalhandler
```
```
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.APIV1ScoringmgrScoreLibnameGet				 100.00% (29/29)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.APIV1ScoringmgrResourceGet				 100.00% (27/27)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.APIV1DiscoverymgrMNEDCDeviceInfoPost			 100.00% (24/24)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.APIV1DiscoverymgrOrchestrationInfoGet			 100.00% (24/24)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.APIV1ServicemgrServicesNotificationServiceIDPost	 100.00% (22/22)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 init								 100.00% (3/3)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.SetCertificateFilePath					 100.00% (3/3)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.SetOrchestrationAPI					 100.00% (2/2)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.setHelper						 100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 GetHandler							 100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.APIV1Ping						 100.00% (1/1)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler/internalhandler.go	 Handler.APIV1ServicemgrServicesPost				 88.00% (44/50)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler			 --------------------------------------------------------	 96.79% (181/187)

Total Coverage: 96.79% (181/187)
```
```
make test internal/restinterface/route/tlsserver
```
```
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route/tlsserver/tlsserver.go	 createServerConfig		 100.00% (11/11)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route/tlsserver/tlsserver.go	 TLSServer.ListenAndServe	 100.00% (8/8)
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route/tlsserver			 ------------------------	 100.00% (19/19)

Total Coverage: 100.00% (19/19)

```

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 & Go v1.16
* Edge Orchestration Release: v1.1.12

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
