### PR TITLE
Increase test coverage

### DIFF
--- a/internal/common/resourceutil/cpu.go
+++ b/internal/common/resourceutil/cpu.go
@@ -55,7 +55,7 @@ func checkCPUUsage() {
 
 	cpus, err := cpu.percent(time.Second, true)
 	if err != nil {
-		log.Println(logPrefix, "usage of cpu is fail : ", err.Error())
+		log.Error(logPrefix, "usage of cpu is fail : ", err.Error())
 		return
 	}
 
@@ -70,14 +70,14 @@ func checkCPUUsage() {
 
 	err = resourceDBExecutor.Set(info)
 	if err != nil {
-		log.Println(logPrefix, "DB error : ", err.Error())
+		log.Error(logPrefix, "DB error : ", err.Error())
 	}
 }
 
 func checkCPUFreq() (out float64, err error) {
 	infos, err := cpu.info()
 	if err != nil {
-		log.Println(logPrefix, "cpu.Info() fail : ", err.Error())
+		log.Error(logPrefix, "cpu.Info() fail : ", err.Error())
 		return
 	}
 
@@ -87,7 +87,7 @@ func checkCPUFreq() (out float64, err error) {
 
 	err = resourceDBExecutor.Set(info)
 	if err != nil {
-		log.Println(logPrefix, "DB error : ", err.Error())
+		log.Error(logPrefix, "DB error : ", err.Error())
 	}
 	return
 }
@@ -95,7 +95,7 @@ func checkCPUFreq() (out float64, err error) {
 func checkCPUCount() {
 	infos, err := cpu.info()
 	if err != nil {
-		log.Println(logPrefix, "cpu info getting fail : ", err.Error())
+		log.Error(logPrefix, "cpu info getting fail : ", err.Error())
 		return
 	}
 
@@ -105,6 +105,6 @@ func checkCPUCount() {
 
 	err = resourceDBExecutor.Set(info)
 	if err != nil {
-		log.Println(logPrefix, "DB error : ", err.Error())
+		log.Error(logPrefix, "DB error : ", err.Error())
 	}
 }

--- a/internal/common/resourceutil/cpu/cpu.go
+++ b/internal/common/resourceutil/cpu/cpu.go
@@ -2,11 +2,12 @@ package cpu
 
 import (
 	"bufio"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 )
 
 const (
@@ -59,7 +60,7 @@ func init() {
 func readCPUUsage() ([]float64, error) {
 	f, err := fileOpen("/proc/stat")
 	if err != nil {
-		log.Println(err.Error())
+		log.Error(err.Error())
 		return nil, err
 	}
 	defer f.Close()
@@ -181,9 +182,11 @@ func getCPUFreqCPUInfo() (float64, error) {
 	defer f.Close()
 
 	r := bufio.NewReader(f)
+	var line string
 	for {
-		line, err := r.ReadString('\n')
+		line, err = r.ReadString('\n')
 		if err != nil {
+			log.Error(err.Error())
 			break
 		}
 

--- a/internal/common/resourceutil/resourceutil_test.go
+++ b/internal/common/resourceutil/resourceutil_test.go
@@ -32,6 +32,11 @@ import (
 	resourceDBMock "github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/resource/mocks"
 )
 
+const (
+	unexpectedSuccess = "unexpected success"
+	unexpectedFail    = "unexpected fail"
+)
+
 type dummpyLink struct {
 	Link
 	attrs   netutil.LinkAttrs
@@ -229,219 +234,251 @@ func setupMemFreeTest() {
 	monitoringExecutor.rttScoring = func() {}
 }
 
-func TestGetCPUUsage_ExpectedSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func TestGetCPUUsage(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
+		resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
 
-	info := resourceDB.Info{}
-	info.Name = CPUUsage
-	info.Value = dummyCPUPercentResult
+		info := resourceDB.Info{}
+		info.Name = CPUUsage
+		info.Value = dummyCPUPercentResult
 
-	resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
-	resourceDBMockObj.EXPECT().Get(CPUUsage).Return(info, nil)
+		resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
+		resourceDBMockObj.EXPECT().Get(CPUUsage).Return(info, nil)
 
-	resourceDBExecutor = resourceDBMockObj
+		resourceDBExecutor = resourceDBMockObj
 
-	setupTestCase()
+		setupTestCase()
 
-	monitoringImpl := GetMonitoringInstance()
-	setupCPUUsageTest()
-	monitoringImpl.StartMonitoringResource()
+		monitoringImpl := GetMonitoringInstance()
+		setupCPUUsageTest()
+		monitoringImpl.StartMonitoringResource()
 
-	cpuUsage, err := resourceIns.GetResource(CPUUsage)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+		cpuUsage, err := resourceIns.GetResource(CPUUsage)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 
-	if cpuUsage != dummyCPUPercentResult {
-		t.Errorf("%f != %f", cpuUsage, dummyCPUPercentResult)
-	}
+		if cpuUsage != dummyCPUPercentResult {
+			t.Errorf("%f != %f", cpuUsage, dummyCPUPercentResult)
+		}
+	})
 }
 
-func TestGetCPUFreq_ExpectedSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func TestGetCPUFreq(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
+		resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
 
-	info := resourceDB.Info{}
-	info.Name = CPUFreq
-	info.Value = dummyCPUFreqResult
+		info := resourceDB.Info{}
+		info.Name = CPUFreq
+		info.Value = dummyCPUFreqResult
 
-	resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
-	resourceDBMockObj.EXPECT().Get(CPUFreq).Return(info, nil)
+		resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
+		resourceDBMockObj.EXPECT().Get(CPUFreq).Return(info, nil)
 
-	resourceDBExecutor = resourceDBMockObj
+		resourceDBExecutor = resourceDBMockObj
 
-	setupTestCase()
+		setupTestCase()
 
-	monitoringImpl := GetMonitoringInstance()
-	setupCPUFreqTest()
-	monitoringImpl.StartMonitoringResource()
+		monitoringImpl := GetMonitoringInstance()
+		setupCPUFreqTest()
+		monitoringImpl.StartMonitoringResource()
 
-	cpuFreq, err := resourceIns.GetResource(CPUFreq)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+		cpuFreq, err := resourceIns.GetResource(CPUFreq)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 
-	if cpuFreq != dummyCPUFreqResult {
-		t.Errorf("%f != %f", cpuFreq, dummyCPUFreqResult)
-	}
+		if cpuFreq != dummyCPUFreqResult {
+			t.Errorf("%f != %f", cpuFreq, dummyCPUFreqResult)
+		}
+	})
 }
 
-func TestGetCPUCount_ExpectedSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func TestGetCPUCount(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
+		resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
 
-	info := resourceDB.Info{}
-	info.Name = CPUCount
-	info.Value = dummyCPUCountResult
+		info := resourceDB.Info{}
+		info.Name = CPUCount
+		info.Value = dummyCPUCountResult
 
-	resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
-	resourceDBMockObj.EXPECT().Get(CPUCount).Return(info, nil)
+		resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
+		resourceDBMockObj.EXPECT().Get(CPUCount).Return(info, nil)
 
-	resourceDBExecutor = resourceDBMockObj
+		resourceDBExecutor = resourceDBMockObj
 
-	setupTestCase()
+		setupTestCase()
 
-	monitoringImpl := GetMonitoringInstance()
-	setupCPUCountTest()
-	monitoringImpl.StartMonitoringResource()
+		monitoringImpl := GetMonitoringInstance()
+		setupCPUCountTest()
+		monitoringImpl.StartMonitoringResource()
 
-	cpuCount, err := resourceIns.GetResource(CPUCount)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+		cpuCount, err := resourceIns.GetResource(CPUCount)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 
-	if cpuCount != dummyCPUCountResult {
-		t.Errorf("%f != %f", cpuCount, dummyCPUCountResult)
-	}
+		if cpuCount != dummyCPUCountResult {
+			t.Errorf("%f != %f", cpuCount, dummyCPUCountResult)
+		}
+	})
 }
 
-func TestGetMemAvailable_ExpectedSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func TestGetMemAvailable(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
+		resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
 
-	info := resourceDB.Info{}
-	info.Name = MemAvailable
-	info.Value = dummyMemAvailableResult
+		info := resourceDB.Info{}
+		info.Name = MemAvailable
+		info.Value = dummyMemAvailableResult
 
-	resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
-	resourceDBMockObj.EXPECT().Get(MemAvailable).Return(info, nil)
+		resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
+		resourceDBMockObj.EXPECT().Get(MemAvailable).Return(info, nil)
 
-	resourceDBExecutor = resourceDBMockObj
+		resourceDBExecutor = resourceDBMockObj
 
-	setupTestCase()
+		setupTestCase()
 
-	monitoringImpl := GetMonitoringInstance()
-	setupMemAvailableTest()
-	monitoringImpl.StartMonitoringResource()
+		monitoringImpl := GetMonitoringInstance()
+		setupMemAvailableTest()
+		monitoringImpl.StartMonitoringResource()
 
-	memAvailable, err := resourceIns.GetResource(MemAvailable)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+		memAvailable, err := resourceIns.GetResource(MemAvailable)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 
-	if memAvailable != dummyMemAvailableResult {
-		t.Errorf("%f != %f", memAvailable, dummyMemAvailableResult)
-	}
+		if memAvailable != dummyMemAvailableResult {
+			t.Errorf("%f != %f", memAvailable, dummyMemAvailableResult)
+		}
+	})
 }
 
-func TestGetMemFree_ExpectedSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func TestGetMemFree(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
+		resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
 
-	info := resourceDB.Info{}
-	info.Name = MemFree
-	info.Value = dummyMemFreeResult
+		info := resourceDB.Info{}
+		info.Name = MemFree
+		info.Value = dummyMemFreeResult
 
-	resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
-	resourceDBMockObj.EXPECT().Get(MemFree).Return(info, nil)
+		resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
+		resourceDBMockObj.EXPECT().Get(MemFree).Return(info, nil)
 
-	resourceDBExecutor = resourceDBMockObj
+		resourceDBExecutor = resourceDBMockObj
 
-	setupTestCase()
+		setupTestCase()
 
-	monitoringImpl := GetMonitoringInstance()
-	setupMemFreeTest()
-	monitoringImpl.StartMonitoringResource()
+		monitoringImpl := GetMonitoringInstance()
+		setupMemFreeTest()
+		monitoringImpl.StartMonitoringResource()
 
-	memFree, err := resourceIns.GetResource(MemFree)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+		memFree, err := resourceIns.GetResource(MemFree)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 
-	if memFree != dummyMemFreeResult {
-		t.Errorf("%f != %f", memFree, dummyMemFreeResult)
-	}
+		if memFree != dummyMemFreeResult {
+			t.Errorf("%f != %f", memFree, dummyMemFreeResult)
+		}
+	})
 }
 
