### PR TITLE
Fix staticcheck warnings

### DIFF
--- a/internal/common/mqtt/mqttconfig.go
+++ b/internal/common/mqtt/mqttconfig.go
@@ -22,7 +22,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+
+	// "io/ioutil"
+
 	"os"
 	"strings"
 	"sync"
@@ -158,7 +160,7 @@ func checkforConnection(brokerURL string, mqttClient *Client, mqttPort uint) int
 
 // NewTLSConfig creates a tls config for mqtt client
 func NewTLSConfig(certsPath string) (*tls.Config, error) {
-	caCertPEM, err := ioutil.ReadFile(certsPath + "/ca-crt.pem")
+	caCertPEM, err := os.ReadFile(certsPath + "/ca-crt.pem")
 	if err != nil {
 		log.Panic(logPrefix, err.Error())
 		return nil, err

--- a/internal/common/mqtt/mqttconnection_test.go
+++ b/internal/common/mqtt/mqttconnection_test.go
@@ -17,7 +17,6 @@
 package mqtt
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -134,7 +133,7 @@ func TestNewTLSConfig(t *testing.T) {
 				t.Error(err.Error())
 			}
 
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte("hello"), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte("hello"), 0444); err != nil {
 				t.Error(err.Error())
 			}
 
@@ -155,7 +154,7 @@ func TestNewTLSConfig(t *testing.T) {
 				t.Error(err.Error())
 			}
 
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 				t.Error(err.Error())
 			}
 
@@ -172,14 +171,14 @@ func TestNewTLSConfig(t *testing.T) {
 			t.Error(err.Error())
 		}
 
-		if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 			t.Error(err.Error())
 		}
 
-		if err := ioutil.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
 			t.Error(err.Error())
 		}
-		if err := ioutil.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
 			t.Error(err.Error())
 		}
 		if _, err := NewTLSConfig(fakeCertsPath); err != nil {

--- a/internal/common/requestervalidator/requesterstore/requesterstore.go
+++ b/internal/common/requestervalidator/requesterstore/requesterstore.go
@@ -61,7 +61,5 @@ func (r *requesters) StoreRequesterInfo(serviceName string, requesters []string)
 	defer r.mutex.Unlock()
 
 	r.requesterInfos[serviceName] = make([]string, len(requesters))
-	for idx, req := range requesters {
-		r.requesterInfos[serviceName][idx] = req
-	}
+	copy(r.requesterInfos[serviceName], requesters)
 }

