### PR TITLE
Create makefile rule to build binary files only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ help:
 	@echo ''
 
 ## define build target not a file
-.PHONY: all build test clean lint fmt help staticcheck run stop
+.PHONY: all build test clean lint fmt help staticcheck run stop binary
 
 define stop_docker_container
 	$(call print_header, "Stop Docker container")
@@ -283,6 +283,21 @@ ifeq ($(CONFIG_CONTAINER),y)
 	$(Q) cp configs/defdockerfiles/$(CONFIG_DOCKERFILE) Dockerfile
 	$(call build_binary)
 	make build_docker_container
+else ifeq ($(CONFIG_NATIVE),y)
+	$(call build-object-c)
+	$(call build-result)
+else ifeq ($(CONFIG_ANDROID),y)
+	$(call print_header, "Target Binary is for Android")
+	$(call print_header, "Create Android archive from Java interface")
+	make build-object-java
+	$(call build-result)
+endif
+
+binary: check_context
+	make clean
+	$(call go-vendor)
+ifeq ($(CONFIG_CONTAINER),y)
+	$(call build_binary)
 else ifeq ($(CONFIG_NATIVE),y)
 	$(call build-object-c)
 	$(call build-result)


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Create makefile rule for build only binary. This is necessary for project fuzzing.

## Type of change

- [x] CI system update

# How Has This Been Tested?
```
make binary
```

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 & Go v1.16
* Edge Orchestration Release: v1.1.14

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