-func TestGetNetMBps_ExpectedSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func TestGetNetMBps(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
+		resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
 
-	info := resourceDB.Info{}
-	info.Name = NetMBps
-	info.Value = dummyNetMBpsResult
+		info := resourceDB.Info{}
+		info.Name = NetMBps
+		info.Value = dummyNetMBpsResult
 
-	resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
-	resourceDBMockObj.EXPECT().Get(NetMBps).Return(info, nil)
+		resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
+		resourceDBMockObj.EXPECT().Get(NetMBps).Return(info, nil)
 
-	resourceDBExecutor = resourceDBMockObj
+		resourceDBExecutor = resourceDBMockObj
 
-	setupTestCase()
+		setupTestCase()
 
-	monitoringImpl := GetMonitoringInstance()
-	setupNetMBpsTest()
-	monitoringImpl.StartMonitoringResource()
+		monitoringImpl := GetMonitoringInstance()
+		setupNetMBpsTest()
+		monitoringImpl.StartMonitoringResource()
 
-	netMBps, err := resourceIns.GetResource(NetMBps)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+		netMBps, err := resourceIns.GetResource(NetMBps)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 
-	if netMBps != dummyNetMBpsResult {
-		t.Errorf("%f != %f", netMBps, dummyNetMBpsResult)
-	}
+		if netMBps != dummyNetMBpsResult {
+			t.Errorf("%f != %f", netMBps, dummyNetMBpsResult)
+		}
+	})
 }
 