--- a/internal/controller/configuremgr/configuremgr.go
+++ b/internal/controller/configuremgr/configuremgr.go
@@ -21,7 +21,6 @@ package configuremgr
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,7 +84,7 @@ func (cfgMgr ConfigureMgr) SetConfigPath(configPath string) error {
 // Watch implements Watcher interface with ConfigureMgr struct
 func (cfgMgr ConfigureMgr) Watch(notifier Notifier) {
 	// logic for already installed configuration
-	files, err := ioutil.ReadDir(cfgMgr.confpath)
+	files, err := os.ReadDir(cfgMgr.confpath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/controller/configuremgr/configuremgr_test.go
+++ b/internal/controller/configuremgr/configuremgr_test.go
@@ -18,7 +18,6 @@
 package configuremgr
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,8 +81,7 @@ func TestBasicMockConfigureMgr(t *testing.T) {
 	os.Mkdir(defaultConfPath, 0775)
 	defer os.RemoveAll(defaultConfPath)
 
-	var contextNoti Notifier
-	contextNoti = new(dummyNoti)
+	var contextNoti Notifier = new(dummyNoti)
 	src := "testdata/score"
 
 	t.Run("Success", func(t *testing.T) {
@@ -98,13 +96,13 @@ func TestBasicMockConfigureMgr(t *testing.T) {
 		if err != nil {
 			t.Errorf(err.Error())
 		} else {
-			files, err := ioutil.ReadDir(src)
+			files, err := os.ReadDir(src)
 			if err != nil {
 				t.Error(err.Error())
 			}
 			for _, file := range files {
-				fileContent, _ := ioutil.ReadFile(filepath.Join(src, file.Name()))
-				err = ioutil.WriteFile(filepath.Join(dir, file.Name()), []byte(fileContent), 0664)
+				fileContent, _ := os.ReadFile(filepath.Join(src, file.Name()))
+				err = os.WriteFile(filepath.Join(dir, file.Name()), []byte(fileContent), 0664)
 				if err != nil {
 					t.Errorf(err.Error())
 				}

--- a/internal/controller/discoverymgr/discovery.go
+++ b/internal/controller/discoverymgr/discovery.go
@@ -18,7 +18,6 @@
 package discoverymgr
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -381,7 +380,7 @@ func detectNetworkChgRoutine() {
 
 func setDeviceID(UUIDPath string) (UUIDstr string, err error) {
 
-	UUIDv4, err := ioutil.ReadFile(UUIDPath)
+	UUIDv4, err := os.ReadFile(UUIDPath)
 
 	if err != nil {
 		log.Println(logPrefix, "No saved UUID : ", err)
@@ -389,7 +388,7 @@ func setDeviceID(UUIDPath string) (UUIDstr string, err error) {
 
 		UUIDstr = UUIDv4New.String()
 
-		err = ioutil.WriteFile(UUIDPath, []byte(UUIDstr), 0644)
+		err = os.WriteFile(UUIDPath, []byte(UUIDstr), 0644)
 		if err != nil {
 			log.Println(logPrefix, "Error Write UUID : ", err)
 		}
@@ -875,7 +874,7 @@ func getServiceFromEnv() string {
 // getMNEDCServerAddress fetches the IP and Port of the server
 func getMNEDCServerAddress(path string) (string, string, error) {
 	c := serverConf{}
-	yamlFile, err := ioutil.ReadFile(path)
+	yamlFile, err := os.ReadFile(path)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/controller/discoverymgr/mnedc/client/client.go
+++ b/internal/controller/discoverymgr/mnedc/client/client.go
@@ -19,8 +19,8 @@ package client
 
 import (
 	"errors"
-	"io/ioutil"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -482,7 +482,7 @@ func (c *Client) SetClient(clientAPI restclient.Clienter) {
 // getMNEDCServerAddress fetches the IP and Port of the server
 func getMNEDCServerAddress(path string) (string, string, error) {
 	c := serverConf{}
-	yamlFile, err := ioutil.ReadFile(path)
+	yamlFile, err := os.ReadFile(path)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/controller/discoverymgr/mnedc/clientcontrol.go
+++ b/internal/controller/discoverymgr/mnedc/clientcontrol.go
@@ -18,9 +18,10 @@
 package mnedcmgr
 
 import (
-	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/tls"
-	"io/ioutil"
+	"os"
 	"time"
+
+	"github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/tls"
 
 	restclient "github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/client"
 	//"controller/discoverymgr"
@@ -98,7 +99,7 @@ func (c *ClientImpl) SetClient(clientAPI restclient.Clienter) {
 
 func getDeviceID(path string) (string, error) {
 	logPrefix := "[GetDeviceID]"
-	UUIDv4, err := ioutil.ReadFile(path)
+	UUIDv4, err := os.ReadFile(path)
 
 	if err != nil {
 		log.Println(logPrefix, "No saved UUID : ", err.Error())

--- a/internal/controller/discoverymgr/mnedc/connectionutil/networkconnectionutil.go
+++ b/internal/controller/discoverymgr/mnedc/connectionutil/networkconnectionutil.go
@@ -21,8 +21,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 )
@@ -46,7 +46,7 @@ func init() {
 }
 
 func createClientConfig() (*tls.Config, error) {
-	caCertPEM, err := ioutil.ReadFile(caCert)
+	caCertPEM, err := os.ReadFile(caCert)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func createClientConfig() (*tls.Config, error) {
 }
 
 func createServerConfig() (*tls.Config, error) {
-	caCertPEM, err := ioutil.ReadFile(caCert)
+	caCertPEM, err := os.ReadFile(caCert)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/discoverymgr/mnedc/servercontrol.go
+++ b/internal/controller/discoverymgr/mnedc/servercontrol.go
@@ -18,7 +18,7 @@
 package mnedcmgr
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -100,7 +100,7 @@ func startMNEDCBroadcastServer() {
 func handleClientInfo(w http.ResponseWriter, r *http.Request) {
 	log.Println("Registered")
 
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 	Info, err := serverIns.Key.DecryptByteToJSON(encryptBytes)
 
 	if err != nil {

--- a/internal/controller/securemgr/authenticator/authenticator.go
+++ b/internal/controller/securemgr/authenticator/authenticator.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -80,17 +79,17 @@ func Init(passPhraseJWTPath string) {
 	passPhraseJWTFilePath = passPhraseJWTPath + "/" + passPhraseJWTFileName
 
 	var err error
-	passphrase, err = ioutil.ReadFile(passPhraseJWTFilePath)
+	passphrase, err = os.ReadFile(passPhraseJWTFilePath)
 	if err != nil {
 		rand.Seed(time.Now().UnixNano())
 		passphrase = []byte(randString(16))
-		err = ioutil.WriteFile(passPhraseJWTFilePath, passphrase, 0666)
+		err = os.WriteFile(passPhraseJWTFilePath, passphrase, 0666)
 		if err != nil {
 			log.Error(logPrefix, "Cannot create passPhraseJWT.txt: ", err)
 		}
 	}
 
-	verifyBytes, err := ioutil.ReadFile(passPhraseJWTPath + "/" + pubKeyPath)
+	verifyBytes, err := os.ReadFile(passPhraseJWTPath + "/" + pubKeyPath)
 	if err != nil {
 		log.Error(logPrefix, err)
 	} else {

--- a/internal/controller/securemgr/authenticator/authenticator_test.go
+++ b/internal/controller/securemgr/authenticator/authenticator_test.go
@@ -17,7 +17,6 @@
 package authenticator
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -67,14 +66,14 @@ func TestInit(t *testing.T) {
 			t.Error(err.Error())
 		}
 
-		err := ioutil.WriteFile(fakejwtPath+"/"+pubKeyPath, []byte(fakejwtpubKey), 0666)
+		err := os.WriteFile(fakejwtPath+"/"+pubKeyPath, []byte(fakejwtpubKey), 0666)
 		if err != nil {
 			t.Error(err.Error())
 		}
 		Init(fakejwtPath)
 		os.RemoveAll(fakejwtPath + "/" + pubKeyPath)
 
-		err = ioutil.WriteFile(fakejwtPath+"/"+pubKeyPath, []byte(""), 0666)
+		err = os.WriteFile(fakejwtPath+"/"+pubKeyPath, []byte(""), 0666)
 		if err != nil {
 			t.Error(err.Error())
 		}

--- a/internal/controller/securemgr/authorizer/authorizer.go
+++ b/internal/controller/securemgr/authorizer/authorizer.go
@@ -20,7 +20,6 @@ package authorizer
 
 import (
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -93,7 +92,7 @@ func Init(rbacRulePath string) {
 	}
 	rbacPolicyFilePath = rbacRulePath + "/" + rbacPolicyFileName
 	if _, err := os.Stat(rbacPolicyFilePath); err != nil {
-		err = ioutil.WriteFile(rbacPolicyFilePath, []byte(policyTemplate), 0664)
+		err = os.WriteFile(rbacPolicyFilePath, []byte(policyTemplate), 0664)
 		if err != nil {
 			log.Panic(logPrefix, "Cannot create ", rbacPolicyFilePath, ": ", err)
 		}
@@ -101,7 +100,7 @@ func Init(rbacRulePath string) {
 
 	rbacAuthModelFilePath = rbacRulePath + "/" + rbacAuthModelFileName
 	if _, err := os.Stat(rbacAuthModelFilePath); err != nil {
-		err = ioutil.WriteFile(rbacAuthModelFilePath, []byte(authModelTemplate), 0664)
+		err = os.WriteFile(rbacAuthModelFilePath, []byte(authModelTemplate), 0664)
 		if err != nil {
 			log.Panic(logPrefix, "Cannot create ", rbacAuthModelFilePath, ": ", err)
 		}

--- a/internal/controller/securemgr/verifier/verifier.go
+++ b/internal/controller/securemgr/verifier/verifier.go
@@ -20,7 +20,6 @@ package verifier
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -82,10 +81,10 @@ func init() {
 // initContainerWhiteList fills the containerWhiteList by reading the information
 // from the file if it exists or creates it otherwise
 func initContainerWhiteList() error {
-	fileContent, err := ioutil.ReadFile(cwlFilePath)
+	fileContent, err := os.ReadFile(cwlFilePath)
 	if err != nil {
 		containerWhiteList = nil
-		err = ioutil.WriteFile(cwlFilePath, []byte(""), 0666)
+		err = os.WriteFile(cwlFilePath, []byte(""), 0666)
 		if err != nil {
 			log.Error(logPrefix, cannotCreateFile, cwlFileName, ": ", err)
 		}
@@ -152,10 +151,10 @@ func (VerificationImpl) ContainerIsInWhiteList(containerName string) error {
 // addHashToContainerWhiteList add the hash to containerWhiteList
 // if it exists then ignore this command
 func addHashToContainerWhiteList(hash string) error {
-	fileContent, err := ioutil.ReadFile(cwlFilePath)
+	fileContent, err := os.ReadFile(cwlFilePath)
 	if err != nil {
 		fileContentStr := hash + "\n"
-		err = ioutil.WriteFile(cwlFilePath, []byte(fileContentStr), 0666)
+		err = os.WriteFile(cwlFilePath, []byte(fileContentStr), 0666)
 		if err != nil {
 			log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 			return err
@@ -175,7 +174,7 @@ func addHashToContainerWhiteList(hash string) error {
 			}
 		}
 		fileContentStr = fileContentStr + hash + "\n"
-		err = ioutil.WriteFile(cwlFilePath, []byte(fileContentStr), 0666)
+		err = os.WriteFile(cwlFilePath, []byte(fileContentStr), 0666)
 		if err != nil {
 			log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 			return err
@@ -188,9 +187,9 @@ func addHashToContainerWhiteList(hash string) error {
 // delHashFromContainerWhiteList deletes the hash from containerWhiteList file,
 // if hash is absent then ignore this command
 func delHashFromContainerWhiteList(hash string) error {
-	fileContent, err := ioutil.ReadFile(cwlFilePath)
+	fileContent, err := os.ReadFile(cwlFilePath)
 	if err != nil {
-		err = ioutil.WriteFile(cwlFilePath, []byte(""), 0666)
+		err = os.WriteFile(cwlFilePath, []byte(""), 0666)
 		if err != nil {
 			log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 			return err
@@ -203,7 +202,7 @@ func delHashFromContainerWhiteList(hash string) error {
 			return nil
 		}
 		fileContentStr = fileContentStr[:digestIndex] + fileContentStr[digestIndex+65:]
-		err = ioutil.WriteFile(cwlFilePath, []byte(fileContentStr), 0666)
+		err = os.WriteFile(cwlFilePath, []byte(fileContentStr), 0666)
 		if err != nil {
 			log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 			return err
@@ -219,7 +218,7 @@ func delHashFromContainerWhiteList(hash string) error {
 
 // delAllHashFromContainerWhiteList deletes all hashes from containerWhiteList file
 func delAllHashFromContainerWhiteList() error {
-	err := ioutil.WriteFile(cwlFilePath, []byte(""), 0666)
+	err := os.WriteFile(cwlFilePath, []byte(""), 0666)
 	if err != nil {
 		log.Error(logPrefix, cannotCreateFile, cwlFileName, err)
 		return err

--- a/internal/controller/servicemgr/executor/containerexecutor/config.go
+++ b/internal/controller/servicemgr/executor/containerexecutor/config.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"regexp"
@@ -841,7 +841,7 @@ func parseSecurityOpts(securityOpts []string) ([]string, error) {
 			}
 		}
 		if con[0] == "seccomp" && con[1] != "unconfined" {
-			f, err := ioutil.ReadFile(con[1])
+			f, err := os.ReadFile(con[1])
 			if err != nil {
 				return securityOpts, errors.Errorf("opening seccomp profile (%s) failed: %v", con[1], err)
 			}

--- a/internal/controller/servicemgr/executor/containerexecutor/config_test.go
+++ b/internal/controller/servicemgr/executor/containerexecutor/config_test.go
@@ -20,7 +20,7 @@ package containerexecutor
 // @Note : Reference - github.com/docker/cli/cli/command/container/opts_test.go @v19.03.14
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -76,7 +76,7 @@ func parseRun(args []string) (*container.Config, *container.HostConfig, *network
 
 func setupRunFlags() (*pflag.FlagSet, *containerOptions) {
 	flags := pflag.NewFlagSet("run", pflag.ContinueOnError)
-	flags.SetOutput(ioutil.Discard)
+	flags.SetOutput(io.Discard)
 	flags.Usage = nil
 	copts := addFlags(flags)
 	return flags, copts

--- a/internal/controller/servicemgr/executor/containerexecutor/containerexecutor_test.go
+++ b/internal/controller/servicemgr/executor/containerexecutor/containerexecutor_test.go
@@ -19,7 +19,7 @@ package containerexecutor
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 	"sync"
@@ -69,7 +69,7 @@ var (
 	errCh      = make(chan error)
 
 	reader     = strings.NewReader("Hello,World")
-	readCloser = ioutil.NopCloser(reader)
+	readCloser = io.NopCloser(reader)
 )
 
 func initializeMock(t *testing.T) (*mocks.MockCEImpl, *notificationMock.MockNotification, *clientApiMock.MockClienter) {

--- a/internal/controller/storagemgr/config/toml_test.go
+++ b/internal/controller/storagemgr/config/toml_test.go
@@ -18,7 +18,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -38,7 +37,7 @@ func createMockFile() {
 
 	b, err := TomlMarshal()
 	if err == nil {
-		ioutil.WriteFile(testFilePath, b, 0644)
+		os.WriteFile(testFilePath, b, 0644)
 	}
 }
 

--- a/internal/controller/storagemgr/storage.go
+++ b/internal/controller/storagemgr/storage.go
@@ -19,7 +19,6 @@ package storagemgr
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -156,7 +155,7 @@ func saveToml(host string) (err error) {
 
 	b, err := config.TomlMarshal()
 	if err == nil {
-		err = ioutil.WriteFile(dataStorageConfFolder+"/configuration.toml", b, 0644)
+		err = os.WriteFile(dataStorageConfFolder+"/configuration.toml", b, 0644)
 	}
 	return
 }
@@ -237,7 +236,7 @@ func saveYaml() (err error) {
 	config.SetYaml(deviceName, manufacture, model, description, label, resource)
 	b, err := config.YamlMarshal()
 	if err == nil {
-		err = ioutil.WriteFile(dataStorageConfFolder+"/datastorage-device.yaml", b, 0644)
+		err = os.WriteFile(dataStorageConfFolder+"/datastorage-device.yaml", b, 0644)
 	}
 	return
 }

--- a/internal/controller/storagemgr/storagedriver/storagehandler.go
+++ b/internal/controller/storagemgr/storagedriver/storagehandler.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"time"
@@ -191,7 +191,7 @@ func (handler StorageHandler) addEvent(writer http.ResponseWriter, request *http
 	}
 
 	requestURL := handler.helper.MakeTargetURL(serverIP, readingPort, readingAPI)
-	reqBody, err := ioutil.ReadAll(request.Body)
+	reqBody, err := io.ReadAll(request.Body)
 	if err != nil {
 		http.Error(writer, "Error in getting body", http.StatusBadRequest)
 	}
@@ -323,7 +323,7 @@ func (handler StorageHandler) readBodyAsString(request *http.Request) (string, e
 	}
 
 	defer request.Body.Close()
-	body, err := ioutil.ReadAll(request.Body)
+	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		return "", err
 	}
@@ -341,7 +341,7 @@ func (handler StorageHandler) readBodyAsBinary(request *http.Request) ([]byte, e
 	}
 
 	defer request.Body.Close()
-	body, err := ioutil.ReadAll(request.Body)
+	body, err := io.ReadAll(request.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/restinterface/cipher/dummy/cipherDummy.go
+++ b/internal/restinterface/cipher/dummy/cipherDummy.go
@@ -21,7 +21,7 @@ package dummy
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 
@@ -40,7 +40,7 @@ var (
 // GetCipher set passphrase for ciphering
 func GetCipher(cipherKeyFilePath string) c.IEdgeCipherer {
 	dummyCipher := new(Cipher)
-	passphrase, err := ioutil.ReadFile(cipherKeyFilePath)
+	passphrase, err := os.ReadFile(cipherKeyFilePath)
 	if err != nil {
 		dummyCipher.passphrase = []byte{}
 		log.Info("can't read passphrase key from keyFilePath - ", err)

--- a/internal/restinterface/cipher/dummy/cipher_test.go
+++ b/internal/restinterface/cipher/dummy/cipher_test.go
@@ -19,7 +19,6 @@ package dummy
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -35,7 +34,7 @@ func TestGetCipher(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		defer os.RemoveAll(fakeCipherKeyFile)
 
-		err := ioutil.WriteFile(fakeCipherKeyFile, []byte("edge-orchestration"), 0666)
+		err := os.WriteFile(fakeCipherKeyFile, []byte("edge-orchestration"), 0666)
 		if err != nil {
 			t.Error(err.Error())
 		}

--- a/internal/restinterface/cipher/sha256/cipherSHA256.go
+++ b/internal/restinterface/cipher/sha256/cipherSHA256.go
@@ -27,7 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 
@@ -46,7 +46,7 @@ var (
 // GetCipher set passphrase for ciphering
 func GetCipher(cipherKeyFilePath string) c.IEdgeCipherer {
 	SHA256Cipher := new(Cipher)
-	passphrase, err := ioutil.ReadFile(cipherKeyFilePath)
+	passphrase, err := os.ReadFile(cipherKeyFilePath)
 	if err != nil {
 		SHA256Cipher.passphrase = []byte{}
 		log.Println("len :", len(SHA256Cipher.passphrase))

--- a/internal/restinterface/cipher/sha256/cipher_test.go
+++ b/internal/restinterface/cipher/sha256/cipher_test.go
@@ -18,7 +18,6 @@ package sha256
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -36,7 +35,7 @@ func TestGetCipher(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		defer os.RemoveAll(fakeCipherKeyFile)
 
-		err := ioutil.WriteFile(fakeCipherKeyFile, []byte("edge-orchestration"), 0666)
+		err := os.WriteFile(fakeCipherKeyFile, []byte("edge-orchestration"), 0666)
 		if err != nil {
 			t.Error(err.Error())
 		}

--- a/internal/restinterface/externalhandler/externalhandler.go
+++ b/internal/restinterface/externalhandler/externalhandler.go
@@ -19,7 +19,7 @@
 package externalhandler
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -162,7 +162,7 @@ func (h *Handler) APIV1RequestServicePost(w http.ResponseWriter, r *http.Request
 	)
 
 	//request
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 
 	appCommand, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
@@ -310,7 +310,7 @@ func (h *Handler) APIV1RequestSecuremgrPost(w http.ResponseWriter, r *http.Reque
 	)
 
 	//request
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 
 	appCommand, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
@@ -426,7 +426,7 @@ func (h *Handler) APIV1RequestCloudSyncmgrPublish(w http.ResponseWriter, r *http
 	)
 
 	//request
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 
 	//Decrypt the request in json format
 	appCommand, err := h.Key.DecryptByteToJSON(encryptBytes)
@@ -512,7 +512,7 @@ func (h *Handler) APIV1RequestCloudSyncmgrSubscribe(w http.ResponseWriter, r *ht
 	)
 
 	//request
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 
 	//Decrypt the request in json format
 	appCommand, err := h.Key.DecryptByteToJSON(encryptBytes)

--- a/internal/restinterface/externalhandler/senderresolver/senderresolver.go
+++ b/internal/restinterface/externalhandler/senderresolver/senderresolver.go
@@ -19,7 +19,6 @@ package senderresolver
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -81,7 +80,7 @@ func GetNameByPort(port int64) (string, error) {
 }
 
 func getData() ([]string, error) {
-	data, err := ioutil.ReadFile(procNetTCP)
+	data, err := os.ReadFile(procNetTCP)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +102,7 @@ func removeEmpty(array []string) []string {
 func getProcess(pid string) (string, error) {
 	fp := processInfoPath + "/" + pid + "/comm"
 
-	data, err := ioutil.ReadFile(fp)
+	data, err := os.ReadFile(fp)
 	if err != nil {
 		return "", err
 	}

--- a/internal/restinterface/externalhandler/senderresolver/senderresolver_test.go
+++ b/internal/restinterface/externalhandler/senderresolver/senderresolver_test.go
@@ -18,7 +18,6 @@
 package senderresolver
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -166,7 +165,7 @@ func TestGetNameByPort(t *testing.T) {
 		}
 
 		procNetTCP = fakeProcNetTCP
-		err = ioutil.WriteFile(procNetTCP, []byte(test), 0644)
+		err = os.WriteFile(procNetTCP, []byte(test), 0644)
 		if err != nil {
 			t.Error(unexpectedError, err.Error())
 		}
@@ -176,7 +175,7 @@ func TestGetNameByPort(t *testing.T) {
 			t.Error(unexpectedSuccess)
 		}
 
-		err = ioutil.WriteFile(procNetTCP, []byte(test1), 0644)
+		err = os.WriteFile(procNetTCP, []byte(test1), 0644)
 		if err != nil {
 			t.Error(unexpectedError, err.Error())
 		}

--- a/internal/restinterface/internalhandler/internalhandler.go
+++ b/internal/restinterface/internalhandler/internalhandler.go
@@ -20,7 +20,7 @@ package internalhandler
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -134,8 +134,7 @@ func (h *Handler) SetCertificateFilePath(path string) {
 
 // APIV1Ping handles ping request from remote orchestration
 func (h *Handler) APIV1Ping(w http.ResponseWriter, r *http.Request) {
-	var responseBytes []byte
-	responseBytes = []byte("Pong\n")
+	var responseBytes = []byte("Pong\n")
 	h.helper.Response(w, responseBytes, http.StatusOK)
 }
 
@@ -153,7 +152,7 @@ func (h *Handler) APIV1ServicemgrServicesPost(w http.ResponseWriter, r *http.Req
 	}
 
 	remoteAddr, _, _ := net.SplitHostPort(r.RemoteAddr)
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 
 	appInfo, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
@@ -224,7 +223,7 @@ func (h *Handler) APIV1ServicemgrServicesNotificationServiceIDPost(w http.Respon
 		return
 	}
 
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 
 	statusNotification, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
@@ -258,7 +257,7 @@ func (h *Handler) APIV1ScoringmgrScoreLibnamePost(w http.ResponseWriter, r *http
 		return
 	}
 
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 	Info, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
 		log.Error(logPrefix, cannotDecryption, err.Error())
@@ -301,7 +300,7 @@ func (h *Handler) APIV1ScoringmgrResourceGet(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 	Info, err := h.Key.DecryptByteToJSON(encryptBytes)
 	if err != nil {
 		log.Error(logPrefix, cannotDecryption, err.Error())
@@ -341,7 +340,7 @@ func (h *Handler) APIV1DiscoverymgrMNEDCDeviceInfoPost(w http.ResponseWriter, r 
 		return
 	}
 
-	encryptBytes, _ := ioutil.ReadAll(r.Body)
+	encryptBytes, _ := io.ReadAll(r.Body)
 	Info, err := h.Key.DecryptByteToJSON(encryptBytes)
 
 	if err != nil {

--- a/internal/restinterface/resthelper/client/tlshelper/tlshelper.go
+++ b/internal/restinterface/resthelper/client/tlshelper/tlshelper.go
@@ -23,9 +23,9 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -49,7 +49,7 @@ func init() {
 }
 
 func createClientConfig(certspath string) (*tls.Config, error) {
-	caCertPEM, err := ioutil.ReadFile(certspath + "/ca-crt.pem")
+	caCertPEM, err := os.ReadFile(certspath + "/ca-crt.pem")
 	if err != nil {
 		log.Panic(err.Error())
 		return nil, err

--- a/internal/restinterface/resthelper/client/tlshelper/tlshelper_test.go
+++ b/internal/restinterface/resthelper/client/tlshelper/tlshelper_test.go
@@ -18,7 +18,6 @@
 package tlshelper
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -133,7 +132,7 @@ func TestCreateClientConfig(t *testing.T) {
 				t.Error(err.Error())
 			}
 
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte("hello"), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte("hello"), 0444); err != nil {
 				t.Error(err.Error())
 			}
 
@@ -154,7 +153,7 @@ func TestCreateClientConfig(t *testing.T) {
 				t.Error(err.Error())
 			}
 
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 				t.Error(err.Error())
 			}
 
@@ -171,14 +170,14 @@ func TestCreateClientConfig(t *testing.T) {
 			t.Error(err.Error())
 		}
 
-		if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 			t.Error(err.Error())
 		}
 
-		if err := ioutil.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
 			t.Error(err.Error())
 		}
-		if err := ioutil.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
 			t.Error(err.Error())
 		}
 		if _, err := createClientConfig(fakeCertsPath); err != nil {
@@ -226,14 +225,14 @@ func TestDo(t *testing.T) {
 				t.Error(err.Error())
 			}
 
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 				t.Error(err.Error())
 			}
 
-			if err := ioutil.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
 				t.Error(err.Error())
 			}
-			if err := ioutil.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
 				t.Error(err.Error())
 			}
 

--- a/internal/restinterface/resthelper/helper.go
+++ b/internal/restinterface/resthelper/helper.go
@@ -21,7 +21,7 @@ package resthelper
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
@@ -108,7 +108,7 @@ func (h helperImpl) DoGet(targetURL string) (respBytes []byte, statusCode int, e
 	defer resp.Body.Close()
 
 	statusCode = resp.StatusCode
-	respBytes, err = ioutil.ReadAll(resp.Body)
+	respBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("[%s] read resp.Body failed !!, err = %v", logmgr.SanitizeUserInput(targetURL), err) // lgtm [go/log-injection]
 		return
@@ -141,7 +141,7 @@ func (h helperImpl) DoGetWithBody(targetURL string, bodybytes []byte) (respBytes
 	defer resp.Body.Close()
 
 	statusCode = resp.StatusCode
-	respBytes, err = ioutil.ReadAll(resp.Body)
+	respBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Println("read resp.Body failed !!", err)
 	}
@@ -173,7 +173,7 @@ func (h helperImpl) DoPost(targetURL string, bodybytes []byte) (respBytes []byte
 	defer resp.Body.Close()
 
 	statusCode = resp.StatusCode
-	respBytes, err = ioutil.ReadAll(resp.Body)
+	respBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Println("read resp.Body failed !!", err)
 		return
@@ -197,7 +197,7 @@ func (h helperImpl) DoDelete(targetURL string) (respBytes []byte, statusCode int
 	defer resp.Body.Close()
 
 	statusCode = resp.StatusCode
-	respBytes, err = ioutil.ReadAll(resp.Body)
+	respBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Println("read resp.Body failed !!", err)
 		return

--- a/internal/restinterface/resthelper/helper_test.go
+++ b/internal/restinterface/resthelper/helper_test.go
@@ -18,7 +18,7 @@
 package resthelper
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -192,7 +192,7 @@ func TestResponse(t *testing.T) {
 				t.Error("unexpected code")
 			} else if w.Header().Get("Content-Type") != contentsType {
 				t.Error("unexpected content type")
-			} else if s, _ := ioutil.ReadAll(w.Body); string(s) != body {
+			} else if s, _ := io.ReadAll(w.Body); string(s) != body {
 				t.Error("unexpected body")
 			}
 		})
@@ -204,7 +204,7 @@ func TestResponse(t *testing.T) {
 				t.Error("unexpected code")
 			} else if w.Header().Get("Content-Type") != contentsType {
 				t.Error("unexpected content type")
-			} else if s, _ := ioutil.ReadAll(w.Body); len(s) > 0 {
+			} else if s, _ := io.ReadAll(w.Body); len(s) > 0 {
 				t.Error("unexpected body")
 			}
 		})

--- a/internal/restinterface/route/tlsserver/tlsserver.go
+++ b/internal/restinterface/route/tlsserver/tlsserver.go
@@ -20,10 +20,10 @@ package tlsserver
 import (
 	"net"
 	"net/http"
+	"os"
 
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 
 	"github.com/lf-edge/edge-home-orchestration-go/internal/common/logmgr"
 )
@@ -48,7 +48,7 @@ type TLSServer struct {
 }
 
 func createServerConfig(certspath string) (*tls.Config, error) {
-	caCertPEM, err := ioutil.ReadFile(certspath + "/ca-crt.pem")
+	caCertPEM, err := os.ReadFile(certspath + "/ca-crt.pem")
 	if err != nil {
 		log.Panic(logPrefix, err.Error())
 		return nil, err

--- a/internal/restinterface/route/tlsserver/tlsserver_test.go
+++ b/internal/restinterface/route/tlsserver/tlsserver_test.go
@@ -18,7 +18,6 @@
 package tlsserver
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -122,7 +121,7 @@ func TestCreateServerConfig(t *testing.T) {
 			if err := os.MkdirAll(fakeCertsPath, os.ModePerm); err != nil {
 				t.Error(err.Error())
 			}
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte("hello"), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte("hello"), 0444); err != nil {
 				t.Error(err.Error())
 			}
 
@@ -141,7 +140,7 @@ func TestCreateServerConfig(t *testing.T) {
 			if err := os.MkdirAll(fakeCertsPath, os.ModePerm); err != nil {
 				t.Error(err.Error())
 			}
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 				t.Error(err.Error())
 			}
 			if _, err := createServerConfig(fakeCertsPath); err == nil {
@@ -158,14 +157,14 @@ func TestCreateServerConfig(t *testing.T) {
 			t.Error(err.Error())
 		}
 
-		if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 			t.Error(err.Error())
 		}
 
-		if err := ioutil.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
 			t.Error(err.Error())
 		}
-		if err := ioutil.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
 			t.Error(err.Error())
 		}
 		if _, err := createServerConfig(fakeCertsPath); err != nil {
@@ -184,13 +183,13 @@ func TestListenAndServe(t *testing.T) {
 		if err := os.MkdirAll(fakeCertsPath, os.ModePerm); err != nil {
 			t.Error(err.Error())
 		}
-		if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 			t.Error(err.Error())
 		}
-		if err := ioutil.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
 			t.Error(err.Error())
 		}
-		if err := ioutil.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
+		if err := os.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
 			t.Error(err.Error())
 		}
 
@@ -225,7 +224,7 @@ func TestListenAndServe(t *testing.T) {
 			if err := os.MkdirAll(fakeCertsPath, os.ModePerm); err != nil {
 				t.Error(err.Error())
 			}
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(""), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(""), 0444); err != nil {
 				t.Error(err.Error())
 			}
 
@@ -243,7 +242,7 @@ func TestListenAndServe(t *testing.T) {
 			if err := os.MkdirAll(fakeCertsPath, os.ModePerm); err != nil {
 				t.Error(err.Error())
 			}
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 				t.Error(err.Error())
 			}
 
@@ -261,13 +260,13 @@ func TestListenAndServe(t *testing.T) {
 			if err := os.MkdirAll(fakeCertsPath, os.ModePerm); err != nil {
 				t.Error(err.Error())
 			}
-			if err := ioutil.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/ca-crt.pem", []byte(fakeCASert), 0444); err != nil {
 				t.Error(err.Error())
 			}
-			if err := ioutil.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/hen-crt.pem", []byte(fakeHENSert), 0444); err != nil {
 				t.Error(err.Error())
 			}
-			if err := ioutil.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
+			if err := os.WriteFile(fakeCertsPath+"/hen-key.pem", []byte(fakeHENKey), 0444); err != nil {
 				t.Error(err.Error())
 			}
 

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,5 +1,5 @@
-checks = ["all", "-ST1000", "-ST1016", "-U1000", "-S1000", "-S1001",
-	"-SA1019", "-S1021", "-S1034", "-S1040"]
+checks = ["all", "-ST1000", "-ST1016", "-U1000", "-S1000",
+	"-S1021", "-S1034", "-S1040"]
 initialisms = ["ACL", "API", "ASCII", "CPU", "CSS", "DNS",
 	"EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID",
 	"IP", "JSON", "QPS", "RAM", "RPC", "SLA",


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Due with the go v1.19 update, it is necessary to fix the staticcheck warnings

## Type of change

- [x] Code cleanup/refactoring
- [x] CI system update

# How Has This Been Tested?
```
make staticcheck
```

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.1.17

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
