### PR TITLE
Fix route testcase "ListenAndServe [tlsserver] listen failed: listen …

### DIFF
--- a/internal/restinterface/route/route_test.go
+++ b/internal/restinterface/route/route_test.go
@@ -116,16 +116,26 @@ func TestStart(t *testing.T) {
 		return
 	}
 	router.Start()
+}
 
-	routers := NewRestRouterWithCerti(fakeCertsPath)
-	if routers == nil {
+func TestStartSecureRoute(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	router := NewRestRouterWithCerti(fakeCertsPath)
+	if router == nil {
 		t.Error(unexpectedFail)
 		return
 	}
-	routers.Start()
+	router.Start()
+}
 
-	routere := NewRestRouter()
-	if routere == nil {
+func TestStartFakeRoute(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	router := NewRestRouter()
+	if router == nil {
 		t.Error(unexpectedFail)
 		return
 	}
@@ -133,10 +143,10 @@ func TestStart(t *testing.T) {
 		restinterface.HasRoutes
 		cipher.HasCipher
 	}
-	routere.Add(&fakeRouter{})
-	routere.Add(externalhandler.GetHandler())
-	if routere.routerExternal == nil {
+	router.Add(&fakeRouter{})
+	router.Add(externalhandler.GetHandler())
+	if router.routerExternal == nil {
 		t.Error("unexpected not set external handler")
 	}
-	routere.Start()
+	router.Start()
 }


### PR DESCRIPTION
…tcp :56002"

Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description
I hope this PR will fix the route testcase
```
INFO[2022-11-02T13:19:13Z]tls.go:45 SetCertFilePath SetCertFilePath:  /var/edge-orchestration/certs 
INFO[2022-11-02T13:19:13Z]route.go:116 listenAndServe [route] Internal ListenAndServe              
INFO[2022-11-02T13:19:13Z]route.go:120 listenAndServe [route] External ListenAndServe              
INFO[2022-11-02T13:19:13Z]tls.go:45 SetCertFilePath SetCertFilePath:  /var/edge-orchestration/certs 
INFO[2022-11-02T13:19:13Z]route.go:112 listenAndServe [route] Internal ListenAndServeTLS           
INFO[2022-11-02T13:19:13Z]route.go:120 listenAndServe [route] External ListenAndServe              
INFO[2022-11-02T13:19:13Z]route.go:99 Add [route] added unknown type, ignore           
INFO[2022-11-02T13:19:13Z]route.go:84 Add {APIV1RequestServicePost POST /api/v1/orchestration/services 0xa15b20} 
INFO[2022-11-02T13:19:13Z]route.go:84 Add {APIV1RequestSecuremgrPost POST /api/v1/orchestration/securemgr 0xa15ba0} 
INFO[2022-11-02T13:19:13Z]route.go:84 Add {APIV1RequestCloudSyncmgrPublish POST /api/v1/orchestration/cloudsyncmgr/publish 0xa15c20} 
INFO[2022-11-02T13:19:13Z]route.go:84 Add {APIV1RequestCloudSyncmgrSubscribe POST /api/v1/orchestration/cloudsyncmgr/subscribe 0xa15ca0} 
INFO[2022-11-02T13:19:13Z]route.go:84 Add {APIV1RequestCloudSyncmgrGetSubscribedData GET /api/v1/orchestration/cloudsyncmgr/getsubscribedata/{host}/{topic}/{appID} 0xa15d20} 
PANI[2022-11-02T13:19:13Z]tlsserver.go:88 ListenAndServe [tlsserver] listen failed: listen tcp :56002: bind: address already in use 
panic: (*logrus.Entry) 0xc0000ce0e0

goroutine 10 [running]:
github.com/sirupsen/logrus.(*Entry).log(0xc0000ce070, 0x0, {0xc0000c6190, 0x4a})
	/home/runner/work/edge-home-orchestration-go/edge-home-orchestration-go/vendor/github.com/sirupsen/logrus/entry.go:260 +0x4a7
github.com/sirupsen/logrus.(*Entry).Log(0xc0000ce070, 0x0, {0xc000121f60?, 0x10?, 0xa77d00?})
	/home/runner/work/edge-home-orchestration-go/edge-home-orchestration-go/vendor/github.com/sirupsen/logrus/entry.go:304 +0x4f
github.com/sirupsen/logrus.(*Logger).Log(0xc000150080, 0x0, {0xc000121f60, 0x3, 0x3})
	/home/runner/work/edge-home-orchestration-go/edge-home-orchestration-go/vendor/github.com/sirupsen/logrus/logger.go:204 +0x65
github.com/sirupsen/logrus.(*Logger).Panic(...)
	/home/runner/work/edge-home-orchestration-go/edge-home-orchestration-go/vendor/github.com/sirupsen/logrus/logger.go:253
github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route/tlsserver.(*TLSServer).ListenAndServe(0xc0002ccc40, {0xc000314f60, 0x6}, {0xc73080?, 0x0})
	/home/runner/work/edge-home-orchestration-go/edge-home-orchestration-go/internal/restinterface/route/tlsserver/tlsserver.go:88 +0x155
created by github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route.RestRouter.listenAndServe
	/home/runner/work/edge-home-orchestration-go/edge-home-orchestration-go/internal/restinterface/route/route.go:114 +0x277
FAIL	github.com/lf-edge/edge-home-orchestration-go/internal/restinterface/route	0.015s
FAIL
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test Coverage update

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.2.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