-func TestGetNetBandwidth_ExpectedSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func TestGetNetBandwidth(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
+		resourceDBMockObj := resourceDBMock.NewMockDBInterface(ctrl)
 
-	info := resourceDB.Info{}
-	info.Name = NetBandwidth
-	info.Value = dummyNetBandwidthResult
+		info := resourceDB.Info{}
+		info.Name = NetBandwidth
+		info.Value = dummyNetBandwidthResult
 
-	resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
-	resourceDBMockObj.EXPECT().Get(NetBandwidth).Return(info, nil)
+		resourceDBMockObj.EXPECT().Set(info).Return(nil).AnyTimes()
+		resourceDBMockObj.EXPECT().Get(NetBandwidth).Return(info, nil)
 
-	resourceDBExecutor = resourceDBMockObj
+		resourceDBExecutor = resourceDBMockObj
 
-	setupTestCase()
+		setupTestCase()
 
-	monitoringImpl := GetMonitoringInstance()
-	setupNetBandwidthTest()
-	monitoringImpl.StartMonitoringResource()
+		monitoringImpl := GetMonitoringInstance()
+		setupNetBandwidthTest()
+		monitoringImpl.StartMonitoringResource()
 
-	netBandwidth, err := resourceIns.GetResource(NetBandwidth)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+		netBandwidth, err := resourceIns.GetResource(NetBandwidth)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
 
-	if netBandwidth != dummyNetBandwidthResult {
-		t.Errorf("%f != %f", netBandwidth, dummyNetBandwidthResult)
-	}
+		if netBandwidth != dummyNetBandwidthResult {
+			t.Errorf("%f != %f", netBandwidth, dummyNetBandwidthResult)
+		}
+	})
+}
+
+func TestGetResource(t *testing.T) {
+	t.Run("Fail", func(t *testing.T) {
+		_, err := resourceIns.GetResource("UndefinedResource")
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+	})
+}
+
+func TestSetDeviceID(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		resourceIns.SetDeviceID("Device1")
+		if resourceIns.targetDeviceID != "Device1" {
+			t.Error(unexpectedFail)
+		}
+	})
 }

