### PR TITLE
Fix codeowner list & update CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo.
-*              @t25kim @MoonkiHong @suresh-lc @NiranjanPatil25 @tdrozdovsky
+*              @t25kim @MoonkiHong @suresh-lc @tdrozdovsky

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@0c670bbf0414f39666df6ce8e718ec5662c21e03
+      uses: github/codeql-action/init@2ca79b6fa8d3ec278944088b4aa5f46912db5d63
       with:
         languages: ${{ matrix.language }}
 
@@ -36,4 +36,4 @@ jobs:
         go-version: '1.16.6'
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@0c670bbf0414f39666df6ce8e718ec5662c21e03
+      uses: github/codeql-action/analyze@2ca79b6fa8d3ec278944088b4aa5f46912db5d63

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -48,6 +48,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@0c670bbf0414f39666df6ce8e718ec5662c21e03
+        uses: github/codeql-action/upload-sarif@2ca79b6fa8d3ec278944088b4aa5f46912db5d63
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Fix codeowners list and update  github/codeql-action from 2.1.17 to 2.1.18

Closes #607 

## Type of change

- [x] CI system update

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 & Go v1.16
* Edge Orchestration Release: v1.1.15

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
