### PR TITLE
Add Fuzzing testing: make fuzz and github->action workflow

### DIFF
--- a/.github/workflows/go-fuzz-test.yml
+++ b/.github/workflows/go-fuzz-test.yml
@@ -1,0 +1,27 @@
+name: Go fuzz test
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test-suite:
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        os: [ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2
+
+      - name: Setup Golang
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v1
+        with:
+          go-version: '1.19'
+
+      - name: Fuzz test
+        run: |
+          GO111MODULE=on go mod tidy
+          GO111MODULE=on go mod vendor
+          ./tools/fuzz-all.sh 30

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ web/package-lock.json
 
 # Test binary, build with `go test -c`
 *.test
+*testdata/
 
 # Output of build
 *.o

--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,10 @@ lint:
 staticcheck:
 	$(Q) -staticcheck ./...
 
+fuzz:
+	$(call print_header, "Run Fuzzer (go test -fuzz)")
+	$(Q) ./tools/fuzz-all.sh $1
+
 ## format go files
 fmt:
 	$(Q) make clean
@@ -247,6 +251,7 @@ help:
 	@echo '    clean              Remove binaries, artifacts.'
 	@echo '    create_context     Prepare configuration.'
 	@echo '    fmt                Run: gofmt -s -w ./ .'
+	@echo '    fuzz               Run: go test -fuzz .'
 	@echo '    help               Show this help screen.'
 	@echo '    lint               Run golint and go vet.'
 	@echo '    menuconfig         Change configuration by kconfig-frontends.'
@@ -257,7 +262,7 @@ help:
 	@echo ''
 
 ## define build target not a file
-.PHONY: all build test clean lint fmt help staticcheck run stop binary
+.PHONY: all binary build clean fmt fuzz help lint run staticcheck stop test
 
 define stop_docker_container
 	$(call print_header, "Stop Docker container")

--- a/docs/testing_policy.md
+++ b/docs/testing_policy.md
@@ -2,8 +2,10 @@
 ## Contents
 1. [Introduction](#1-introduction)
 2. [How to start Test Suite (Local)](#2-how-to-start-test-suite-local)  
-    2.1 [Using the makefile](#21-using-the-makefile)  
-    2.2 [Using standard Go language facilities](#22-using-standard-go-language-facilities)  
+    2.1 [Using the makefile to regular test](#21-using-the-makefile-to-regular-test)  
+    2.2 [Using standard Go language facilities to regular test](#22-using-standard-go-language-facilities-to-regular-test)  
+    2.3 [Using the makefile to fuzzing test](#23-using-the-makefile)  
+    2.4 [Using standard Go language facilities to fuzzing test](#24-using-standard-go-language-facilities-to-fuzzing-test)
 3. [Automated Run Test Suite (Remote)](#3-automated-run-test-suite-remote)  
 4. [Test file pattern](#4-test-file-pattern)  
 
@@ -26,8 +28,8 @@ The Edge Orchestration team strongly recommends adhering to the [Test-driven dev
 
 > Make sure the `gocov` and `gocov-html` packages are installed [(How to install)](https://github.com/matm/gocov-html#installation). Recommendation: Do not install these utilities from the `edge-home-orchestration-go` folder.
 
-There are two ways to test:
-### 2.1 Using the makefile
+There are two ways to regular test and two ways to fuzzing test:
+### 2.1 Using the makefile to regular test
 To start testing all packages:
 ```
 make test
@@ -37,7 +39,7 @@ To start testing a specific package:
 make test [PKG_NAME]
 ```
 
-### 2.2 Using standard Go language facilities
+### 2.2 Using standard Go language facilities to regular test
 To start testing all packages:
 ```
 gocov test $(go list ./internal/... | grep -v mock) -coverprofile=/dev/null
@@ -47,11 +49,21 @@ To start testing a specific package:
 go test -v [PKG_NAME]
 ```
 
+### 2.3 Using the makefile to fuzzing test
+To start search and fuzzing test all packages:
+```
+make fuzz
+```
+### 2.4 Using standard Go language facilities to fuzzing test
+To start fuzzing test a specific package:
+```
+go test [PKG_NAME] --fuzz=Fuzz -fuzztime=10s
+```
 ---
 
 ## 3. Automated Run Test Suite (Remote)
 
-Code testing occurs remotely using a [github->Actions->workflow (Build)](https://github.com/lf-edge/edge-home-orchestration-go/actions) during each `push` or `pull_request`.
+Code regular and fuzz testing occurs remotely using a [github->Actions->workflow (Test-Suite and Go fuzz test)](https://github.com/lf-edge/edge-home-orchestration-go/actions) during each `push` or `pull_request`.
 
 > [More information on github->actions](https://docs.github.com/en/actions) 
 
@@ -102,3 +114,23 @@ func TestFuncName(t *testing.T) {
 	})
 }
 ```
+
+func FuzzTestFuncName(f *testing.F) {
+
+	defer func() {
+		...
+	}()
+
+	testcases := []string{"Your", "Seed", "Value"}
+	for _, tc := range testcases {
+		f.Add(tc) // Use f.Add to provide a seed corpus
+	}
+
+	f.Fuzz(func(t *testing.T, orig string) {
+
+		if err := FuncName(orig, req); err != nil {
+			return
+		}
+		t.Error(unexpectedSuccess)
+	})
+}

--- a/tools/fuzz-all.sh
+++ b/tools/fuzz-all.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+fuzzTime=${1:-10}
+
+files=$(grep -r --include='**_test.go' --files-with-matches 'func FuzzTest' --exclude-dir=fuzzer .)
+
+for file in ${files}
+do
+    funcs=$(grep -oP 'func \K(Fuzz\w*)' $file)
+    for func in ${funcs}
+    do
+        echo "Fuzzing $func in $file"
+        parentDir=$(dirname $file)
+        go test $parentDir -run=$func -fuzz=$func -fuzztime=${fuzzTime}s
+    done
+done


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

The introduction of fuzzing testing is a very important step to improve code security. This is just the first step.

In addition to this fuzzing activity, another parallel activity is planned using the [OSS-Fuzz](https://github.com/google/oss-fuzz)


## Type of change

- [x] Documentation update
- [x] CI system update
- [x] Test Coverage update

# How Has This Been Tested?
```
make fuzz
```

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.1.16

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