--- a/internal/controller/configuremgr/configuremgr_test.go
+++ b/internal/controller/configuremgr/configuremgr_test.go
@@ -37,6 +37,12 @@ const (
 	fakeExecType    = "native"
 )
 
+const (
+	fakePath          = "fakePath"
+	unexpectedSuccess = "unexpected success"
+	unexpectedFail    = "unexpected fail"
+)
+
 type dummyNoti struct{}
 
 func (d dummyNoti) Notify(serviceinfo configuremgrtypes.ServiceInfo) {
@@ -108,6 +114,24 @@ func TestBasicMockConfigureMgr(t *testing.T) {
 
 		if name != expectedName {
 			t.Errorf("Not matched notified serviceName %s != %s", name, expectedName)
+		}
+	})
+}
+
+func TestGetServiceInfo(t *testing.T) {
+	t.Run("Fail", func(t *testing.T) {
+		_, err := getServiceInfo(fakePath)
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+	})
+}
+
+func TestGetdirname(t *testing.T) {
+	t.Run("Fail", func(t *testing.T) {
+		_, err := getdirname(fakePath + "/")
+		if err == nil {
+			t.Error(unexpectedSuccess)
 		}
 	})
 }

--- a/internal/orchestrationapi/orchestration_test.go
+++ b/internal/orchestrationapi/orchestration_test.go
@@ -41,6 +41,8 @@ import (
 
 const (
 	defaultServiceName = "default_service"
+	unexpectedSuccess  = "unexpected success"
+	unexpectedFail     = "unexpected fail"
 )
 
 var (
@@ -273,5 +275,31 @@ func TestNotify(t *testing.T) {
 				ExecutableFileName: defaultServiceName,
 			})
 		})
+	})
+}
+
+func TestInternalExternalAPI(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		getOrcheImple().Ready = true
+
+		if _, err := GetInternalAPI(); err != nil {
+			t.Error(unexpectedFail + err.Error())
+		}
+
+		if _, err := GetExternalAPI(); err != nil {
+			t.Error(unexpectedFail + err.Error())
+		}
+
+	})
+	t.Run("Fail", func(t *testing.T) {
+		getOrcheImple().Ready = false
+
+		if _, err := GetInternalAPI(); err == nil {
+			t.Error(unexpectedSuccess)
+		}
+
+		if _, err := GetExternalAPI(); err == nil {
+			t.Error(unexpectedSuccess)
+		}
 	})
 }

