### PR TITLE
Fix pull-request-reviewer-reminder permission for correct work

### DIFF
--- a/.github/workflows/pull-request-reviewer-reminder.yml
+++ b/.github/workflows/pull-request-reviewer-reminder.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 10,17 * * 1-5'
 
 permissions:
-  contents: read
+  pull-requests: write
 
 jobs:
   pull-request-reviewer-reminder: 


### PR DESCRIPTION
# Description

`pull-request-reviewer-reminder` action stopped working. This patch fixes it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI system update


**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64 (e.g., x86, x86-64, arm, arm64)
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.1.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
