### PR TITLE
Temporarily remove "cpu" package testing from test-suite github->action

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,4 +37,4 @@ jobs:
         run: |
           GO111MODULE=on go mod tidy
           GO111MODULE=on go mod vendor
-          gocov test $(go list ./internal/... | grep -v mock) -coverprofile=/dev/null
+          gocov test $(go list ./internal/... | grep -v cpu | grep -v mock) -coverprofile=/dev/null


### PR DESCRIPTION
# Description

Probably the server uses a new type of processor, so this test does not work correctly. Deeper study of the issue is required

## Type of change

- [x] CI system update
- [x] Test Coverage update

**Test Configuration**:
* OS type & version: Ubuntu 20.04
* Hardware: x86-64 (e.g., x86, x86-64, arm, arm64)
* Toolchain: Docker v20.10 & Go v1.19
* Edge Orchestration Release: v1.1.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
