### PR TITLE
[GetScoreAPI] Removed request body and added the id as request parameter

### DIFF
--- a/internal/restinterface/internalhandler/internalhandler.go
+++ b/internal/restinterface/internalhandler/internalhandler.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/commandvalidator"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/requestervalidator"
@@ -42,6 +43,7 @@ const (
 	doesNotSetKey    = " does not set key"
 	cannotDecryption = " cannot decryption "
 	cannotEncryption = " cannot encryption "
+	devID            = "devID"
 )
 
 // Handler struct
@@ -88,7 +90,7 @@ func init() {
 		restinterface.Route{
 			Name:        "APIV1ScoringmgrScoreLibnameGet",
 			Method:      strings.ToUpper("Get"),
-			Pattern:     "/api/v1/scoringmgr/score",
+			Pattern:     "/api/v1/scoringmgr/score/{" + devID + "}",
 			HandlerFunc: handler.APIV1ScoringmgrScoreLibnameGet,
 		},
 
@@ -258,17 +260,10 @@ func (h *Handler) APIV1ScoringmgrScoreLibnameGet(w http.ResponseWriter, r *http.
 		return
 	}
 
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
-	Info, err := h.Key.DecryptByteToJSON(encryptBytes)
-	if err != nil {
-		log.Error(logPrefix, cannotDecryption, err.Error())
-		h.helper.Response(w, nil, http.StatusServiceUnavailable)
-		return
-	}
+	vars := mux.Vars(r)
+	devID := vars["devID"]
 
-	devID := Info["devID"]
-
-	scoreValue, err := h.api.GetScore(devID.(string))
+	scoreValue, err := h.api.GetScore(devID)
 	if err != nil {
 		log.Error(logPrefix, " GetScore fail : ", err.Error())
 		h.helper.Response(w, nil, http.StatusInternalServerError)


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description

API to get score required a request body with id of the device. But GET request body adds no meaning and hence the deviceID is added to the path parameter and removed from request body
API is 
http://{IP of the device which will calculate score}:56002/scoringmgr/score/{DeviceID for which the score is to be obtained}


Fixes # (#609)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Start the Edge container and make a curl request as 

curl --location --request GET 'http://<IP of the device of which score is needed>:56002/api/v1/scoringmgr/score/<deviceID of the device for which score is needed>

For ex:
```
curl --location --request GET 'http://192.168.1.108:56002/api/v1/scoringmgr/score/edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e'
```
The response received is 
{"ScoreValue":19.196700286368028}

Logs for the edge Container are 
```
INFO[2022-08-22T14:04:28Z]discovery.go:860 activeDiscovery [discoverymgr] activeDiscovery!!!            
INFO[2022-08-22T14:04:28Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-22T14:04:28Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-22T14:04:28Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-22T14:04:28Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-22T14:04:28Z]discovery.go:578 func1                                              
INFO[2022-08-22T14:04:28Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-22T14:04:28Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-22T14:04:28Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-22T14:04:28Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-22T14:04:28Z]discovery.go:578 func1                                              
INFO[2022-08-22T14:05:28Z]discovery.go:860 activeDiscovery [discoverymgr] activeDiscovery!!!            
INFO[2022-08-22T14:05:28Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-22T14:05:28Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-22T14:05:28Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-22T14:05:28Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-22T14:05:28Z]discovery.go:578 func1                                              
INFO[2022-08-22T14:05:28Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-22T14:05:28Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-22T14:05:28Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-22T14:05:28Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-22T14:05:28Z]discovery.go:578 func1                                              
INFO[2022-08-22T14:06:28Z]discovery.go:860 activeDiscovery [discoverymgr] activeDiscovery!!!            
INFO[2022-08-22T14:06:28Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-22T14:06:28Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-22T14:06:28Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-22T14:06:28Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-22T14:06:28Z]discovery.go:578 func1                                              
INFO[2022-08-22T14:06:28Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-22T14:06:28Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-22T14:06:28Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-22T14:06:28Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-22T14:06:28Z]discovery.go:578 func1                                              
**INFO[2022-08-22T14:07:10Z]internalhandler.go:252 APIV1ScoringmgrScoreLibnameGet [RestInternalInterface] APIV1ScoringmgrScoreLibnameGet 
INFO[2022-08-22T14:07:10Z]route.go:132 func1 From [192.168.1.108:39314] GET /api/v1/scoringmgr/score/edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e APIV1ScoringmgrScoreLibnameGet 19.970377ms** 
INFO[2022-08-22T14:07:28Z]discovery.go:860 activeDiscovery [discoverymgr] activeDiscovery!!!            
INFO[2022-08-22T14:07:28Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-22T14:07:28Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-22T14:07:28Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-22T14:07:28Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-22T14:07:28Z]discovery.go:578 func1                                              
INFO[2022-08-22T14:07:28Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-22T14:07:28Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-22T14:07:28Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-22T14:07:28Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-22T14:07:28Z]discovery.go:578 func1                                  
```

*Test Configuration**:
* OS type & version: (Ubuntu 20.04)
* Hardware: (x86-64)
* Edge Orchestration Release: (v1.1.1)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes