### PR TITLE
Attempt to fix testing error

### DIFF
--- a/internal/restinterface/route/route_test.go
+++ b/internal/restinterface/route/route_test.go
@@ -118,18 +118,6 @@ func TestStart(t *testing.T) {
 	router.Start()
 }
 
-func TestStartSecureRoute(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	router := NewRestRouterWithCerti(fakeCertsPath)
-	if router == nil {
-		t.Error(unexpectedFail)
-		return
-	}
-	router.Start()
-}
-
 func TestStartFakeRoute(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -147,6 +135,18 @@ func TestStartFakeRoute(t *testing.T) {
 	router.Add(externalhandler.GetHandler())
 	if router.routerExternal == nil {
 		t.Error("unexpected not set external handler")
+	}
+	router.Start()
+}
+
+func TestStartSecureRoute(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	router := NewRestRouterWithCerti(fakeCertsPath)
+	if router == nil {
+		t.Error(unexpectedFail)
+		return
 	}
 	router.Start()
 }

--- a/internal/restinterface/route/tlsserver/tlsserver.go
+++ b/internal/restinterface/route/tlsserver/tlsserver.go
@@ -80,9 +80,11 @@ func createServerConfig(certspath string) (*tls.Config, error) {
 // ListenAndServe listens HTTPS connection and calls Serve with handler to handle requests on incoming connections.
 func (s *TLSServer) ListenAndServe(addr string, handler http.Handler) {
 
-	config, _ := createServerConfig(s.Certspath)
+	config, err := createServerConfig(s.Certspath)
+	if err != nil {
+		log.Panic(logPrefix, "create tls configuration failed: ", err.Error())
+	}
 
-	var err error
 	s.listener, err = tls.Listen("tcp", addr, config)
 	if err != nil {
 		log.Panic(logPrefix, "listen failed: ", err.Error())

--- a/internal/restinterface/route/tlsserver/tlsserver_test.go
+++ b/internal/restinterface/route/tlsserver/tlsserver_test.go
@@ -114,6 +114,8 @@ func TestCreateServerConfig(t *testing.T) {
 				}
 			}()
 
+			os.RemoveAll(fakeCertsPath)
+
 			if _, err := createServerConfig(fakeCertsPath); err == nil {
 				t.Error(unexpectedSuccess)
 			}
@@ -199,7 +201,10 @@ func TestListenAndServe(t *testing.T) {
 			s.listener.Close()
 		}()
 		s.ListenAndServe(addr, nil)
+		time.Sleep(1 * time.Second)
+
 	})
+
 	t.Run("Fail", func(t *testing.T) {
 		t.Run("AbsentCertsPath", func(t *testing.T) {
 			defer func() {
@@ -210,8 +215,12 @@ func TestListenAndServe(t *testing.T) {
 			}()
 
 			s := TLSServer{Certspath: fakeCertsPath}
+			go func() {
+				time.Sleep(2 * time.Second)
+				s.listener.Close()
+			}()
 			s.ListenAndServe(addr, nil)
-
+			time.Sleep(1 * time.Second)
 		})
 		t.Run("WrongCACrtFmt", func(t *testing.T) {
 			defer func() {
@@ -229,7 +238,12 @@ func TestListenAndServe(t *testing.T) {
 			}
 
 			s := TLSServer{Certspath: fakeCertsPath}
+			go func() {
+				time.Sleep(2 * time.Second)
+				s.listener.Close()
+			}()
 			s.ListenAndServe(addr, nil)
+			time.Sleep(1 * time.Second)
 		})
 		t.Run("AbsentHenCrtKey", func(t *testing.T) {
 			defer func() {
@@ -247,7 +261,12 @@ func TestListenAndServe(t *testing.T) {
 			}
 
 			s := TLSServer{Certspath: fakeCertsPath}
+			go func() {
+				time.Sleep(2 * time.Second)
+				s.listener.Close()
+			}()
 			s.ListenAndServe(addr, nil)
+			time.Sleep(1 * time.Second)
 		})
 		t.Run("BadAddr", func(t *testing.T) {
 			defer func() {
@@ -271,7 +290,12 @@ func TestListenAndServe(t *testing.T) {
 			}
 
 			s := TLSServer{Certspath: fakeCertsPath}
+			go func() {
+				time.Sleep(2 * time.Second)
+				s.listener.Close()
+			}()
 			s.ListenAndServe("_", nil)
+			time.Sleep(1 * time.Second)
 		})
 	})
 }


### PR DESCRIPTION
# Description

Often, _listen failed: listen tcp :56002: bind: address already in use_ error occurs during the run of a test workflow. This occurs because the port (56002) was not closed, and it was not possible to reopen it. I hope this code will fix this bug. I ran the test 12 times and they were all successful. I hope the tests continue to work successfully
 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test Coverage update

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64 (e.g., x86, x86-64, arm, arm64)
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.2.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