--- a/internal/restinterface/client/restclient/restclient_test.go
+++ b/internal/restinterface/client/restclient/restclient_test.go
@@ -291,6 +291,19 @@ func TestDoGetScoreRemoteDevice(t *testing.T) {
 				}
 			})
 		})
+		t.Run("EncryptionFail", func(t *testing.T) {
+			client.SetCipher(mockCipher)
+			client.setHelper(mockHelper)
+			gomock.InOrder(
+				mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
+				mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, errors.New("")),
+			)
+
+			_, err := client.DoGetScoreRemoteDevice("", "")
+			if err == nil {
+				t.Error("expect error is not nil, but nil")
+			}
+		})
 		t.Run("DecryptionFail", func(t *testing.T) {
 			client.SetCipher(mockCipher)
 			client.setHelper(mockHelper)
@@ -346,6 +359,115 @@ func TestDoGetScoreRemoteDevice(t *testing.T) {
 			t.Error("expect error is nil, but not nil")
 		} else if score != float64(1.0) {
 			t.Error("unexpected score value")
+		}
+	})
+}
+
+func TestDoGetResourceRemoteDevice(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := restClient
+	if client == nil {
+		t.Error("unexpected return value")
+	}
+
+	mockCipher := ciphermock.NewMockIEdgeCipherer(ctrl)
+	mockHelper := helpermock.NewMockRestHelper(ctrl)
+
+	t.Run("Error", func(t *testing.T) {
+		t.Run("IsNotSetKey", func(t *testing.T) {
+			client.setHelper(mockHelper)
+
+			client.IsSetKey = false
+			_, err := client.DoGetResourceRemoteDevice("", "")
+			if err == nil {
+				t.Error("expect error is not nil, but nil")
+			}
+		})
+		t.Run("DoGetWithBody", func(t *testing.T) {
+			t.Run("ReturnError", func(t *testing.T) {
+				client.SetCipher(mockCipher)
+				client.setHelper(mockHelper)
+				gomock.InOrder(
+					mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
+					mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, nil),
+					mockHelper.EXPECT().DoGetWithBody(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, errors.New("")),
+				)
+
+				_, err := client.DoGetResourceRemoteDevice("", "")
+				if err == nil {
+					t.Error("expect error is not nil, but nil")
+				}
+			})
+		})
+		t.Run("EncryptionFail", func(t *testing.T) {
+			client.SetCipher(mockCipher)
+			client.setHelper(mockHelper)
+			gomock.InOrder(
+				mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
+				mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, errors.New("")),
+			)
+
+			_, err := client.DoGetResourceRemoteDevice("", "")
+			if err == nil {
+				t.Error("expect error is not nil, but nil")
+			}
+		})
+
+		t.Run("DecryptionFail", func(t *testing.T) {
+			client.SetCipher(mockCipher)
+			client.setHelper(mockHelper)
+			gomock.InOrder(
+				mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
+				mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, nil),
+				mockHelper.EXPECT().DoGetWithBody(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, nil),
+				mockCipher.EXPECT().DecryptByteToJSON(gomock.Any()).Return(nil, errors.New("")),
+			)
+
+			_, err := client.DoGetResourceRemoteDevice("", "")
+			if err == nil {
+				t.Error("expect error is not nil, but nil")
+			}
+		})
+		t.Run("ReturnError", func(t *testing.T) {
+			client.SetCipher(mockCipher)
+			client.setHelper(mockHelper)
+
+			respMsg := make(map[string]interface{})
+			respMsg["error"] = "failed"
+
+			gomock.InOrder(
+				mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
+				mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, nil),
+				mockHelper.EXPECT().DoGetWithBody(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, nil),
+				mockCipher.EXPECT().DecryptByteToJSON(gomock.Any()).Return(respMsg, nil),
+			)
+
+			_, err := client.DoGetResourceRemoteDevice("", "")
+			if err == nil {
+				t.Error("expect error is not nil, but nil")
+			}
+		})
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		client.SetCipher(mockCipher)
+		client.setHelper(mockHelper)
+
+		respMsg := make(map[string]interface{})
+		// 	respMsg["ScoreValue"] = float64(1.0)
+
+		gomock.InOrder(
+			mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
+			mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, nil),
+			mockHelper.EXPECT().DoGetWithBody(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, nil),
+			mockCipher.EXPECT().DecryptByteToJSON(gomock.Any()).Return(respMsg, nil),
+		)
+
+		_, err := client.DoGetResourceRemoteDevice("", "")
+		if err != nil {
+			t.Error("unexpectedFail")
 		}
 	})
 }

