### PR TITLE
Remove lgtm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Goreport](https://goreportcard.com/badge/github.com/lf-edge/edge-home-orchestration-go)](https://goreportcard.com/report/github.com/lf-edge/edge-home-orchestration-go)
 [![Build](https://github.com/lf-edge/edge-home-orchestration-go/workflows/Build/badge.svg)](https://github.com/lf-edge/edge-home-orchestration-go/actions?query=workflow%3ABuild)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/lf-edge/edge-home-orchestration-go.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/lf-edge/edge-home-orchestration-go/alerts/)
 [![CodeQL Analysis](https://github.com/lf-edge/edge-home-orchestration-go/workflows/CodeQL%20Analysis/badge.svg)](https://github.com/lf-edge/edge-home-orchestration-go/actions?query=workflow%3A%22CodeQL+Analysis%22)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=lf-edge_edge-home-orchestration-go&metric=alert_status)](https://sonarcloud.io/dashboard?id=lf-edge_edge-home-orchestration-go)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4336/badge)](https://bestpractices.coreinfrastructure.org/projects/4336)


### PR DESCRIPTION
Signed-off-by: Taras Drozdovskyi <t.drozdovsky@samsung.com>

# Description

Removed the LGTM badge as it is no longer supported from December 16th. Exception comments in the code will be removed later, it is necessary to check the functionality of the Code scanning more carefully

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64 (e.g., x86, x86-64, arm, arm64)
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.2.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
