### PR TITLE
docs: Add descriptions of what type of prefix to add to the commit me…

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,9 +75,34 @@ add the files/changes you want to commit to the staging area with
 git add path/to/my/file.go
 ```
 
-Commit your changes with a descriptive commit message. Make sure to mention the ticket number with #XXX so github will automatically link your commit with the ticket:
+Commit your changes with a descriptive commit message. Make sure to mention the issue number with `#XXX` so that GitHub will automatically link your commit with the issue. Additionally, use appropriate commit message prefixes to categorize your changes.
+
+   - **feat**: Introduce a new feature or enhancement.
+   - **fix**: Address a bug or resolve an issue.
+   - **chore**: Perform routine tasks or maintenance.
+   - **docs**: Make changes to documentation.
+   - **style**: Implement code style changes (e.g., formatting).
+   - **test**: Modify or add tests.
+   - **refactor**: Implement code refactoring.
+   - **perf**: Performance Improvements.
+   - **build**: Any changes in build conditions.
+   - **ci**: Implement any continuous integration changes.
+   - **revert**: Revert to previous code state.
+
+   For example:
+
 ```sh
-git commit -m "A brief description of this change which fixes #42 goes here" --signoff
+   git commit -m "feat: A brief description of this new feature which resolves #42" --signoff
+   git commit -m "fix: A brief description of this bug fix which fixes #42" --signoff
+   git commit -m "chore: A brief description of routine tasks or maintenance" --signoff
+   git commit -m "docs: A brief description of documentation changes" --signoff
+   git commit -m "style: A brief description of code style changes (e.g., formatting)" --signoff
+   git commit -m "test: A brief description of changes related to testing" --signoff
+   git commit -m "refactor: A brief description of code refactoring" --signoff
+   git commit -m "perf: A brief description of performance improvements" --signoff
+   git commit -m "build: A brief description of build conditions" --signoff
+   git commit -m "ci: A brief description of continuous integration changes" --signoff
+   git commit -m "revert: A brief description of revert previous code state" --signoff
 ```
 
 #### 9. Pull the latest Edge Orchestration code from upstream into your branch

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df205d5d22a31266ced268874388b861e4b58bb5c2f33aa23a56210a8
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
…ssage

# Description

To automatically create a release description, you need to add a prefix for the commit message.

also I fixed a hash typo (applies to a previous commit)

## Type of change

- [x] Documentation update
- [x] CI system update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