--- a/internal/restinterface/resthelper/helper_test.go
+++ b/internal/restinterface/resthelper/helper_test.go
@@ -25,6 +25,11 @@ import (
 	"testing"
 )
 
+const (
+	unexpectedSuccess = "unexpected success"
+	unexpectedFail    = "unexpected fail"
+)
+
 var (
 	expectMethod = http.MethodGet
 	statusCode   = http.StatusOK
@@ -38,10 +43,12 @@ var (
 )
 
 func TestGetHelper(t *testing.T) {
-	helper := GetHelper()
-	if helper == nil {
-		t.Error("unexpected return value")
-	}
+	t.Run("Success", func(t *testing.T) {
+		helper := GetHelper()
+		if helper == nil {
+			t.Error("unexpected return value")
+		}
+	})
 }
 
 func getTestServer(handler http.HandlerFunc) *httptest.Server {
@@ -60,6 +67,12 @@ func TestDoGet(t *testing.T) {
 			t.Error("unexpected error " + err.Error())
 		}
 	})
+	t.Run("Fail", func(t *testing.T) {
+		_, _, err := GetHelper().DoGet("")
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+	})
 }
 
 func TestDoGetWithBody(t *testing.T) {
@@ -72,6 +85,12 @@ func TestDoGetWithBody(t *testing.T) {
 			t.Error("unexpected error code " + http.StatusText(code))
 		} else if err != nil {
 			t.Error("unexpected error " + err.Error())
+		}
+	})
+	t.Run("Fail", func(t *testing.T) {
+		_, _, err := GetHelper().DoGetWithBody("", nil)
+		if err == nil {
+			t.Error(unexpectedSuccess)
 		}
 	})
 }
@@ -89,6 +108,12 @@ func TestDoPost(t *testing.T) {
 			t.Error("unexpected error " + err.Error())
 		}
 	})
+	t.Run("Fail", func(t *testing.T) {
+		_, _, err := GetHelper().DoPost("", make([]byte, 0))
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+	})
 }
 
 func TestDoDelete(t *testing.T) {
@@ -104,20 +129,53 @@ func TestDoDelete(t *testing.T) {
 			t.Error("unexpected error " + err.Error())
 		}
 	})
