### PR TITLE
Replaced the "os" (ubuntu-18.04) for CI build, test-suite with a newe…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86c, x86_64c, armc, arm64c, x86_64n, x86_64a]
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           context: .
           build-args: TARGETVERSION=v${{ steps.meta.outputs.version }}
-          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2

--- a/configs/defdockerfiles/ubuntu
+++ b/configs/defdockerfiles/ubuntu
@@ -1,7 +1,7 @@
 # Docker image for "edge-orchestration"
-### ubuntu:18.04
+### ubuntu:20.04
 ARG PLATFORM
-FROM $PLATFORM/ubuntu:18.04
+FROM $PLATFORM/ubuntu:20.04
 
 # environment variables
 ENV TARGET_DIR=/edge-orchestration

--- a/configs/defdockerfiles/ubuntu_multistage
+++ b/configs/defdockerfiles/ubuntu_multistage
@@ -1,5 +1,5 @@
 # Docker image for "edge-orchestration"
-FROM --platform=$TARGETPLATFORM ubuntu:18.04 AS builder
+FROM --platform=$TARGETPLATFORM ubuntu:20.04 AS builder
 
 # environment variables
 ARG TARGETPLATFORM
@@ -19,7 +19,7 @@ RUN script/install-golang.sh
 ARG TARGETVERSION
 RUN make buildx_binary VERSION=$TARGETVERSION
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # environment variables
 ENV TARGET_DIR=/edge-orchestration


### PR DESCRIPTION
…r one (ubuntu-20.04)

Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Due to the ubuntu 18.04 is deprecated, it was replaced with ubuntu 20.04 for CI.

Fixes #612 

## Type of change

- [x] CI system update

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 & Go v1.16
* Edge Orchestration Release: v1.1.16

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
