### PR TITLE
[ScoringManager] Change the score API from GET to POST

### DIFF
--- a/internal/orchestrationapi/orchestrationapi.go
+++ b/internal/orchestrationapi/orchestrationapi.go
@@ -355,7 +355,7 @@ func (orcheEngine orcheImpl) gatherDevicesScore(candidates []dbhelper.ExecutionC
 				}
 				score, err = orcheEngine.GetScore(info.Value)
 			} else {
-				score, err = orcheEngine.clientAPI.DoGetScoreRemoteDevice(info.Value, cand.Endpoint[0])
+				score, err = orcheEngine.clientAPI.DoScoreRemoteDevice(info.Value, cand.Endpoint[0])
 			}
 
 			if err != nil {

--- a/internal/orchestrationapi/orchestrationapi_test.go
+++ b/internal/orchestrationapi/orchestrationapi_test.go
@@ -86,9 +86,9 @@ func TestRequestService(t *testing.T) {
 			mockDBHelper.EXPECT().GetDeviceInfoWithService(gomock.Eq(appName), gomock.Any(), gomock.Any()).Return(candidateInfos, nil),
 			mockSystemDBExecutor.EXPECT().Get("id").Return(sysInfo, nil),
 			mockNetwork.EXPECT().GetIPs().Return([]string{""}, nil),
-			mockClient.EXPECT().DoGetScoreRemoteDevice(gomock.Any(), gomock.Any()).Return(scores[0], nil),
-			mockClient.EXPECT().DoGetScoreRemoteDevice(gomock.Any(), gomock.Any()).Return(scores[1], nil),
-			mockClient.EXPECT().DoGetScoreRemoteDevice(gomock.Any(), gomock.Any()).Return(scores[2], nil),
+			mockClient.EXPECT().DoScoreRemoteDevice(gomock.Any(), gomock.Any()).Return(scores[0], nil),
+			mockClient.EXPECT().DoScoreRemoteDevice(gomock.Any(), gomock.Any()).Return(scores[1], nil),
+			mockClient.EXPECT().DoScoreRemoteDevice(gomock.Any(), gomock.Any()).Return(scores[2], nil),
 			mockNetwork.EXPECT().GetIPs().Return([]string{""}, nil),
 			mockService.EXPECT().Execute(gomock.Any(), appName, gomock.Any(), gomock.Any(), gomock.Any()),
 		)

--- a/internal/restinterface/client/client.go
+++ b/internal/restinterface/client/client.go
@@ -31,7 +31,7 @@ type Clienter interface {
 	DoNotifyAppStatusRemoteDevice(statusNotificationInfo map[string]interface{}, appID uint64, target string) (err error)
 
 	// for scoringmgr
-	DoGetScoreRemoteDevice(devID string, endpoint string) (scoreValue float64, err error)
+	DoScoreRemoteDevice(devID string, endpoint string) (scoreValue float64, err error)
 	DoGetResourceRemoteDevice(devID string, endpoint string) (respMsg map[string]interface{}, err error)
 	// for discoverymgr
 	DoGetOrchestrationInfo(endpoint string) (platform string, executionType string, serviceList []string, err error)

--- a/internal/restinterface/client/mocks/mocks_client.go
+++ b/internal/restinterface/client/mocks/mocks_client.go
@@ -99,19 +99,19 @@ func (mr *MockClienterMockRecorder) DoGetResourceRemoteDevice(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoGetResourceRemoteDevice", reflect.TypeOf((*MockClienter)(nil).DoGetResourceRemoteDevice), arg0, arg1)
 }
 
-// DoGetScoreRemoteDevice mocks base method.
-func (m *MockClienter) DoGetScoreRemoteDevice(arg0, arg1 string) (float64, error) {
+// DoScoreRemoteDevice mocks base method.
+func (m *MockClienter) DoScoreRemoteDevice(arg0, arg1 string) (float64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DoGetScoreRemoteDevice", arg0, arg1)
+	ret := m.ctrl.Call(m, "DoScoreRemoteDevice", arg0, arg1)
 	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DoGetScoreRemoteDevice indicates an expected call of DoGetScoreRemoteDevice.
-func (mr *MockClienterMockRecorder) DoGetScoreRemoteDevice(arg0, arg1 interface{}) *gomock.Call {
+// DoScoreRemoteDevice indicates an expected call of DoScoreRemoteDevice.
+func (mr *MockClienterMockRecorder) DoScoreRemoteDevice(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoGetScoreRemoteDevice", reflect.TypeOf((*MockClienter)(nil).DoGetScoreRemoteDevice), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoScoreRemoteDevice", reflect.TypeOf((*MockClienter)(nil).DoScoreRemoteDevice), arg0, arg1)
 }
 
 // DoNotifyAppStatusRemoteDevice mocks base method.

--- a/internal/restinterface/client/restclient/restclient.go
+++ b/internal/restinterface/client/restclient/restclient.go
@@ -21,9 +21,10 @@ package restclient
 import (
 	"errors"
 	"fmt"
-	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 	"net/http"
 	"strings"
+
+	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/cipher"
 	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/client"
@@ -122,9 +123,9 @@ func (c restClientImpl) DoNotifyAppStatusRemoteDevice(statusNotificationInfo map
 	return nil
 }
 
-// DoGetScoreRemoteDevice  sends request to remote orchestration (APIV1ScoringmgrScoreLibnameGet) to get score
-func (c restClientImpl) DoGetScoreRemoteDevice(devID string, endpoint string) (scoreValue float64, err error) {
-	log.Printf("%s DoGetScoreRemoteDevice : endpoint[%v]", logPrefix, endpoint)
+// DoScoreRemoteDevice  sends request to remote orchestration (APIV1ScoringmgrScoreLibnameGet) to get score
+func (c restClientImpl) DoScoreRemoteDevice(devID string, endpoint string) (scoreValue float64, err error) {
+	log.Printf("%s DoScoreRemoteDevice : endpoint[%v]", logPrefix, endpoint)
 	if !c.IsSetKey {
 		return scoreValue, errors.New(logPrefix + " does not set key")
 	}
@@ -140,7 +141,7 @@ func (c restClientImpl) DoGetScoreRemoteDevice(devID string, endpoint string) (s
 		return scoreValue, errors.New(logPrefix + " can not encryption " + err.Error())
 	}
 
-	respBytes, code, err := c.helper.DoGetWithBody(targetURL, encryptBytes)
+	respBytes, code, err := c.helper.DoPost(targetURL, encryptBytes)
 	if err != nil || code != http.StatusOK {
 		return scoreValue, errors.New(logPrefix + " get return error")
 	}

--- a/internal/restinterface/client/restclient/restclient_test.go
+++ b/internal/restinterface/client/restclient/restclient_test.go
@@ -239,7 +239,7 @@ func TestDoNotifyAppStatusRemoteDevice(t *testing.T) {
 	})
 }
 
-func TestDoGetScoreRemoteDevice(t *testing.T) {
+func TestDoScoreRemoteDevice(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -256,22 +256,22 @@ func TestDoGetScoreRemoteDevice(t *testing.T) {
 			client.setHelper(mockHelper)
 
 			client.IsSetKey = false
-			_, err := client.DoGetScoreRemoteDevice("", "")
+			_, err := client.DoScoreRemoteDevice("", "")
 			if err == nil {
 				t.Error("expect error is not nil, but nil")
 			}
 		})
-		t.Run("DoGetWithBody", func(t *testing.T) {
+		t.Run("DoPost", func(t *testing.T) {
 			t.Run("ReturnError", func(t *testing.T) {
 				client.SetCipher(mockCipher)
 				client.setHelper(mockHelper)
 				gomock.InOrder(
 					mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
 					mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, nil),
-					mockHelper.EXPECT().DoGetWithBody(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, errors.New("")),
+					mockHelper.EXPECT().DoPost(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, errors.New("")),
 				)
 
-				_, err := client.DoGetScoreRemoteDevice("", "")
+				_, err := client.DoScoreRemoteDevice("", "")
 				if err == nil {
 					t.Error("expect error is not nil, but nil")
 				}
@@ -282,10 +282,10 @@ func TestDoGetScoreRemoteDevice(t *testing.T) {
 				gomock.InOrder(
 					mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
 					mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, nil),
-					mockHelper.EXPECT().DoGetWithBody(gomock.Any(), gomock.Any()).Return(nil, http.StatusInternalServerError, nil),
+					mockHelper.EXPECT().DoPost(gomock.Any(), gomock.Any()).Return(nil, http.StatusInternalServerError, nil),
 				)
 
-				_, err := client.DoGetScoreRemoteDevice("", "")
+				_, err := client.DoScoreRemoteDevice("", "")
 				if err == nil {
 					t.Error("expect error is not nil, but nil")
 				}
@@ -299,7 +299,7 @@ func TestDoGetScoreRemoteDevice(t *testing.T) {
 				mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, errors.New("")),
 			)
 
-			_, err := client.DoGetScoreRemoteDevice("", "")
+			_, err := client.DoScoreRemoteDevice("", "")
 			if err == nil {
 				t.Error("expect error is not nil, but nil")
 			}
@@ -310,11 +310,11 @@ func TestDoGetScoreRemoteDevice(t *testing.T) {
 			gomock.InOrder(
 				mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
 				mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, nil),
-				mockHelper.EXPECT().DoGetWithBody(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, nil),
+				mockHelper.EXPECT().DoPost(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, nil),
 				mockCipher.EXPECT().DecryptByteToJSON(gomock.Any()).Return(nil, errors.New("")),
 			)
 
-			_, err := client.DoGetScoreRemoteDevice("", "")
+			_, err := client.DoScoreRemoteDevice("", "")
 			if err == nil {
 				t.Error("expect error is not nil, but nil")
 			}
@@ -329,11 +329,11 @@ func TestDoGetScoreRemoteDevice(t *testing.T) {
 			gomock.InOrder(
 				mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
 				mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, nil),
-				mockHelper.EXPECT().DoGetWithBody(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, nil),
+				mockHelper.EXPECT().DoPost(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, nil),
 				mockCipher.EXPECT().DecryptByteToJSON(gomock.Any()).Return(respMsg, nil),
 			)
 
-			_, err := client.DoGetScoreRemoteDevice("", "")
+			_, err := client.DoScoreRemoteDevice("", "")
 			if err == nil {
 				t.Error("expect error is not nil, but nil")
 			}
@@ -350,11 +350,11 @@ func TestDoGetScoreRemoteDevice(t *testing.T) {
 		gomock.InOrder(
 			mockHelper.EXPECT().MakeTargetURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(""),
 			mockCipher.EXPECT().EncryptJSONToByte(gomock.Any()).Return(nil, nil),
-			mockHelper.EXPECT().DoGetWithBody(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, nil),
+			mockHelper.EXPECT().DoPost(gomock.Any(), gomock.Any()).Return(nil, http.StatusOK, nil),
 			mockCipher.EXPECT().DecryptByteToJSON(gomock.Any()).Return(respMsg, nil),
 		)
 
-		score, err := client.DoGetScoreRemoteDevice("", "")
+		score, err := client.DoScoreRemoteDevice("", "")
 		if err != nil {
 			t.Error("expect error is nil, but not nil")
 		} else if score != float64(1.0) {

--- a/internal/restinterface/internalhandler/internalhandler.go
+++ b/internal/restinterface/internalhandler/internalhandler.go
@@ -86,10 +86,10 @@ func init() {
 		},
 
 		restinterface.Route{
-			Name:        "APIV1ScoringmgrScoreLibnameGet",
-			Method:      strings.ToUpper("Get"),
+			Name:        "APIV1ScoringmgrScoreLibnamePost",
+			Method:      strings.ToUpper("Post"),
 			Pattern:     "/api/v1/scoringmgr/score",
-			HandlerFunc: handler.APIV1ScoringmgrScoreLibnameGet,
+			HandlerFunc: handler.APIV1ScoringmgrScoreLibnamePost,
 		},
 
 		restinterface.Route{
@@ -245,9 +245,9 @@ func (h *Handler) APIV1ServicemgrServicesNotificationServiceIDPost(w http.Respon
 	handler.helper.Response(w, nil, http.StatusOK)
 }
 
-// APIV1ScoringmgrScoreLibnameGet handles scoring request from remote orchestration
-func (h *Handler) APIV1ScoringmgrScoreLibnameGet(w http.ResponseWriter, r *http.Request) {
-	log.Info(logPrefix, " APIV1ScoringmgrScoreLibnameGet")
+// APIV1ScoringmgrScoreLibnamePost handles scoring request from remote orchestration
+func (h *Handler) APIV1ScoringmgrScoreLibnamePost(w http.ResponseWriter, r *http.Request) {
+	log.Info(logPrefix, " APIV1ScoringmgrScoreLibnamePost")
 	if !h.isSetAPI {
 		log.Error(logPrefix, doesNotSetAPI)
 		h.helper.Response(w, nil, http.StatusServiceUnavailable)

--- a/internal/restinterface/internalhandler/internalhandler_test.go
+++ b/internal/restinterface/internalhandler/internalhandler_test.go
@@ -273,7 +273,7 @@ func TestAPIV1ScoringmgrScoreLibnameGet(t *testing.T) {
 			mockHelper.EXPECT().Response(gomock.Any(), gomock.Any(), gomock.Eq(http.StatusServiceUnavailable))
 
 			handler.isSetAPI = false
-			handler.APIV1ScoringmgrScoreLibnameGet(w, r)
+			handler.APIV1ScoringmgrScoreLibnamePost(w, r)
 		})
 		t.Run("IsNotSetKey", func(t *testing.T) {
 			handler.SetOrchestrationAPI(mockOrchestration)
@@ -281,7 +281,7 @@ func TestAPIV1ScoringmgrScoreLibnameGet(t *testing.T) {
 			mockHelper.EXPECT().Response(gomock.Any(), gomock.Any(), gomock.Eq(http.StatusServiceUnavailable))
 
 			handler.IsSetKey = false
-			handler.APIV1ScoringmgrScoreLibnameGet(w, r)
+			handler.APIV1ScoringmgrScoreLibnamePost(w, r)
 		})
 		t.Run("DecryptionFail", func(t *testing.T) {
 			handler.SetCipher(mockCipher)
@@ -292,7 +292,7 @@ func TestAPIV1ScoringmgrScoreLibnameGet(t *testing.T) {
 				mockHelper.EXPECT().Response(gomock.Any(), gomock.Any(), gomock.Eq(http.StatusServiceUnavailable)),
 			)
 
-			handler.APIV1ScoringmgrScoreLibnameGet(w, r)
+			handler.APIV1ScoringmgrScoreLibnamePost(w, r)
 		})
 		t.Run("GetScoreFail", func(t *testing.T) {
 			handler.SetCipher(mockCipher)
@@ -304,7 +304,7 @@ func TestAPIV1ScoringmgrScoreLibnameGet(t *testing.T) {
 				mockHelper.EXPECT().Response(gomock.Any(), gomock.Any(), gomock.Eq(http.StatusInternalServerError)),
 			)
 
-			handler.APIV1ScoringmgrScoreLibnameGet(w, r)
+			handler.APIV1ScoringmgrScoreLibnamePost(w, r)
 		})
 		t.Run("EncryptionFail", func(t *testing.T) {
 			handler.SetCipher(mockCipher)
@@ -317,7 +317,7 @@ func TestAPIV1ScoringmgrScoreLibnameGet(t *testing.T) {
 				mockHelper.EXPECT().Response(gomock.Any(), gomock.Any(), gomock.Eq(http.StatusServiceUnavailable)),
 			)
 
-			handler.APIV1ScoringmgrScoreLibnameGet(w, r)
+			handler.APIV1ScoringmgrScoreLibnamePost(w, r)
 		})
 	})
 
@@ -332,7 +332,7 @@ func TestAPIV1ScoringmgrScoreLibnameGet(t *testing.T) {
 			mockHelper.EXPECT().Response(gomock.Any(), gomock.Any(), gomock.Eq(http.StatusOK)),
 		)
 
-		handler.APIV1ScoringmgrScoreLibnameGet(w, r)
+		handler.APIV1ScoringmgrScoreLibnamePost(w, r)
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Nitu Gupta <nitu.gupta@samsung.com>

# Description

API to get score required a request body with id of the device. But GET request body adds no meaning and the ID of the devices has to be passed in encrypted form for secure mode. So the API is changed method from GET to POST

API is
http://{IP of the device which will calculate score}:56002/scoringmgr/score

Fixes #610 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Start the Edge Orchestration and run the following curl command to execute the hello-world coontainer. This API will internally calculate the score and display on the terminal
Example
```
curl -X POST "127.0.0.1:56001/api/v1/orchestration/services" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: $EDGE_ORCHESTRATION_TOKEN" -d "{ \"ServiceName\": \"hello-world\", \"ServiceInfo\": [{ \"ExecutionType\": \"container\", \"ExecCmd\": [ \"docker\", \"run\", \"-v\", \"/var/run:/var/run:rw\", \"hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752\"]}]}"
```
Response Generated is 
```
{"Message":"ERROR_NONE","RemoteTargetInfo":{"ExecutionType":"container","Target":"192.168.1.108"},"ServiceName":"hello-world"}
```
2. The logs generated for Edge-Orchestration is 
```
INFO[2022-08-25T06:28:19Z]externalhandler.go:123 APIV1RequestServicePost [RestExternalInterface] APIV1RequestServicePost 
INFO[2022-08-25T06:28:19Z]externalhandler.go:187 APIV1RequestServicePost [RestExternalInterface] port: 59332          
INFO[2022-08-25T06:28:19Z]externalhandler.go:192 APIV1RequestServicePost [RestExternalInterface] requester: curl      
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:153 RequestService [RequestService] hello-world: [{container [docker run -v /var/run:/var/run:rw hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752] map[]}] 
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:183 RequestService [RequestService] getCandidate                
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:185 RequestService [0] ID       : edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:186 RequestService [0] ExecType : container                     
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:187 RequestService [0] Endpoint : [192.168.1.108]               
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:188 RequestService                                              
INFO[2022-08-25T06:28:19Z]restclient.go:128 DoScoreRemoteDevice [restclient] DoScoreRemoteDevice : endpoint[192.168.1.108] 
INFO[2022-08-25T06:28:19Z]internalhandler.go:250 APIV1ScoringmgrScoreLibnamePost [RestInternalInterface] APIV1ScoringmgrScoreLibnamePost 
INFO[2022-08-25T06:28:19Z]route.go:132 func1 From [192.168.1.108:52548] POST /api/v1/scoringmgr/score APIV1ScoringmgrScoreLibnamePost 546.237µs 
INFO[2022-08-25T06:28:19Z]restclient.go:153 DoScoreRemoteDevice [restclient] respMsg From [192.168.1.108] : map[ScoreValue:10.002320359566955] 
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:367 func3 [orchestrationapi] deviceScore               
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:368 func3 candidate ID       : edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:369 func3 candidate ExecType : container               
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:370 func3 candidate Endpoint : 192.168.1.108           
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:371 func3 candidate score    : 10.002320359566955      
INFO[2022-08-25T06:28:19Z]orchestrationapi.go:273 RequestService [orchestrationapi]  [{edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 192.168.1.108 10.002320359566955 map[] container}] 
INFO[2022-08-25T06:28:19Z]route.go:132 func1 From [127.0.0.1:59332] POST /api/v1/orchestration/services APIV1RequestServicePost 64.3596ms 
INFO[2022-08-25T06:28:19Z]containerexecutor.go:71 Execute [containerexecutor] hello-world docker run -v /var/run:/var/run:rw -e REQUEST=192.168.1.108 hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752 
INFO[2022-08-25T06:28:19Z]containerexecutor.go:72 Execute [containerexecutor] parameter length : 7     
{"status":"Pulling from library/hello-world","id":"docker.io/library/hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"}
{"status":"Digest: sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"}
{"status":"Status: Image is up to date for hello-world@sha256:fc6a51919cfeb2e6763f62b6d9e8815acbf7cd2e476ea353743570610737b752"}
INFO[2022-08-25T06:28:23Z]containerexecutor.go:92 Execute [containerexecutor] create container : 76908c62ff 
2022-08-25T06:28:24.446297368Z 
2022-08-25T06:28:24.446397835Z Hello from Docker!
2022-08-25T06:28:24.446424951Z This message shows that your installation appears to be working correctly.
2022-08-25T06:28:24.446446793Z 
2022-08-25T06:28:24.446466092Z To generate this message, Docker took the following steps:
2022-08-25T06:28:24.446485874Z  1. The Docker client contacted the Docker daemon.
2022-08-25T06:28:24.446505724Z  2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
2022-08-25T06:28:24.446526431Z     (amd64)
2022-08-25T06:28:24.446545426Z  3. The Docker daemon created a new container from that image which runs the
2022-08-25T06:28:24.446565317Z     executable that produces the output you are currently reading.
2022-08-25T06:28:24.446585026Z  4. The Docker daemon streamed that output to the Docker client, which sent it
2022-08-25T06:28:24.446605098Z     to your terminal.
2022-08-25T06:28:24.446624185Z 
2022-08-25T06:28:24.446643065Z To try something more ambitious, you can run an Ubuntu container with:
2022-08-25T06:28:24.446662787Z  $ docker run -it ubuntu bash
2022-08-25T06:28:24.446682589Z 
2022-08-25T06:28:24.446701493Z Share images, automate workflows, and more with a free Docker ID:
2022-08-25T06:28:24.446721065Z  https://hub.docker.com/
2022-08-25T06:28:24.446740065Z 
2022-08-25T06:28:24.446759416Z For more examples and ideas, visit:
2022-08-25T06:28:24.446779138Z  https://docs.docker.com/get-started/
2022-08-25T06:28:24.446798260Z 
INFO[2022-08-25T06:28:26Z]containerexecutor.go:118 Execute [containerexecutor] container execution status : 0 
INFO[2022-08-25T06:28:26Z]orchestrationapi.go:475 listenNotify [orchestrationapi] service status changed [appNames:hello-world][status:Finished] 
INFO[2022-08-25T06:28:44Z]discovery.go:860 activeDiscovery [discoverymgr] activeDiscovery!!!            
INFO[2022-08-25T06:28:44Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-25T06:28:44Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-25T06:28:44Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-25T06:28:44Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-25T06:28:44Z]discovery.go:578 func1                                              
INFO[2022-08-25T06:28:44Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-25T06:28:44Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-25T06:28:44Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-25T06:28:44Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-25T06:28:44Z]discovery.go:578 func1                                              
INFO[2022-08-25T06:29:44Z]discovery.go:860 activeDiscovery [discoverymgr] activeDiscovery!!!            
INFO[2022-08-25T06:29:44Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-25T06:29:44Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-25T06:29:44Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-25T06:29:44Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-25T06:29:44Z]discovery.go:578 func1                                              
INFO[2022-08-25T06:29:44Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-25T06:29:44Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-25T06:29:44Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-25T06:29:44Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-25T06:29:44Z]discovery.go:578 func1                                              
INFO[2022-08-25T06:30:44Z]discovery.go:860 activeDiscovery [discoverymgr] activeDiscovery!!!            
INFO[2022-08-25T06:30:44Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-25T06:30:44Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-25T06:30:44Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-25T06:30:44Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-25T06:30:44Z]discovery.go:578 func1                                              
INFO[2022-08-25T06:30:44Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-25T06:30:44Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-25T06:30:44Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-25T06:30:44Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
INFO[2022-08-25T06:30:44Z]discovery.go:578 func1                                              
INFO[2022-08-25T06:31:44Z]discovery.go:860 activeDiscovery [discoverymgr] activeDiscovery!!!            
INFO[2022-08-25T06:31:44Z]discovery.go:574 func1 [deviceDetectionRoutine] edge-orchestration-314b6cd6-a8af-46ea-a3a8-452495c8b02e 
INFO[2022-08-25T06:31:44Z]discovery.go:575 func1 [deviceDetectionRoutine] confInfo    : ExecType(container), Platform(docker) 
INFO[2022-08-25T06:31:44Z]discovery.go:576 func1 [deviceDetectionRoutine] netInfo     : IPv4([192.168.1.108]), RTT(0) 
INFO[2022-08-25T06:31:44Z]discovery.go:577 func1 [deviceDetectionRoutine] serviceInfo : Services([AISER DataStorage TEST]) 
````
**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64 (e.g., x86, x86-64, arm, arm64)
* Toolchain: Docker v20.10 & Go v1.16
* Edge Orchestration Release: v1.1.1

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