+	t.Run("Fail", func(t *testing.T) {
+		_, _, err := GetHelper().DoDelete("")
+		if err == nil {
+			t.Error(unexpectedSuccess)
+		}
+	})
 }
 
 func TestMakeTargetURL(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		target := "testserver.test"
-		port := 1234
-		restapi := "/api/v1/test"
-		expected := "http://" + target + ":" + strconv.Itoa(port) + restapi
+		t.Run("GetHelper-MakeTargetURL", func(t *testing.T) {
+			target := "testserver.test"
+			port := 1234
+			restapi := "/api/v1/test"
+			expected := "http://" + target + ":" + strconv.Itoa(port) + restapi
 
-		fullURL := GetHelper().MakeTargetURL(target, port, restapi)
+			fullURL := GetHelper().MakeTargetURL(target, port, restapi)
 
-		if expected != fullURL {
-			t.Error("expect same, but not same")
-		}
+			if expected != fullURL {
+				t.Error("expect same, but not same")
+			}
+		})
+		t.Run("GetHelperWithCertificate-MakeTargetURL", func(t *testing.T) {
+			target := "testserver.test"
+			port := 1234
+			restapi := "/api/v1/test"
+			expected := "http://" + target + ":" + strconv.Itoa(port) + restapi
+
+			fullURL := GetHelperWithCertificate().MakeTargetURL(target, port, restapi)
+			if expected != fullURL {
+				t.Error("expect same, but not same")
+			}
+		})
+		t.Run("HTTPS-MakeTargetURL", func(t *testing.T) {
+			target := "testserver.test"
+			port := 1234
+			restapi := "/api/v1/test"
+			expected := "https://" + target + ":" + strconv.Itoa(port) + restapi
+
+			var hh helperImpl
+			hh.SetCertificateFilePath("fakecerts")
+
+			fullURL := hh.MakeTargetURL(target, port, restapi)
+			if expected != fullURL {
+				t.Error("expect same, but not same")
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description
Achieving a test coverage of more than 80% will get a OpenSSF Best Practices "gold" badge

Fixes #463 

## Type of change

- [x] Test Coverage update

# How Has This Been Tested?
```
make test
```

```
github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator	96.77%	30/31
github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator/blacklist	100.00%	1/1
github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator/commands	100.00%	12/12
github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator/injectionchecker	100.00%	4/4
github.com/lf-edge/edge-home-orchestration-go/internal/common/errormsg	100.00%	10/10
github.com/lf-edge/edge-home-orchestration-go/internal/common/errors	100.00%	8/8
github.com/lf-edge/edge-home-orchestration-go/internal/common/fscreator	100.00%	5/5
github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr	100.00%	28/28
github.com/lf-edge/edge-home-orchestration-go/internal/common/mqtt	96.90%	125/129
github.com/lf-edge/edge-home-orchestration-go/internal/common/networkhelper	81.44%	79/97
github.com/lf-edge/edge-home-orchestration-go/internal/common/networkhelper/detector	95.00%	19/20
github.com/lf-edge/edge-home-orchestration-go/internal/common/requestervalidator	100.00%	8/8
github.com/lf-edge/edge-home-orchestration-go/internal/common/requestervalidator/requesterstore	100.00%	12/12
github.com/lf-edge/edge-home-orchestration-go/internal/common/resourceutil	57.94%	124/214
github.com/lf-edge/edge-home-orchestration-go/internal/common/resourceutil/cpu	98.11%	104/106
github.com/lf-edge/edge-home-orchestration-go/internal/common/sigmgr	83.33%	10/12
github.com/lf-edge/edge-home-orchestration-go/internal/controller/configuremgr	79.78%	71/89
github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr	82.37%	341/414
github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc	78.79%	78/99
github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc/client	73.09%	163/223
github.com/lf-edge/edge-home-orchestration-go/internal/controller/discoverymgr/mnedc/server	88.83%	167/188
github.com/lf-edge/edge-home-orchestration-go/internal/controller/scoringmgr	100.00%	65/65
github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authenticator	48.21%	27/56
github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authorizer	92.31%	36/39
github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/verifier	93.46%	100/107
github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr	90.00%	63/70
github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor	100.00%	2/2
github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/androidexecutor	68.00%	34/50
github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/containerexecutor	86.25%	414/480
github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/executor/nativeexecutor	97.50%	39/40
github.com/lf-edge/edge-home-orchestration-go/internal/controller/servicemgr/notification	92.50%	37/40
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/config	100.00%	17/17
github.com/lf-edge/edge-home-orchestration-go/internal/controller/storagemgr/storagedriver	43.88%	129/294
github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/application	86.11%	31/36
github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/common	100.00%	6/6
github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/configuration	83.67%	41/49
github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/network	74.58%	44/59
github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/resource	84.62%	22/26
github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/service	84.00%	42/50
github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/system	84.62%	22/26
github.com/lf-edge/edge-home-orchestration-go/internal/db/bolt/wrapper	84.13%	53/63
github.com/lf-edge/edge-home-orchestration-go/internal/db/helper	100.00%	45/45
github.com/lf-edge/edge-home-orchestration-go/internal/orchestrationapi	59.39%	155/261
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface	100.00%	1/1
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher	100.00%	2/2
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/dummy	94.74%	18/19
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher/sha256	88.33%	53/60
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/client	0.00%	0/1
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/client/restclient	100.00%	122/122
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/externalhandler	78.73%	248/315
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/externalhandler/senderresolver	98.00%	49/50
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/internalhandler	96.79%	181/187
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper	84.21%	64/76
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper/client/httphelper	50.00%	1/2
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/resthelper/client/tlshelper	62.50%	20/32
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route	89.19%	33/37
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route/tlsserver	100.00%	20/20
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/tls	100.00%	11/11
Report Total	80.56%	3646/4526
```
**Test Configuration**:
* OS type & version: Ubuntu 20.04 
* Hardware: x86-64 
* Toolchain: Docker v20.10 & Go v1.16
* Edge Orchestration Release: v1.1.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
