### PR TITLE
Add --no-check-certificate option during install-golang.sh

### DIFF
--- a/script/install-golang.sh
+++ b/script/install-golang.sh
@@ -11,6 +11,6 @@ elif [ $TARGETPLATFORM = "linux/arm/v7" ]; then
     arch="armv6l"
 fi
 
-wget https://golang.org/dl/go$GOVERSION.linux-$arch.tar.gz && \
+wget --no-check-certificate https://golang.org/dl/go$GOVERSION.linux-$arch.tar.gz && \
 tar -C /usr/local -xzf go$GOVERSION.linux-$arch.tar.gz && \
 ln -s $GOPATH/bin/go /usr/bin/


### PR DESCRIPTION
Signed-off-by: Taewan Kim <t25.kim@samsung.com>

# Description

Log of github action

```
 > [linux/arm/v7 builder 6/7] RUN script/install-golang.sh:
#31 0.217 The platform is linux/arm/v7.
#31 0.282 --2022-09-29 23:25:34--  https://golang.org/dl/go1.19.linux-armv6l.tar.gz
#31 0.322 Resolving golang.org (golang.org)... 172.253.63.141, 2607:f8b0:4004:c08::8d
#31 0.364 Connecting to golang.org (golang.org)|172.253.63.141|:443... connected.
#31 0.452 ERROR: cannot verify golang.org's certificate, issued by 'CN=GTS CA 1C3,O=Google Trust Services LLC,C=US':
#31 0.452   Unable to locally verify the issuer's authority.
#31 0.456 To connect to golang.org insecurely, use `--no-check-certificate'.
------
Dockerfile:18
--------------------
  16 |     RUN apt update
  17 |     RUN apt install -y wget build-essential git
  18 | >>> RUN script/install-golang.sh
  19 |     ARG TARGETVERSION
  20 |     RUN make buildx_binary VERSION=$TARGETVERSION
--------------------
ERROR: failed to solve: process "/bin/sh -c script/install-golang.sh" did not complete successfully: exit code: 5
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c script/install-golang.sh" did not complete successfully: exit code: 5
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64 
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.2.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
