### PR TITLE
[Urgent] Specify the certificate location for wget tool

### DIFF
--- a/configs/defdockerfiles/ubuntu_multistage
+++ b/configs/defdockerfiles/ubuntu_multistage
@@ -3,7 +3,7 @@ FROM --platform=$TARGETPLATFORM ubuntu:20.04 AS builder
 
 # environment variables
 ARG TARGETPLATFORM
-ENV GOVERSION=1.19
+ENV GOVERSION=1.19.1
 ENV GOPATH=/usr/local/go
 ENV TARGET_DIR=/edge-orchestration
 

--- a/script/install-golang.sh
+++ b/script/install-golang.sh
@@ -11,6 +11,6 @@ elif [ $TARGETPLATFORM = "linux/arm/v7" ]; then
     arch="armv6l"
 fi
 
-wget https://golang.org/dl/go$GOVERSION.linux-$arch.tar.gz && \
+wget --ca-certificate=/etc/ssl/certs/ca-certificates.crt https://golang.org/dl/go$GOVERSION.linux-$arch.tar.gz && \
 tar -C /usr/local -xzf go$GOVERSION.linux-$arch.tar.gz && \
 ln -s $GOPATH/bin/go /usr/bin/


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

The exact location of the `ca-certificate.crt` is indicated because the certificate was not found when using the `wget` tool under `linux/arm/v7` architecture.

Using the `--no-check-certificate` option is a bad as it could be a security vulnerability (man in the middle attack)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI system update

# How Has This Been Tested?

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64 arm, arm64
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.1.17

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
