### PR TITLE
[URGENT] Add fuzzing test configuration for oss-fuzz

### DIFF
--- a/test/fuzzing/fuzzing.go
+++ b/test/fuzzing/fuzzing.go
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright 2022 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+
+package fuzz
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/lf-edge/edge-home-orchestration-go/internal/controller/securemgr/authorizer"
+)
+
+const (
+	fakerbacPath      = "fakerbac"
+	unexpectedSuccess = "unexpected success"
+	unexpectedFail    = "unexpected fail"
+)
+
+func FuzzTestAuthorizer(f *testing.F) {
+	defer func() {
+		os.RemoveAll(fakerbacPath)
+	}()
+
+	authorizer.Init(fakerbacPath)
+
+	req, err := http.NewRequest("POST", "/api/v1/orchestration/securemgr", nil)
+	if err != nil {
+		return
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) int {
+		orig := string(data)
+		if err := authorizer.Authorizer(orig, req); err != nil {
+			return 0
+		}
+
+		if orig == "Admin" || orig == "Member" {
+			return 0
+		}
+		t.Error(unexpectedSuccess)
+		return 1
+	})
+}

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -1,0 +1,4 @@
+#/bin/bash -eu
+
+# go mod init github.com/lf-edge/edge-home-orchestration-go/test/fuzzing
+compile_go_fuzzer github.com/lf-edge/edge-home-orchestration-go/test/fuzzing Fuzz fuzz gofuzz


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Configuration to include our project in the fuzzing test list of [OSS-Fuzz](https://github.com/google/oss-fuzz)

## Type of change

- [x] Test Coverage update

# How Has This Been Tested?

The result should be after including edge-home-orchestration-go project in the fuzzing test list of oss-fuzz project.

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.1.17

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
